### PR TITLE
fix(api): Remove category from struct properties

### DIFF
--- a/goldenmaster/Plugins/TbSame1/Source/TbSame1/Public/Generated/api/TbSame1_data.h
+++ b/goldenmaster/Plugins/TbSame1/Source/TbSame1/Public/Generated/api/TbSame1_data.h
@@ -62,13 +62,13 @@ struct TBSAME1_API FTbSame1Struct1 : public FTableRowBase
 {
 	GENERATED_BODY()
 
-	UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "ApiGear|TbSame1")
+	UPROPERTY(EditAnywhere, BlueprintReadWrite)
 	int32 field1{0};
 
-	UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "ApiGear|TbSame1")
+	UPROPERTY(EditAnywhere, BlueprintReadWrite)
 	int32 field2{0};
 
-	UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "ApiGear|TbSame1")
+	UPROPERTY(EditAnywhere, BlueprintReadWrite)
 	int32 field3{0};
 
 	bool operator==(const FTbSame1Struct1& rhs) const;
@@ -83,13 +83,13 @@ struct TBSAME1_API FTbSame1Struct2 : public FTableRowBase
 {
 	GENERATED_BODY()
 
-	UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "ApiGear|TbSame1")
+	UPROPERTY(EditAnywhere, BlueprintReadWrite)
 	int32 field1{0};
 
-	UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "ApiGear|TbSame1")
+	UPROPERTY(EditAnywhere, BlueprintReadWrite)
 	int32 field2{0};
 
-	UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "ApiGear|TbSame1")
+	UPROPERTY(EditAnywhere, BlueprintReadWrite)
 	int32 field3{0};
 
 	bool operator==(const FTbSame1Struct2& rhs) const;

--- a/goldenmaster/Plugins/TbSame2/Source/TbSame2/Public/Generated/api/TbSame2_data.h
+++ b/goldenmaster/Plugins/TbSame2/Source/TbSame2/Public/Generated/api/TbSame2_data.h
@@ -62,13 +62,13 @@ struct TBSAME2_API FTbSame2Struct1 : public FTableRowBase
 {
 	GENERATED_BODY()
 
-	UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "ApiGear|TbSame2")
+	UPROPERTY(EditAnywhere, BlueprintReadWrite)
 	int32 field1{0};
 
-	UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "ApiGear|TbSame2")
+	UPROPERTY(EditAnywhere, BlueprintReadWrite)
 	int32 field2{0};
 
-	UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "ApiGear|TbSame2")
+	UPROPERTY(EditAnywhere, BlueprintReadWrite)
 	int32 field3{0};
 
 	bool operator==(const FTbSame2Struct1& rhs) const;
@@ -83,13 +83,13 @@ struct TBSAME2_API FTbSame2Struct2 : public FTableRowBase
 {
 	GENERATED_BODY()
 
-	UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "ApiGear|TbSame2")
+	UPROPERTY(EditAnywhere, BlueprintReadWrite)
 	int32 field1{0};
 
-	UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "ApiGear|TbSame2")
+	UPROPERTY(EditAnywhere, BlueprintReadWrite)
 	int32 field2{0};
 
-	UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "ApiGear|TbSame2")
+	UPROPERTY(EditAnywhere, BlueprintReadWrite)
 	int32 field3{0};
 
 	bool operator==(const FTbSame2Struct2& rhs) const;

--- a/goldenmaster/Plugins/Testbed1/Source/Testbed1/Public/Generated/api/Testbed1_data.h
+++ b/goldenmaster/Plugins/Testbed1/Source/Testbed1/Public/Generated/api/Testbed1_data.h
@@ -30,7 +30,7 @@ struct TESTBED1_API FTestbed1StructBool : public FTableRowBase
 {
 	GENERATED_BODY()
 
-	UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "ApiGear|Testbed1")
+	UPROPERTY(EditAnywhere, BlueprintReadWrite)
 	bool fieldBool{false};
 
 	bool operator==(const FTestbed1StructBool& rhs) const;
@@ -45,7 +45,7 @@ struct TESTBED1_API FTestbed1StructInt : public FTableRowBase
 {
 	GENERATED_BODY()
 
-	UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "ApiGear|Testbed1")
+	UPROPERTY(EditAnywhere, BlueprintReadWrite)
 	int32 fieldInt{0};
 
 	bool operator==(const FTestbed1StructInt& rhs) const;
@@ -60,7 +60,7 @@ struct TESTBED1_API FTestbed1StructFloat : public FTableRowBase
 {
 	GENERATED_BODY()
 
-	UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "ApiGear|Testbed1")
+	UPROPERTY(EditAnywhere, BlueprintReadWrite)
 	float fieldFloat{0.0f};
 
 	bool operator==(const FTestbed1StructFloat& rhs) const;
@@ -75,7 +75,7 @@ struct TESTBED1_API FTestbed1StructString : public FTableRowBase
 {
 	GENERATED_BODY()
 
-	UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "ApiGear|Testbed1")
+	UPROPERTY(EditAnywhere, BlueprintReadWrite)
 	FString fieldString{FString()};
 
 	bool operator==(const FTestbed1StructString& rhs) const;

--- a/goldenmaster/Plugins/Testbed2/Source/Testbed2/Public/Generated/api/Testbed2_data.h
+++ b/goldenmaster/Plugins/Testbed2/Source/Testbed2/Public/Generated/api/Testbed2_data.h
@@ -84,7 +84,7 @@ struct TESTBED2_API FTestbed2Struct1 : public FTableRowBase
 {
 	GENERATED_BODY()
 
-	UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "ApiGear|Testbed2")
+	UPROPERTY(EditAnywhere, BlueprintReadWrite)
 	int32 field1{0};
 
 	bool operator==(const FTestbed2Struct1& rhs) const;
@@ -99,10 +99,10 @@ struct TESTBED2_API FTestbed2Struct2 : public FTableRowBase
 {
 	GENERATED_BODY()
 
-	UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "ApiGear|Testbed2")
+	UPROPERTY(EditAnywhere, BlueprintReadWrite)
 	int32 field1{0};
 
-	UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "ApiGear|Testbed2")
+	UPROPERTY(EditAnywhere, BlueprintReadWrite)
 	int32 field2{0};
 
 	bool operator==(const FTestbed2Struct2& rhs) const;
@@ -117,13 +117,13 @@ struct TESTBED2_API FTestbed2Struct3 : public FTableRowBase
 {
 	GENERATED_BODY()
 
-	UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "ApiGear|Testbed2")
+	UPROPERTY(EditAnywhere, BlueprintReadWrite)
 	int32 field1{0};
 
-	UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "ApiGear|Testbed2")
+	UPROPERTY(EditAnywhere, BlueprintReadWrite)
 	int32 field2{0};
 
-	UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "ApiGear|Testbed2")
+	UPROPERTY(EditAnywhere, BlueprintReadWrite)
 	int32 field3{0};
 
 	bool operator==(const FTestbed2Struct3& rhs) const;
@@ -138,16 +138,16 @@ struct TESTBED2_API FTestbed2Struct4 : public FTableRowBase
 {
 	GENERATED_BODY()
 
-	UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "ApiGear|Testbed2")
+	UPROPERTY(EditAnywhere, BlueprintReadWrite)
 	int32 field1{0};
 
-	UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "ApiGear|Testbed2")
+	UPROPERTY(EditAnywhere, BlueprintReadWrite)
 	int32 field2{0};
 
-	UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "ApiGear|Testbed2")
+	UPROPERTY(EditAnywhere, BlueprintReadWrite)
 	int32 field3{0};
 
-	UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "ApiGear|Testbed2")
+	UPROPERTY(EditAnywhere, BlueprintReadWrite)
 	int32 field4{0};
 
 	bool operator==(const FTestbed2Struct4& rhs) const;
@@ -162,7 +162,7 @@ struct TESTBED2_API FTestbed2NestedStruct1 : public FTableRowBase
 {
 	GENERATED_BODY()
 
-	UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "ApiGear|Testbed2")
+	UPROPERTY(EditAnywhere, BlueprintReadWrite)
 	FTestbed2Struct1 field1{FTestbed2Struct1()};
 
 	bool operator==(const FTestbed2NestedStruct1& rhs) const;
@@ -177,10 +177,10 @@ struct TESTBED2_API FTestbed2NestedStruct2 : public FTableRowBase
 {
 	GENERATED_BODY()
 
-	UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "ApiGear|Testbed2")
+	UPROPERTY(EditAnywhere, BlueprintReadWrite)
 	FTestbed2Struct1 field1{FTestbed2Struct1()};
 
-	UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "ApiGear|Testbed2")
+	UPROPERTY(EditAnywhere, BlueprintReadWrite)
 	FTestbed2Struct2 field2{FTestbed2Struct2()};
 
 	bool operator==(const FTestbed2NestedStruct2& rhs) const;
@@ -195,13 +195,13 @@ struct TESTBED2_API FTestbed2NestedStruct3 : public FTableRowBase
 {
 	GENERATED_BODY()
 
-	UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "ApiGear|Testbed2")
+	UPROPERTY(EditAnywhere, BlueprintReadWrite)
 	FTestbed2Struct1 field1{FTestbed2Struct1()};
 
-	UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "ApiGear|Testbed2")
+	UPROPERTY(EditAnywhere, BlueprintReadWrite)
 	FTestbed2Struct2 field2{FTestbed2Struct2()};
 
-	UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "ApiGear|Testbed2")
+	UPROPERTY(EditAnywhere, BlueprintReadWrite)
 	FTestbed2Struct3 field3{FTestbed2Struct3()};
 
 	bool operator==(const FTestbed2NestedStruct3& rhs) const;

--- a/templates/module/Source/module/Public/Generated/api/data.h.tpl
+++ b/templates/module/Source/module/Public/Generated/api/data.h.tpl
@@ -59,7 +59,7 @@ struct {{$API_MACRO}} {{$class }} : public FTableRowBase
 	GENERATED_BODY()
 {{- range .Fields }}
 
-	UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "{{$Category}}")
+	UPROPERTY(EditAnywhere, BlueprintReadWrite)
 	{{ueType "" .}} {{.Name}}{ {{- ueDefault "" . -}} };
 {{- end }}
 


### PR DESCRIPTION
The Category meta specifier on UPROPERTY for structs seems to break the structs use in Blueprint datatables.