### PR TITLE
feat(olink): reduce network load for prop changes

### DIFF
--- a/goldenmaster/Plugins/TbEnum/Source/TbEnum/Private/Generated/OLink/TbEnumEnumInterfaceOLinkClient.cpp
+++ b/goldenmaster/Plugins/TbEnum/Source/TbEnum/Private/Generated/OLink/TbEnumEnumInterfaceOLinkClient.cpp
@@ -43,8 +43,20 @@ bool IsTbEnumEnumInterfaceLogEnabled()
 }
 } // namespace
 
+/**
+   \brief data structure to hold the last sent property values
+*/
+struct TbEnumEnumInterfacePropertiesData
+{
+	ETbEnumEnum0 Prop0{ETbEnumEnum0::TEE_VALUE0};
+	ETbEnumEnum1 Prop1{ETbEnumEnum1::TEE_VALUE1};
+	ETbEnumEnum2 Prop2{ETbEnumEnum2::TEE_VALUE2};
+	ETbEnumEnum3 Prop3{ETbEnumEnum3::TEE_VALUE3};
+};
+
 UTbEnumEnumInterfaceOLinkClient::UTbEnumEnumInterfaceOLinkClient()
 	: UAbstractTbEnumEnumInterface()
+	, _SentData(MakePimpl<TbEnumEnumInterfacePropertiesData>())
 {
 	m_sink = std::make_shared<FUnrealOLinkSink>("tb.enum.EnumInterface");
 }
@@ -101,7 +113,20 @@ void UTbEnumEnumInterfaceOLinkClient::SetProp0_Implementation(ETbEnumEnum0 InPro
 	{
 		return;
 	}
+
+	// only send change requests if the value changed -> reduce network load
+	if (GetProp0_Implementation() == InProp0)
+	{
+		return;
+	}
+
+	// only send change requests if the value wasn't already sent -> reduce network load
+	if (_SentData->Prop0 == InProp0)
+	{
+		return;
+	}
 	m_sink->GetNode()->setRemoteProperty(ApiGear::ObjectLink::Name::createMemberId(m_sink->olinkObjectName(), "prop0"), InProp0);
+	_SentData->Prop0 = InProp0;
 }
 
 ETbEnumEnum1 UTbEnumEnumInterfaceOLinkClient::GetProp1_Implementation() const
@@ -115,7 +140,20 @@ void UTbEnumEnumInterfaceOLinkClient::SetProp1_Implementation(ETbEnumEnum1 InPro
 	{
 		return;
 	}
+
+	// only send change requests if the value changed -> reduce network load
+	if (GetProp1_Implementation() == InProp1)
+	{
+		return;
+	}
+
+	// only send change requests if the value wasn't already sent -> reduce network load
+	if (_SentData->Prop1 == InProp1)
+	{
+		return;
+	}
 	m_sink->GetNode()->setRemoteProperty(ApiGear::ObjectLink::Name::createMemberId(m_sink->olinkObjectName(), "prop1"), InProp1);
+	_SentData->Prop1 = InProp1;
 }
 
 ETbEnumEnum2 UTbEnumEnumInterfaceOLinkClient::GetProp2_Implementation() const
@@ -129,7 +167,20 @@ void UTbEnumEnumInterfaceOLinkClient::SetProp2_Implementation(ETbEnumEnum2 InPro
 	{
 		return;
 	}
+
+	// only send change requests if the value changed -> reduce network load
+	if (GetProp2_Implementation() == InProp2)
+	{
+		return;
+	}
+
+	// only send change requests if the value wasn't already sent -> reduce network load
+	if (_SentData->Prop2 == InProp2)
+	{
+		return;
+	}
 	m_sink->GetNode()->setRemoteProperty(ApiGear::ObjectLink::Name::createMemberId(m_sink->olinkObjectName(), "prop2"), InProp2);
+	_SentData->Prop2 = InProp2;
 }
 
 ETbEnumEnum3 UTbEnumEnumInterfaceOLinkClient::GetProp3_Implementation() const
@@ -143,7 +194,20 @@ void UTbEnumEnumInterfaceOLinkClient::SetProp3_Implementation(ETbEnumEnum3 InPro
 	{
 		return;
 	}
+
+	// only send change requests if the value changed -> reduce network load
+	if (GetProp3_Implementation() == InProp3)
+	{
+		return;
+	}
+
+	// only send change requests if the value wasn't already sent -> reduce network load
+	if (_SentData->Prop3 == InProp3)
+	{
+		return;
+	}
 	m_sink->GetNode()->setRemoteProperty(ApiGear::ObjectLink::Name::createMemberId(m_sink->olinkObjectName(), "prop3"), InProp3);
+	_SentData->Prop3 = InProp3;
 }
 
 ETbEnumEnum0 UTbEnumEnumInterfaceOLinkClient::Func0_Implementation(ETbEnumEnum0 Param0)

--- a/goldenmaster/Plugins/TbEnum/Source/TbEnum/Public/Generated/OLink/TbEnumEnumInterfaceOLinkClient.h
+++ b/goldenmaster/Plugins/TbEnum/Source/TbEnum/Public/Generated/OLink/TbEnumEnumInterfaceOLinkClient.h
@@ -22,7 +22,10 @@ THIRD_PARTY_INCLUDES_START
 THIRD_PARTY_INCLUDES_END
 #include "unrealolinksink.h"
 #include "Subsystems/GameInstanceSubsystem.h"
+#include "Templates/PimplPtr.h"
 #include "TbEnumEnumInterfaceOLinkClient.generated.h"
+
+struct TbEnumEnumInterfacePropertiesData;
 
 UCLASS(NotBlueprintable, BlueprintType)
 class TBENUM_API UTbEnumEnumInterfaceOLinkClient : public UAbstractTbEnumEnumInterface
@@ -62,4 +65,7 @@ private:
 	void applyState(const nlohmann::json& fields);
 	void emitSignal(const std::string& signalName, const nlohmann::json& args);
 	std::shared_ptr<FUnrealOLinkSink> m_sink;
+
+	// member variable to store the last sent data
+	TPimplPtr<TbEnumEnumInterfacePropertiesData> _SentData;
 };

--- a/goldenmaster/Plugins/TbSame1/Source/TbSame1/Private/Generated/OLink/TbSame1SameEnum1InterfaceOLinkClient.cpp
+++ b/goldenmaster/Plugins/TbSame1/Source/TbSame1/Private/Generated/OLink/TbSame1SameEnum1InterfaceOLinkClient.cpp
@@ -43,8 +43,17 @@ bool IsTbSame1SameEnum1InterfaceLogEnabled()
 }
 } // namespace
 
+/**
+   \brief data structure to hold the last sent property values
+*/
+struct TbSame1SameEnum1InterfacePropertiesData
+{
+	ETbSame1Enum1 Prop1{ETbSame1Enum1::TSE_VALUE1};
+};
+
 UTbSame1SameEnum1InterfaceOLinkClient::UTbSame1SameEnum1InterfaceOLinkClient()
 	: UAbstractTbSame1SameEnum1Interface()
+	, _SentData(MakePimpl<TbSame1SameEnum1InterfacePropertiesData>())
 {
 	m_sink = std::make_shared<FUnrealOLinkSink>("tb.same1.SameEnum1Interface");
 }
@@ -101,7 +110,20 @@ void UTbSame1SameEnum1InterfaceOLinkClient::SetProp1_Implementation(ETbSame1Enum
 	{
 		return;
 	}
+
+	// only send change requests if the value changed -> reduce network load
+	if (GetProp1_Implementation() == InProp1)
+	{
+		return;
+	}
+
+	// only send change requests if the value wasn't already sent -> reduce network load
+	if (_SentData->Prop1 == InProp1)
+	{
+		return;
+	}
 	m_sink->GetNode()->setRemoteProperty(ApiGear::ObjectLink::Name::createMemberId(m_sink->olinkObjectName(), "prop1"), InProp1);
+	_SentData->Prop1 = InProp1;
 }
 
 ETbSame1Enum1 UTbSame1SameEnum1InterfaceOLinkClient::Func1_Implementation(ETbSame1Enum1 Param1)

--- a/goldenmaster/Plugins/TbSame1/Source/TbSame1/Private/Generated/OLink/TbSame1SameEnum2InterfaceOLinkClient.cpp
+++ b/goldenmaster/Plugins/TbSame1/Source/TbSame1/Private/Generated/OLink/TbSame1SameEnum2InterfaceOLinkClient.cpp
@@ -43,8 +43,18 @@ bool IsTbSame1SameEnum2InterfaceLogEnabled()
 }
 } // namespace
 
+/**
+   \brief data structure to hold the last sent property values
+*/
+struct TbSame1SameEnum2InterfacePropertiesData
+{
+	ETbSame1Enum1 Prop1{ETbSame1Enum1::TSE_VALUE1};
+	ETbSame1Enum2 Prop2{ETbSame1Enum2::TSE_VALUE1};
+};
+
 UTbSame1SameEnum2InterfaceOLinkClient::UTbSame1SameEnum2InterfaceOLinkClient()
 	: UAbstractTbSame1SameEnum2Interface()
+	, _SentData(MakePimpl<TbSame1SameEnum2InterfacePropertiesData>())
 {
 	m_sink = std::make_shared<FUnrealOLinkSink>("tb.same1.SameEnum2Interface");
 }
@@ -101,7 +111,20 @@ void UTbSame1SameEnum2InterfaceOLinkClient::SetProp1_Implementation(ETbSame1Enum
 	{
 		return;
 	}
+
+	// only send change requests if the value changed -> reduce network load
+	if (GetProp1_Implementation() == InProp1)
+	{
+		return;
+	}
+
+	// only send change requests if the value wasn't already sent -> reduce network load
+	if (_SentData->Prop1 == InProp1)
+	{
+		return;
+	}
 	m_sink->GetNode()->setRemoteProperty(ApiGear::ObjectLink::Name::createMemberId(m_sink->olinkObjectName(), "prop1"), InProp1);
+	_SentData->Prop1 = InProp1;
 }
 
 ETbSame1Enum2 UTbSame1SameEnum2InterfaceOLinkClient::GetProp2_Implementation() const
@@ -115,7 +138,20 @@ void UTbSame1SameEnum2InterfaceOLinkClient::SetProp2_Implementation(ETbSame1Enum
 	{
 		return;
 	}
+
+	// only send change requests if the value changed -> reduce network load
+	if (GetProp2_Implementation() == InProp2)
+	{
+		return;
+	}
+
+	// only send change requests if the value wasn't already sent -> reduce network load
+	if (_SentData->Prop2 == InProp2)
+	{
+		return;
+	}
 	m_sink->GetNode()->setRemoteProperty(ApiGear::ObjectLink::Name::createMemberId(m_sink->olinkObjectName(), "prop2"), InProp2);
+	_SentData->Prop2 = InProp2;
 }
 
 ETbSame1Enum1 UTbSame1SameEnum2InterfaceOLinkClient::Func1_Implementation(ETbSame1Enum1 Param1)

--- a/goldenmaster/Plugins/TbSame1/Source/TbSame1/Private/Generated/OLink/TbSame1SameStruct1InterfaceOLinkClient.cpp
+++ b/goldenmaster/Plugins/TbSame1/Source/TbSame1/Private/Generated/OLink/TbSame1SameStruct1InterfaceOLinkClient.cpp
@@ -43,8 +43,17 @@ bool IsTbSame1SameStruct1InterfaceLogEnabled()
 }
 } // namespace
 
+/**
+   \brief data structure to hold the last sent property values
+*/
+struct TbSame1SameStruct1InterfacePropertiesData
+{
+	FTbSame1Struct1 Prop1{FTbSame1Struct1()};
+};
+
 UTbSame1SameStruct1InterfaceOLinkClient::UTbSame1SameStruct1InterfaceOLinkClient()
 	: UAbstractTbSame1SameStruct1Interface()
+	, _SentData(MakePimpl<TbSame1SameStruct1InterfacePropertiesData>())
 {
 	m_sink = std::make_shared<FUnrealOLinkSink>("tb.same1.SameStruct1Interface");
 }
@@ -101,7 +110,20 @@ void UTbSame1SameStruct1InterfaceOLinkClient::SetProp1_Implementation(const FTbS
 	{
 		return;
 	}
+
+	// only send change requests if the value changed -> reduce network load
+	if (GetProp1_Implementation() == InProp1)
+	{
+		return;
+	}
+
+	// only send change requests if the value wasn't already sent -> reduce network load
+	if (_SentData->Prop1 == InProp1)
+	{
+		return;
+	}
 	m_sink->GetNode()->setRemoteProperty(ApiGear::ObjectLink::Name::createMemberId(m_sink->olinkObjectName(), "prop1"), InProp1);
+	_SentData->Prop1 = InProp1;
 }
 
 FTbSame1Struct1 UTbSame1SameStruct1InterfaceOLinkClient::Func1_Implementation(const FTbSame1Struct1& Param1)

--- a/goldenmaster/Plugins/TbSame1/Source/TbSame1/Private/Generated/OLink/TbSame1SameStruct2InterfaceOLinkClient.cpp
+++ b/goldenmaster/Plugins/TbSame1/Source/TbSame1/Private/Generated/OLink/TbSame1SameStruct2InterfaceOLinkClient.cpp
@@ -43,8 +43,18 @@ bool IsTbSame1SameStruct2InterfaceLogEnabled()
 }
 } // namespace
 
+/**
+   \brief data structure to hold the last sent property values
+*/
+struct TbSame1SameStruct2InterfacePropertiesData
+{
+	FTbSame1Struct2 Prop1{FTbSame1Struct2()};
+	FTbSame1Struct2 Prop2{FTbSame1Struct2()};
+};
+
 UTbSame1SameStruct2InterfaceOLinkClient::UTbSame1SameStruct2InterfaceOLinkClient()
 	: UAbstractTbSame1SameStruct2Interface()
+	, _SentData(MakePimpl<TbSame1SameStruct2InterfacePropertiesData>())
 {
 	m_sink = std::make_shared<FUnrealOLinkSink>("tb.same1.SameStruct2Interface");
 }
@@ -101,7 +111,20 @@ void UTbSame1SameStruct2InterfaceOLinkClient::SetProp1_Implementation(const FTbS
 	{
 		return;
 	}
+
+	// only send change requests if the value changed -> reduce network load
+	if (GetProp1_Implementation() == InProp1)
+	{
+		return;
+	}
+
+	// only send change requests if the value wasn't already sent -> reduce network load
+	if (_SentData->Prop1 == InProp1)
+	{
+		return;
+	}
 	m_sink->GetNode()->setRemoteProperty(ApiGear::ObjectLink::Name::createMemberId(m_sink->olinkObjectName(), "prop1"), InProp1);
+	_SentData->Prop1 = InProp1;
 }
 
 FTbSame1Struct2 UTbSame1SameStruct2InterfaceOLinkClient::GetProp2_Implementation() const
@@ -115,7 +138,20 @@ void UTbSame1SameStruct2InterfaceOLinkClient::SetProp2_Implementation(const FTbS
 	{
 		return;
 	}
+
+	// only send change requests if the value changed -> reduce network load
+	if (GetProp2_Implementation() == InProp2)
+	{
+		return;
+	}
+
+	// only send change requests if the value wasn't already sent -> reduce network load
+	if (_SentData->Prop2 == InProp2)
+	{
+		return;
+	}
 	m_sink->GetNode()->setRemoteProperty(ApiGear::ObjectLink::Name::createMemberId(m_sink->olinkObjectName(), "prop2"), InProp2);
+	_SentData->Prop2 = InProp2;
 }
 
 FTbSame1Struct1 UTbSame1SameStruct2InterfaceOLinkClient::Func1_Implementation(const FTbSame1Struct1& Param1)

--- a/goldenmaster/Plugins/TbSame1/Source/TbSame1/Public/Generated/OLink/TbSame1SameEnum1InterfaceOLinkClient.h
+++ b/goldenmaster/Plugins/TbSame1/Source/TbSame1/Public/Generated/OLink/TbSame1SameEnum1InterfaceOLinkClient.h
@@ -22,7 +22,10 @@ THIRD_PARTY_INCLUDES_START
 THIRD_PARTY_INCLUDES_END
 #include "unrealolinksink.h"
 #include "Subsystems/GameInstanceSubsystem.h"
+#include "Templates/PimplPtr.h"
 #include "TbSame1SameEnum1InterfaceOLinkClient.generated.h"
+
+struct TbSame1SameEnum1InterfacePropertiesData;
 
 UCLASS(NotBlueprintable, BlueprintType)
 class TBSAME1_API UTbSame1SameEnum1InterfaceOLinkClient : public UAbstractTbSame1SameEnum1Interface
@@ -47,4 +50,7 @@ private:
 	void applyState(const nlohmann::json& fields);
 	void emitSignal(const std::string& signalName, const nlohmann::json& args);
 	std::shared_ptr<FUnrealOLinkSink> m_sink;
+
+	// member variable to store the last sent data
+	TPimplPtr<TbSame1SameEnum1InterfacePropertiesData> _SentData;
 };

--- a/goldenmaster/Plugins/TbSame1/Source/TbSame1/Public/Generated/OLink/TbSame1SameEnum2InterfaceOLinkClient.h
+++ b/goldenmaster/Plugins/TbSame1/Source/TbSame1/Public/Generated/OLink/TbSame1SameEnum2InterfaceOLinkClient.h
@@ -22,7 +22,10 @@ THIRD_PARTY_INCLUDES_START
 THIRD_PARTY_INCLUDES_END
 #include "unrealolinksink.h"
 #include "Subsystems/GameInstanceSubsystem.h"
+#include "Templates/PimplPtr.h"
 #include "TbSame1SameEnum2InterfaceOLinkClient.generated.h"
+
+struct TbSame1SameEnum2InterfacePropertiesData;
 
 UCLASS(NotBlueprintable, BlueprintType)
 class TBSAME1_API UTbSame1SameEnum2InterfaceOLinkClient : public UAbstractTbSame1SameEnum2Interface
@@ -52,4 +55,7 @@ private:
 	void applyState(const nlohmann::json& fields);
 	void emitSignal(const std::string& signalName, const nlohmann::json& args);
 	std::shared_ptr<FUnrealOLinkSink> m_sink;
+
+	// member variable to store the last sent data
+	TPimplPtr<TbSame1SameEnum2InterfacePropertiesData> _SentData;
 };

--- a/goldenmaster/Plugins/TbSame1/Source/TbSame1/Public/Generated/OLink/TbSame1SameStruct1InterfaceOLinkClient.h
+++ b/goldenmaster/Plugins/TbSame1/Source/TbSame1/Public/Generated/OLink/TbSame1SameStruct1InterfaceOLinkClient.h
@@ -22,7 +22,10 @@ THIRD_PARTY_INCLUDES_START
 THIRD_PARTY_INCLUDES_END
 #include "unrealolinksink.h"
 #include "Subsystems/GameInstanceSubsystem.h"
+#include "Templates/PimplPtr.h"
 #include "TbSame1SameStruct1InterfaceOLinkClient.generated.h"
+
+struct TbSame1SameStruct1InterfacePropertiesData;
 
 UCLASS(NotBlueprintable, BlueprintType)
 class TBSAME1_API UTbSame1SameStruct1InterfaceOLinkClient : public UAbstractTbSame1SameStruct1Interface
@@ -47,4 +50,7 @@ private:
 	void applyState(const nlohmann::json& fields);
 	void emitSignal(const std::string& signalName, const nlohmann::json& args);
 	std::shared_ptr<FUnrealOLinkSink> m_sink;
+
+	// member variable to store the last sent data
+	TPimplPtr<TbSame1SameStruct1InterfacePropertiesData> _SentData;
 };

--- a/goldenmaster/Plugins/TbSame1/Source/TbSame1/Public/Generated/OLink/TbSame1SameStruct2InterfaceOLinkClient.h
+++ b/goldenmaster/Plugins/TbSame1/Source/TbSame1/Public/Generated/OLink/TbSame1SameStruct2InterfaceOLinkClient.h
@@ -22,7 +22,10 @@ THIRD_PARTY_INCLUDES_START
 THIRD_PARTY_INCLUDES_END
 #include "unrealolinksink.h"
 #include "Subsystems/GameInstanceSubsystem.h"
+#include "Templates/PimplPtr.h"
 #include "TbSame1SameStruct2InterfaceOLinkClient.generated.h"
+
+struct TbSame1SameStruct2InterfacePropertiesData;
 
 UCLASS(NotBlueprintable, BlueprintType)
 class TBSAME1_API UTbSame1SameStruct2InterfaceOLinkClient : public UAbstractTbSame1SameStruct2Interface
@@ -52,4 +55,7 @@ private:
 	void applyState(const nlohmann::json& fields);
 	void emitSignal(const std::string& signalName, const nlohmann::json& args);
 	std::shared_ptr<FUnrealOLinkSink> m_sink;
+
+	// member variable to store the last sent data
+	TPimplPtr<TbSame1SameStruct2InterfacePropertiesData> _SentData;
 };

--- a/goldenmaster/Plugins/TbSame2/Source/TbSame2/Private/Generated/OLink/TbSame2SameEnum1InterfaceOLinkClient.cpp
+++ b/goldenmaster/Plugins/TbSame2/Source/TbSame2/Private/Generated/OLink/TbSame2SameEnum1InterfaceOLinkClient.cpp
@@ -43,8 +43,17 @@ bool IsTbSame2SameEnum1InterfaceLogEnabled()
 }
 } // namespace
 
+/**
+   \brief data structure to hold the last sent property values
+*/
+struct TbSame2SameEnum1InterfacePropertiesData
+{
+	ETbSame2Enum1 Prop1{ETbSame2Enum1::TSE_VALUE1};
+};
+
 UTbSame2SameEnum1InterfaceOLinkClient::UTbSame2SameEnum1InterfaceOLinkClient()
 	: UAbstractTbSame2SameEnum1Interface()
+	, _SentData(MakePimpl<TbSame2SameEnum1InterfacePropertiesData>())
 {
 	m_sink = std::make_shared<FUnrealOLinkSink>("tb.same2.SameEnum1Interface");
 }
@@ -101,7 +110,20 @@ void UTbSame2SameEnum1InterfaceOLinkClient::SetProp1_Implementation(ETbSame2Enum
 	{
 		return;
 	}
+
+	// only send change requests if the value changed -> reduce network load
+	if (GetProp1_Implementation() == InProp1)
+	{
+		return;
+	}
+
+	// only send change requests if the value wasn't already sent -> reduce network load
+	if (_SentData->Prop1 == InProp1)
+	{
+		return;
+	}
 	m_sink->GetNode()->setRemoteProperty(ApiGear::ObjectLink::Name::createMemberId(m_sink->olinkObjectName(), "prop1"), InProp1);
+	_SentData->Prop1 = InProp1;
 }
 
 ETbSame2Enum1 UTbSame2SameEnum1InterfaceOLinkClient::Func1_Implementation(ETbSame2Enum1 Param1)

--- a/goldenmaster/Plugins/TbSame2/Source/TbSame2/Private/Generated/OLink/TbSame2SameEnum2InterfaceOLinkClient.cpp
+++ b/goldenmaster/Plugins/TbSame2/Source/TbSame2/Private/Generated/OLink/TbSame2SameEnum2InterfaceOLinkClient.cpp
@@ -43,8 +43,18 @@ bool IsTbSame2SameEnum2InterfaceLogEnabled()
 }
 } // namespace
 
+/**
+   \brief data structure to hold the last sent property values
+*/
+struct TbSame2SameEnum2InterfacePropertiesData
+{
+	ETbSame2Enum1 Prop1{ETbSame2Enum1::TSE_VALUE1};
+	ETbSame2Enum2 Prop2{ETbSame2Enum2::TSE_VALUE1};
+};
+
 UTbSame2SameEnum2InterfaceOLinkClient::UTbSame2SameEnum2InterfaceOLinkClient()
 	: UAbstractTbSame2SameEnum2Interface()
+	, _SentData(MakePimpl<TbSame2SameEnum2InterfacePropertiesData>())
 {
 	m_sink = std::make_shared<FUnrealOLinkSink>("tb.same2.SameEnum2Interface");
 }
@@ -101,7 +111,20 @@ void UTbSame2SameEnum2InterfaceOLinkClient::SetProp1_Implementation(ETbSame2Enum
 	{
 		return;
 	}
+
+	// only send change requests if the value changed -> reduce network load
+	if (GetProp1_Implementation() == InProp1)
+	{
+		return;
+	}
+
+	// only send change requests if the value wasn't already sent -> reduce network load
+	if (_SentData->Prop1 == InProp1)
+	{
+		return;
+	}
 	m_sink->GetNode()->setRemoteProperty(ApiGear::ObjectLink::Name::createMemberId(m_sink->olinkObjectName(), "prop1"), InProp1);
+	_SentData->Prop1 = InProp1;
 }
 
 ETbSame2Enum2 UTbSame2SameEnum2InterfaceOLinkClient::GetProp2_Implementation() const
@@ -115,7 +138,20 @@ void UTbSame2SameEnum2InterfaceOLinkClient::SetProp2_Implementation(ETbSame2Enum
 	{
 		return;
 	}
+
+	// only send change requests if the value changed -> reduce network load
+	if (GetProp2_Implementation() == InProp2)
+	{
+		return;
+	}
+
+	// only send change requests if the value wasn't already sent -> reduce network load
+	if (_SentData->Prop2 == InProp2)
+	{
+		return;
+	}
 	m_sink->GetNode()->setRemoteProperty(ApiGear::ObjectLink::Name::createMemberId(m_sink->olinkObjectName(), "prop2"), InProp2);
+	_SentData->Prop2 = InProp2;
 }
 
 ETbSame2Enum1 UTbSame2SameEnum2InterfaceOLinkClient::Func1_Implementation(ETbSame2Enum1 Param1)

--- a/goldenmaster/Plugins/TbSame2/Source/TbSame2/Private/Generated/OLink/TbSame2SameStruct1InterfaceOLinkClient.cpp
+++ b/goldenmaster/Plugins/TbSame2/Source/TbSame2/Private/Generated/OLink/TbSame2SameStruct1InterfaceOLinkClient.cpp
@@ -43,8 +43,17 @@ bool IsTbSame2SameStruct1InterfaceLogEnabled()
 }
 } // namespace
 
+/**
+   \brief data structure to hold the last sent property values
+*/
+struct TbSame2SameStruct1InterfacePropertiesData
+{
+	FTbSame2Struct1 Prop1{FTbSame2Struct1()};
+};
+
 UTbSame2SameStruct1InterfaceOLinkClient::UTbSame2SameStruct1InterfaceOLinkClient()
 	: UAbstractTbSame2SameStruct1Interface()
+	, _SentData(MakePimpl<TbSame2SameStruct1InterfacePropertiesData>())
 {
 	m_sink = std::make_shared<FUnrealOLinkSink>("tb.same2.SameStruct1Interface");
 }
@@ -101,7 +110,20 @@ void UTbSame2SameStruct1InterfaceOLinkClient::SetProp1_Implementation(const FTbS
 	{
 		return;
 	}
+
+	// only send change requests if the value changed -> reduce network load
+	if (GetProp1_Implementation() == InProp1)
+	{
+		return;
+	}
+
+	// only send change requests if the value wasn't already sent -> reduce network load
+	if (_SentData->Prop1 == InProp1)
+	{
+		return;
+	}
 	m_sink->GetNode()->setRemoteProperty(ApiGear::ObjectLink::Name::createMemberId(m_sink->olinkObjectName(), "prop1"), InProp1);
+	_SentData->Prop1 = InProp1;
 }
 
 FTbSame2Struct1 UTbSame2SameStruct1InterfaceOLinkClient::Func1_Implementation(const FTbSame2Struct1& Param1)

--- a/goldenmaster/Plugins/TbSame2/Source/TbSame2/Private/Generated/OLink/TbSame2SameStruct2InterfaceOLinkClient.cpp
+++ b/goldenmaster/Plugins/TbSame2/Source/TbSame2/Private/Generated/OLink/TbSame2SameStruct2InterfaceOLinkClient.cpp
@@ -43,8 +43,18 @@ bool IsTbSame2SameStruct2InterfaceLogEnabled()
 }
 } // namespace
 
+/**
+   \brief data structure to hold the last sent property values
+*/
+struct TbSame2SameStruct2InterfacePropertiesData
+{
+	FTbSame2Struct2 Prop1{FTbSame2Struct2()};
+	FTbSame2Struct2 Prop2{FTbSame2Struct2()};
+};
+
 UTbSame2SameStruct2InterfaceOLinkClient::UTbSame2SameStruct2InterfaceOLinkClient()
 	: UAbstractTbSame2SameStruct2Interface()
+	, _SentData(MakePimpl<TbSame2SameStruct2InterfacePropertiesData>())
 {
 	m_sink = std::make_shared<FUnrealOLinkSink>("tb.same2.SameStruct2Interface");
 }
@@ -101,7 +111,20 @@ void UTbSame2SameStruct2InterfaceOLinkClient::SetProp1_Implementation(const FTbS
 	{
 		return;
 	}
+
+	// only send change requests if the value changed -> reduce network load
+	if (GetProp1_Implementation() == InProp1)
+	{
+		return;
+	}
+
+	// only send change requests if the value wasn't already sent -> reduce network load
+	if (_SentData->Prop1 == InProp1)
+	{
+		return;
+	}
 	m_sink->GetNode()->setRemoteProperty(ApiGear::ObjectLink::Name::createMemberId(m_sink->olinkObjectName(), "prop1"), InProp1);
+	_SentData->Prop1 = InProp1;
 }
 
 FTbSame2Struct2 UTbSame2SameStruct2InterfaceOLinkClient::GetProp2_Implementation() const
@@ -115,7 +138,20 @@ void UTbSame2SameStruct2InterfaceOLinkClient::SetProp2_Implementation(const FTbS
 	{
 		return;
 	}
+
+	// only send change requests if the value changed -> reduce network load
+	if (GetProp2_Implementation() == InProp2)
+	{
+		return;
+	}
+
+	// only send change requests if the value wasn't already sent -> reduce network load
+	if (_SentData->Prop2 == InProp2)
+	{
+		return;
+	}
 	m_sink->GetNode()->setRemoteProperty(ApiGear::ObjectLink::Name::createMemberId(m_sink->olinkObjectName(), "prop2"), InProp2);
+	_SentData->Prop2 = InProp2;
 }
 
 FTbSame2Struct1 UTbSame2SameStruct2InterfaceOLinkClient::Func1_Implementation(const FTbSame2Struct1& Param1)

--- a/goldenmaster/Plugins/TbSame2/Source/TbSame2/Public/Generated/OLink/TbSame2SameEnum1InterfaceOLinkClient.h
+++ b/goldenmaster/Plugins/TbSame2/Source/TbSame2/Public/Generated/OLink/TbSame2SameEnum1InterfaceOLinkClient.h
@@ -22,7 +22,10 @@ THIRD_PARTY_INCLUDES_START
 THIRD_PARTY_INCLUDES_END
 #include "unrealolinksink.h"
 #include "Subsystems/GameInstanceSubsystem.h"
+#include "Templates/PimplPtr.h"
 #include "TbSame2SameEnum1InterfaceOLinkClient.generated.h"
+
+struct TbSame2SameEnum1InterfacePropertiesData;
 
 UCLASS(NotBlueprintable, BlueprintType)
 class TBSAME2_API UTbSame2SameEnum1InterfaceOLinkClient : public UAbstractTbSame2SameEnum1Interface
@@ -47,4 +50,7 @@ private:
 	void applyState(const nlohmann::json& fields);
 	void emitSignal(const std::string& signalName, const nlohmann::json& args);
 	std::shared_ptr<FUnrealOLinkSink> m_sink;
+
+	// member variable to store the last sent data
+	TPimplPtr<TbSame2SameEnum1InterfacePropertiesData> _SentData;
 };

--- a/goldenmaster/Plugins/TbSame2/Source/TbSame2/Public/Generated/OLink/TbSame2SameEnum2InterfaceOLinkClient.h
+++ b/goldenmaster/Plugins/TbSame2/Source/TbSame2/Public/Generated/OLink/TbSame2SameEnum2InterfaceOLinkClient.h
@@ -22,7 +22,10 @@ THIRD_PARTY_INCLUDES_START
 THIRD_PARTY_INCLUDES_END
 #include "unrealolinksink.h"
 #include "Subsystems/GameInstanceSubsystem.h"
+#include "Templates/PimplPtr.h"
 #include "TbSame2SameEnum2InterfaceOLinkClient.generated.h"
+
+struct TbSame2SameEnum2InterfacePropertiesData;
 
 UCLASS(NotBlueprintable, BlueprintType)
 class TBSAME2_API UTbSame2SameEnum2InterfaceOLinkClient : public UAbstractTbSame2SameEnum2Interface
@@ -52,4 +55,7 @@ private:
 	void applyState(const nlohmann::json& fields);
 	void emitSignal(const std::string& signalName, const nlohmann::json& args);
 	std::shared_ptr<FUnrealOLinkSink> m_sink;
+
+	// member variable to store the last sent data
+	TPimplPtr<TbSame2SameEnum2InterfacePropertiesData> _SentData;
 };

--- a/goldenmaster/Plugins/TbSame2/Source/TbSame2/Public/Generated/OLink/TbSame2SameStruct1InterfaceOLinkClient.h
+++ b/goldenmaster/Plugins/TbSame2/Source/TbSame2/Public/Generated/OLink/TbSame2SameStruct1InterfaceOLinkClient.h
@@ -22,7 +22,10 @@ THIRD_PARTY_INCLUDES_START
 THIRD_PARTY_INCLUDES_END
 #include "unrealolinksink.h"
 #include "Subsystems/GameInstanceSubsystem.h"
+#include "Templates/PimplPtr.h"
 #include "TbSame2SameStruct1InterfaceOLinkClient.generated.h"
+
+struct TbSame2SameStruct1InterfacePropertiesData;
 
 UCLASS(NotBlueprintable, BlueprintType)
 class TBSAME2_API UTbSame2SameStruct1InterfaceOLinkClient : public UAbstractTbSame2SameStruct1Interface
@@ -47,4 +50,7 @@ private:
 	void applyState(const nlohmann::json& fields);
 	void emitSignal(const std::string& signalName, const nlohmann::json& args);
 	std::shared_ptr<FUnrealOLinkSink> m_sink;
+
+	// member variable to store the last sent data
+	TPimplPtr<TbSame2SameStruct1InterfacePropertiesData> _SentData;
 };

--- a/goldenmaster/Plugins/TbSame2/Source/TbSame2/Public/Generated/OLink/TbSame2SameStruct2InterfaceOLinkClient.h
+++ b/goldenmaster/Plugins/TbSame2/Source/TbSame2/Public/Generated/OLink/TbSame2SameStruct2InterfaceOLinkClient.h
@@ -22,7 +22,10 @@ THIRD_PARTY_INCLUDES_START
 THIRD_PARTY_INCLUDES_END
 #include "unrealolinksink.h"
 #include "Subsystems/GameInstanceSubsystem.h"
+#include "Templates/PimplPtr.h"
 #include "TbSame2SameStruct2InterfaceOLinkClient.generated.h"
+
+struct TbSame2SameStruct2InterfacePropertiesData;
 
 UCLASS(NotBlueprintable, BlueprintType)
 class TBSAME2_API UTbSame2SameStruct2InterfaceOLinkClient : public UAbstractTbSame2SameStruct2Interface
@@ -52,4 +55,7 @@ private:
 	void applyState(const nlohmann::json& fields);
 	void emitSignal(const std::string& signalName, const nlohmann::json& args);
 	std::shared_ptr<FUnrealOLinkSink> m_sink;
+
+	// member variable to store the last sent data
+	TPimplPtr<TbSame2SameStruct2InterfacePropertiesData> _SentData;
 };

--- a/goldenmaster/Plugins/TbSimple/Source/TbSimple/Private/Generated/OLink/TbSimpleNoOperationsInterfaceOLinkClient.cpp
+++ b/goldenmaster/Plugins/TbSimple/Source/TbSimple/Private/Generated/OLink/TbSimpleNoOperationsInterfaceOLinkClient.cpp
@@ -43,8 +43,18 @@ bool IsTbSimpleNoOperationsInterfaceLogEnabled()
 }
 } // namespace
 
+/**
+   \brief data structure to hold the last sent property values
+*/
+struct TbSimpleNoOperationsInterfacePropertiesData
+{
+	bool bPropBool{false};
+	int32 PropInt{0};
+};
+
 UTbSimpleNoOperationsInterfaceOLinkClient::UTbSimpleNoOperationsInterfaceOLinkClient()
 	: UAbstractTbSimpleNoOperationsInterface()
+	, _SentData(MakePimpl<TbSimpleNoOperationsInterfacePropertiesData>())
 {
 	m_sink = std::make_shared<FUnrealOLinkSink>("tb.simple.NoOperationsInterface");
 }
@@ -101,7 +111,20 @@ void UTbSimpleNoOperationsInterfaceOLinkClient::SetPropBool_Implementation(bool 
 	{
 		return;
 	}
+
+	// only send change requests if the value changed -> reduce network load
+	if (GetPropBool_Implementation() == bInPropBool)
+	{
+		return;
+	}
+
+	// only send change requests if the value wasn't already sent -> reduce network load
+	if (_SentData->bPropBool == bInPropBool)
+	{
+		return;
+	}
 	m_sink->GetNode()->setRemoteProperty(ApiGear::ObjectLink::Name::createMemberId(m_sink->olinkObjectName(), "propBool"), bInPropBool);
+	_SentData->bPropBool = bInPropBool;
 }
 
 int32 UTbSimpleNoOperationsInterfaceOLinkClient::GetPropInt_Implementation() const
@@ -115,7 +138,20 @@ void UTbSimpleNoOperationsInterfaceOLinkClient::SetPropInt_Implementation(int32 
 	{
 		return;
 	}
+
+	// only send change requests if the value changed -> reduce network load
+	if (GetPropInt_Implementation() == InPropInt)
+	{
+		return;
+	}
+
+	// only send change requests if the value wasn't already sent -> reduce network load
+	if (_SentData->PropInt == InPropInt)
+	{
+		return;
+	}
 	m_sink->GetNode()->setRemoteProperty(ApiGear::ObjectLink::Name::createMemberId(m_sink->olinkObjectName(), "propInt"), InPropInt);
+	_SentData->PropInt = InPropInt;
 }
 
 void UTbSimpleNoOperationsInterfaceOLinkClient::applyState(const nlohmann::json& fields)

--- a/goldenmaster/Plugins/TbSimple/Source/TbSimple/Private/Generated/OLink/TbSimpleNoSignalsInterfaceOLinkClient.cpp
+++ b/goldenmaster/Plugins/TbSimple/Source/TbSimple/Private/Generated/OLink/TbSimpleNoSignalsInterfaceOLinkClient.cpp
@@ -43,8 +43,18 @@ bool IsTbSimpleNoSignalsInterfaceLogEnabled()
 }
 } // namespace
 
+/**
+   \brief data structure to hold the last sent property values
+*/
+struct TbSimpleNoSignalsInterfacePropertiesData
+{
+	bool bPropBool{false};
+	int32 PropInt{0};
+};
+
 UTbSimpleNoSignalsInterfaceOLinkClient::UTbSimpleNoSignalsInterfaceOLinkClient()
 	: UAbstractTbSimpleNoSignalsInterface()
+	, _SentData(MakePimpl<TbSimpleNoSignalsInterfacePropertiesData>())
 {
 	m_sink = std::make_shared<FUnrealOLinkSink>("tb.simple.NoSignalsInterface");
 }
@@ -101,7 +111,20 @@ void UTbSimpleNoSignalsInterfaceOLinkClient::SetPropBool_Implementation(bool bIn
 	{
 		return;
 	}
+
+	// only send change requests if the value changed -> reduce network load
+	if (GetPropBool_Implementation() == bInPropBool)
+	{
+		return;
+	}
+
+	// only send change requests if the value wasn't already sent -> reduce network load
+	if (_SentData->bPropBool == bInPropBool)
+	{
+		return;
+	}
 	m_sink->GetNode()->setRemoteProperty(ApiGear::ObjectLink::Name::createMemberId(m_sink->olinkObjectName(), "propBool"), bInPropBool);
+	_SentData->bPropBool = bInPropBool;
 }
 
 int32 UTbSimpleNoSignalsInterfaceOLinkClient::GetPropInt_Implementation() const
@@ -115,7 +138,20 @@ void UTbSimpleNoSignalsInterfaceOLinkClient::SetPropInt_Implementation(int32 InP
 	{
 		return;
 	}
+
+	// only send change requests if the value changed -> reduce network load
+	if (GetPropInt_Implementation() == InPropInt)
+	{
+		return;
+	}
+
+	// only send change requests if the value wasn't already sent -> reduce network load
+	if (_SentData->PropInt == InPropInt)
+	{
+		return;
+	}
 	m_sink->GetNode()->setRemoteProperty(ApiGear::ObjectLink::Name::createMemberId(m_sink->olinkObjectName(), "propInt"), InPropInt);
+	_SentData->PropInt = InPropInt;
 }
 
 void UTbSimpleNoSignalsInterfaceOLinkClient::FuncVoid_Implementation()

--- a/goldenmaster/Plugins/TbSimple/Source/TbSimple/Private/Generated/OLink/TbSimpleSimpleArrayInterfaceOLinkClient.cpp
+++ b/goldenmaster/Plugins/TbSimple/Source/TbSimple/Private/Generated/OLink/TbSimpleSimpleArrayInterfaceOLinkClient.cpp
@@ -43,8 +43,24 @@ bool IsTbSimpleSimpleArrayInterfaceLogEnabled()
 }
 } // namespace
 
+/**
+   \brief data structure to hold the last sent property values
+*/
+struct TbSimpleSimpleArrayInterfacePropertiesData
+{
+	TArray<bool> PropBool{TArray<bool>()};
+	TArray<int32> PropInt{TArray<int32>()};
+	TArray<int32> PropInt32{TArray<int32>()};
+	TArray<int64> PropInt64{TArray<int64>()};
+	TArray<float> PropFloat{TArray<float>()};
+	TArray<float> PropFloat32{TArray<float>()};
+	TArray<double> PropFloat64{TArray<double>()};
+	TArray<FString> PropString{TArray<FString>()};
+};
+
 UTbSimpleSimpleArrayInterfaceOLinkClient::UTbSimpleSimpleArrayInterfaceOLinkClient()
 	: UAbstractTbSimpleSimpleArrayInterface()
+	, _SentData(MakePimpl<TbSimpleSimpleArrayInterfacePropertiesData>())
 {
 	m_sink = std::make_shared<FUnrealOLinkSink>("tb.simple.SimpleArrayInterface");
 }
@@ -101,7 +117,20 @@ void UTbSimpleSimpleArrayInterfaceOLinkClient::SetPropBool_Implementation(const 
 	{
 		return;
 	}
+
+	// only send change requests if the value changed -> reduce network load
+	if (GetPropBool_Implementation() == InPropBool)
+	{
+		return;
+	}
+
+	// only send change requests if the value wasn't already sent -> reduce network load
+	if (_SentData->PropBool == InPropBool)
+	{
+		return;
+	}
 	m_sink->GetNode()->setRemoteProperty(ApiGear::ObjectLink::Name::createMemberId(m_sink->olinkObjectName(), "propBool"), InPropBool);
+	_SentData->PropBool = InPropBool;
 }
 
 TArray<int32> UTbSimpleSimpleArrayInterfaceOLinkClient::GetPropInt_Implementation() const
@@ -115,7 +144,20 @@ void UTbSimpleSimpleArrayInterfaceOLinkClient::SetPropInt_Implementation(const T
 	{
 		return;
 	}
+
+	// only send change requests if the value changed -> reduce network load
+	if (GetPropInt_Implementation() == InPropInt)
+	{
+		return;
+	}
+
+	// only send change requests if the value wasn't already sent -> reduce network load
+	if (_SentData->PropInt == InPropInt)
+	{
+		return;
+	}
 	m_sink->GetNode()->setRemoteProperty(ApiGear::ObjectLink::Name::createMemberId(m_sink->olinkObjectName(), "propInt"), InPropInt);
+	_SentData->PropInt = InPropInt;
 }
 
 TArray<int32> UTbSimpleSimpleArrayInterfaceOLinkClient::GetPropInt32_Implementation() const
@@ -129,7 +171,20 @@ void UTbSimpleSimpleArrayInterfaceOLinkClient::SetPropInt32_Implementation(const
 	{
 		return;
 	}
+
+	// only send change requests if the value changed -> reduce network load
+	if (GetPropInt32_Implementation() == InPropInt32)
+	{
+		return;
+	}
+
+	// only send change requests if the value wasn't already sent -> reduce network load
+	if (_SentData->PropInt32 == InPropInt32)
+	{
+		return;
+	}
 	m_sink->GetNode()->setRemoteProperty(ApiGear::ObjectLink::Name::createMemberId(m_sink->olinkObjectName(), "propInt32"), InPropInt32);
+	_SentData->PropInt32 = InPropInt32;
 }
 
 TArray<int64> UTbSimpleSimpleArrayInterfaceOLinkClient::GetPropInt64_Implementation() const
@@ -143,7 +198,20 @@ void UTbSimpleSimpleArrayInterfaceOLinkClient::SetPropInt64_Implementation(const
 	{
 		return;
 	}
+
+	// only send change requests if the value changed -> reduce network load
+	if (GetPropInt64_Implementation() == InPropInt64)
+	{
+		return;
+	}
+
+	// only send change requests if the value wasn't already sent -> reduce network load
+	if (_SentData->PropInt64 == InPropInt64)
+	{
+		return;
+	}
 	m_sink->GetNode()->setRemoteProperty(ApiGear::ObjectLink::Name::createMemberId(m_sink->olinkObjectName(), "propInt64"), InPropInt64);
+	_SentData->PropInt64 = InPropInt64;
 }
 
 TArray<float> UTbSimpleSimpleArrayInterfaceOLinkClient::GetPropFloat_Implementation() const
@@ -157,7 +225,20 @@ void UTbSimpleSimpleArrayInterfaceOLinkClient::SetPropFloat_Implementation(const
 	{
 		return;
 	}
+
+	// only send change requests if the value changed -> reduce network load
+	if (GetPropFloat_Implementation() == InPropFloat)
+	{
+		return;
+	}
+
+	// only send change requests if the value wasn't already sent -> reduce network load
+	if (_SentData->PropFloat == InPropFloat)
+	{
+		return;
+	}
 	m_sink->GetNode()->setRemoteProperty(ApiGear::ObjectLink::Name::createMemberId(m_sink->olinkObjectName(), "propFloat"), InPropFloat);
+	_SentData->PropFloat = InPropFloat;
 }
 
 TArray<float> UTbSimpleSimpleArrayInterfaceOLinkClient::GetPropFloat32_Implementation() const
@@ -171,7 +252,20 @@ void UTbSimpleSimpleArrayInterfaceOLinkClient::SetPropFloat32_Implementation(con
 	{
 		return;
 	}
+
+	// only send change requests if the value changed -> reduce network load
+	if (GetPropFloat32_Implementation() == InPropFloat32)
+	{
+		return;
+	}
+
+	// only send change requests if the value wasn't already sent -> reduce network load
+	if (_SentData->PropFloat32 == InPropFloat32)
+	{
+		return;
+	}
 	m_sink->GetNode()->setRemoteProperty(ApiGear::ObjectLink::Name::createMemberId(m_sink->olinkObjectName(), "propFloat32"), InPropFloat32);
+	_SentData->PropFloat32 = InPropFloat32;
 }
 
 TArray<double> UTbSimpleSimpleArrayInterfaceOLinkClient::GetPropFloat64_Implementation() const
@@ -185,7 +279,20 @@ void UTbSimpleSimpleArrayInterfaceOLinkClient::SetPropFloat64_Implementation(con
 	{
 		return;
 	}
+
+	// only send change requests if the value changed -> reduce network load
+	if (GetPropFloat64_Implementation() == InPropFloat64)
+	{
+		return;
+	}
+
+	// only send change requests if the value wasn't already sent -> reduce network load
+	if (_SentData->PropFloat64 == InPropFloat64)
+	{
+		return;
+	}
 	m_sink->GetNode()->setRemoteProperty(ApiGear::ObjectLink::Name::createMemberId(m_sink->olinkObjectName(), "propFloat64"), InPropFloat64);
+	_SentData->PropFloat64 = InPropFloat64;
 }
 
 TArray<FString> UTbSimpleSimpleArrayInterfaceOLinkClient::GetPropString_Implementation() const
@@ -199,7 +306,20 @@ void UTbSimpleSimpleArrayInterfaceOLinkClient::SetPropString_Implementation(cons
 	{
 		return;
 	}
+
+	// only send change requests if the value changed -> reduce network load
+	if (GetPropString_Implementation() == InPropString)
+	{
+		return;
+	}
+
+	// only send change requests if the value wasn't already sent -> reduce network load
+	if (_SentData->PropString == InPropString)
+	{
+		return;
+	}
 	m_sink->GetNode()->setRemoteProperty(ApiGear::ObjectLink::Name::createMemberId(m_sink->olinkObjectName(), "propString"), InPropString);
+	_SentData->PropString = InPropString;
 }
 
 TArray<bool> UTbSimpleSimpleArrayInterfaceOLinkClient::FuncBool_Implementation(const TArray<bool>& ParamBool)

--- a/goldenmaster/Plugins/TbSimple/Source/TbSimple/Private/Generated/OLink/TbSimpleSimpleInterfaceOLinkClient.cpp
+++ b/goldenmaster/Plugins/TbSimple/Source/TbSimple/Private/Generated/OLink/TbSimpleSimpleInterfaceOLinkClient.cpp
@@ -43,8 +43,24 @@ bool IsTbSimpleSimpleInterfaceLogEnabled()
 }
 } // namespace
 
+/**
+   \brief data structure to hold the last sent property values
+*/
+struct TbSimpleSimpleInterfacePropertiesData
+{
+	bool bPropBool{false};
+	int32 PropInt{0};
+	int32 PropInt32{0};
+	int64 PropInt64{0LL};
+	float PropFloat{0.0f};
+	float PropFloat32{0.0f};
+	double PropFloat64{0.0};
+	FString PropString{FString()};
+};
+
 UTbSimpleSimpleInterfaceOLinkClient::UTbSimpleSimpleInterfaceOLinkClient()
 	: UAbstractTbSimpleSimpleInterface()
+	, _SentData(MakePimpl<TbSimpleSimpleInterfacePropertiesData>())
 {
 	m_sink = std::make_shared<FUnrealOLinkSink>("tb.simple.SimpleInterface");
 }
@@ -101,7 +117,20 @@ void UTbSimpleSimpleInterfaceOLinkClient::SetPropBool_Implementation(bool bInPro
 	{
 		return;
 	}
+
+	// only send change requests if the value changed -> reduce network load
+	if (GetPropBool_Implementation() == bInPropBool)
+	{
+		return;
+	}
+
+	// only send change requests if the value wasn't already sent -> reduce network load
+	if (_SentData->bPropBool == bInPropBool)
+	{
+		return;
+	}
 	m_sink->GetNode()->setRemoteProperty(ApiGear::ObjectLink::Name::createMemberId(m_sink->olinkObjectName(), "propBool"), bInPropBool);
+	_SentData->bPropBool = bInPropBool;
 }
 
 int32 UTbSimpleSimpleInterfaceOLinkClient::GetPropInt_Implementation() const
@@ -115,7 +144,20 @@ void UTbSimpleSimpleInterfaceOLinkClient::SetPropInt_Implementation(int32 InProp
 	{
 		return;
 	}
+
+	// only send change requests if the value changed -> reduce network load
+	if (GetPropInt_Implementation() == InPropInt)
+	{
+		return;
+	}
+
+	// only send change requests if the value wasn't already sent -> reduce network load
+	if (_SentData->PropInt == InPropInt)
+	{
+		return;
+	}
 	m_sink->GetNode()->setRemoteProperty(ApiGear::ObjectLink::Name::createMemberId(m_sink->olinkObjectName(), "propInt"), InPropInt);
+	_SentData->PropInt = InPropInt;
 }
 
 int32 UTbSimpleSimpleInterfaceOLinkClient::GetPropInt32_Implementation() const
@@ -129,7 +171,20 @@ void UTbSimpleSimpleInterfaceOLinkClient::SetPropInt32_Implementation(int32 InPr
 	{
 		return;
 	}
+
+	// only send change requests if the value changed -> reduce network load
+	if (GetPropInt32_Implementation() == InPropInt32)
+	{
+		return;
+	}
+
+	// only send change requests if the value wasn't already sent -> reduce network load
+	if (_SentData->PropInt32 == InPropInt32)
+	{
+		return;
+	}
 	m_sink->GetNode()->setRemoteProperty(ApiGear::ObjectLink::Name::createMemberId(m_sink->olinkObjectName(), "propInt32"), InPropInt32);
+	_SentData->PropInt32 = InPropInt32;
 }
 
 int64 UTbSimpleSimpleInterfaceOLinkClient::GetPropInt64_Implementation() const
@@ -143,7 +198,20 @@ void UTbSimpleSimpleInterfaceOLinkClient::SetPropInt64_Implementation(int64 InPr
 	{
 		return;
 	}
+
+	// only send change requests if the value changed -> reduce network load
+	if (GetPropInt64_Implementation() == InPropInt64)
+	{
+		return;
+	}
+
+	// only send change requests if the value wasn't already sent -> reduce network load
+	if (_SentData->PropInt64 == InPropInt64)
+	{
+		return;
+	}
 	m_sink->GetNode()->setRemoteProperty(ApiGear::ObjectLink::Name::createMemberId(m_sink->olinkObjectName(), "propInt64"), InPropInt64);
+	_SentData->PropInt64 = InPropInt64;
 }
 
 float UTbSimpleSimpleInterfaceOLinkClient::GetPropFloat_Implementation() const
@@ -157,7 +225,20 @@ void UTbSimpleSimpleInterfaceOLinkClient::SetPropFloat_Implementation(float InPr
 	{
 		return;
 	}
+
+	// only send change requests if the value changed -> reduce network load
+	if (GetPropFloat_Implementation() == InPropFloat)
+	{
+		return;
+	}
+
+	// only send change requests if the value wasn't already sent -> reduce network load
+	if (_SentData->PropFloat == InPropFloat)
+	{
+		return;
+	}
 	m_sink->GetNode()->setRemoteProperty(ApiGear::ObjectLink::Name::createMemberId(m_sink->olinkObjectName(), "propFloat"), InPropFloat);
+	_SentData->PropFloat = InPropFloat;
 }
 
 float UTbSimpleSimpleInterfaceOLinkClient::GetPropFloat32_Implementation() const
@@ -171,7 +252,20 @@ void UTbSimpleSimpleInterfaceOLinkClient::SetPropFloat32_Implementation(float In
 	{
 		return;
 	}
+
+	// only send change requests if the value changed -> reduce network load
+	if (GetPropFloat32_Implementation() == InPropFloat32)
+	{
+		return;
+	}
+
+	// only send change requests if the value wasn't already sent -> reduce network load
+	if (_SentData->PropFloat32 == InPropFloat32)
+	{
+		return;
+	}
 	m_sink->GetNode()->setRemoteProperty(ApiGear::ObjectLink::Name::createMemberId(m_sink->olinkObjectName(), "propFloat32"), InPropFloat32);
+	_SentData->PropFloat32 = InPropFloat32;
 }
 
 double UTbSimpleSimpleInterfaceOLinkClient::GetPropFloat64_Implementation() const
@@ -185,7 +279,20 @@ void UTbSimpleSimpleInterfaceOLinkClient::SetPropFloat64_Implementation(double I
 	{
 		return;
 	}
+
+	// only send change requests if the value changed -> reduce network load
+	if (GetPropFloat64_Implementation() == InPropFloat64)
+	{
+		return;
+	}
+
+	// only send change requests if the value wasn't already sent -> reduce network load
+	if (_SentData->PropFloat64 == InPropFloat64)
+	{
+		return;
+	}
 	m_sink->GetNode()->setRemoteProperty(ApiGear::ObjectLink::Name::createMemberId(m_sink->olinkObjectName(), "propFloat64"), InPropFloat64);
+	_SentData->PropFloat64 = InPropFloat64;
 }
 
 FString UTbSimpleSimpleInterfaceOLinkClient::GetPropString_Implementation() const
@@ -199,7 +306,20 @@ void UTbSimpleSimpleInterfaceOLinkClient::SetPropString_Implementation(const FSt
 	{
 		return;
 	}
+
+	// only send change requests if the value changed -> reduce network load
+	if (GetPropString_Implementation() == InPropString)
+	{
+		return;
+	}
+
+	// only send change requests if the value wasn't already sent -> reduce network load
+	if (_SentData->PropString == InPropString)
+	{
+		return;
+	}
 	m_sink->GetNode()->setRemoteProperty(ApiGear::ObjectLink::Name::createMemberId(m_sink->olinkObjectName(), "propString"), InPropString);
+	_SentData->PropString = InPropString;
 }
 
 void UTbSimpleSimpleInterfaceOLinkClient::FuncVoid_Implementation()

--- a/goldenmaster/Plugins/TbSimple/Source/TbSimple/Public/Generated/OLink/TbSimpleEmptyInterfaceOLinkClient.h
+++ b/goldenmaster/Plugins/TbSimple/Source/TbSimple/Public/Generated/OLink/TbSimpleEmptyInterfaceOLinkClient.h
@@ -22,6 +22,7 @@ THIRD_PARTY_INCLUDES_START
 THIRD_PARTY_INCLUDES_END
 #include "unrealolinksink.h"
 #include "Subsystems/GameInstanceSubsystem.h"
+#include "Templates/PimplPtr.h"
 #include "TbSimpleEmptyInterfaceOLinkClient.generated.h"
 
 UCLASS(NotBlueprintable, BlueprintType)

--- a/goldenmaster/Plugins/TbSimple/Source/TbSimple/Public/Generated/OLink/TbSimpleNoOperationsInterfaceOLinkClient.h
+++ b/goldenmaster/Plugins/TbSimple/Source/TbSimple/Public/Generated/OLink/TbSimpleNoOperationsInterfaceOLinkClient.h
@@ -22,7 +22,10 @@ THIRD_PARTY_INCLUDES_START
 THIRD_PARTY_INCLUDES_END
 #include "unrealolinksink.h"
 #include "Subsystems/GameInstanceSubsystem.h"
+#include "Templates/PimplPtr.h"
 #include "TbSimpleNoOperationsInterfaceOLinkClient.generated.h"
+
+struct TbSimpleNoOperationsInterfacePropertiesData;
 
 UCLASS(NotBlueprintable, BlueprintType)
 class TBSIMPLE_API UTbSimpleNoOperationsInterfaceOLinkClient : public UAbstractTbSimpleNoOperationsInterface
@@ -49,4 +52,7 @@ private:
 	void applyState(const nlohmann::json& fields);
 	void emitSignal(const std::string& signalName, const nlohmann::json& args);
 	std::shared_ptr<FUnrealOLinkSink> m_sink;
+
+	// member variable to store the last sent data
+	TPimplPtr<TbSimpleNoOperationsInterfacePropertiesData> _SentData;
 };

--- a/goldenmaster/Plugins/TbSimple/Source/TbSimple/Public/Generated/OLink/TbSimpleNoPropertiesInterfaceOLinkClient.h
+++ b/goldenmaster/Plugins/TbSimple/Source/TbSimple/Public/Generated/OLink/TbSimpleNoPropertiesInterfaceOLinkClient.h
@@ -22,6 +22,7 @@ THIRD_PARTY_INCLUDES_START
 THIRD_PARTY_INCLUDES_END
 #include "unrealolinksink.h"
 #include "Subsystems/GameInstanceSubsystem.h"
+#include "Templates/PimplPtr.h"
 #include "TbSimpleNoPropertiesInterfaceOLinkClient.generated.h"
 
 UCLASS(NotBlueprintable, BlueprintType)

--- a/goldenmaster/Plugins/TbSimple/Source/TbSimple/Public/Generated/OLink/TbSimpleNoSignalsInterfaceOLinkClient.h
+++ b/goldenmaster/Plugins/TbSimple/Source/TbSimple/Public/Generated/OLink/TbSimpleNoSignalsInterfaceOLinkClient.h
@@ -22,7 +22,10 @@ THIRD_PARTY_INCLUDES_START
 THIRD_PARTY_INCLUDES_END
 #include "unrealolinksink.h"
 #include "Subsystems/GameInstanceSubsystem.h"
+#include "Templates/PimplPtr.h"
 #include "TbSimpleNoSignalsInterfaceOLinkClient.generated.h"
+
+struct TbSimpleNoSignalsInterfacePropertiesData;
 
 UCLASS(NotBlueprintable, BlueprintType)
 class TBSIMPLE_API UTbSimpleNoSignalsInterfaceOLinkClient : public UAbstractTbSimpleNoSignalsInterface
@@ -52,4 +55,7 @@ private:
 	void applyState(const nlohmann::json& fields);
 	void emitSignal(const std::string& signalName, const nlohmann::json& args);
 	std::shared_ptr<FUnrealOLinkSink> m_sink;
+
+	// member variable to store the last sent data
+	TPimplPtr<TbSimpleNoSignalsInterfacePropertiesData> _SentData;
 };

--- a/goldenmaster/Plugins/TbSimple/Source/TbSimple/Public/Generated/OLink/TbSimpleSimpleArrayInterfaceOLinkClient.h
+++ b/goldenmaster/Plugins/TbSimple/Source/TbSimple/Public/Generated/OLink/TbSimpleSimpleArrayInterfaceOLinkClient.h
@@ -22,7 +22,10 @@ THIRD_PARTY_INCLUDES_START
 THIRD_PARTY_INCLUDES_END
 #include "unrealolinksink.h"
 #include "Subsystems/GameInstanceSubsystem.h"
+#include "Templates/PimplPtr.h"
 #include "TbSimpleSimpleArrayInterfaceOLinkClient.generated.h"
+
+struct TbSimpleSimpleArrayInterfacePropertiesData;
 
 UCLASS(NotBlueprintable, BlueprintType)
 class TBSIMPLE_API UTbSimpleSimpleArrayInterfaceOLinkClient : public UAbstractTbSimpleSimpleArrayInterface
@@ -82,4 +85,7 @@ private:
 	void applyState(const nlohmann::json& fields);
 	void emitSignal(const std::string& signalName, const nlohmann::json& args);
 	std::shared_ptr<FUnrealOLinkSink> m_sink;
+
+	// member variable to store the last sent data
+	TPimplPtr<TbSimpleSimpleArrayInterfacePropertiesData> _SentData;
 };

--- a/goldenmaster/Plugins/TbSimple/Source/TbSimple/Public/Generated/OLink/TbSimpleSimpleInterfaceOLinkClient.h
+++ b/goldenmaster/Plugins/TbSimple/Source/TbSimple/Public/Generated/OLink/TbSimpleSimpleInterfaceOLinkClient.h
@@ -22,7 +22,10 @@ THIRD_PARTY_INCLUDES_START
 THIRD_PARTY_INCLUDES_END
 #include "unrealolinksink.h"
 #include "Subsystems/GameInstanceSubsystem.h"
+#include "Templates/PimplPtr.h"
 #include "TbSimpleSimpleInterfaceOLinkClient.generated.h"
+
+struct TbSimpleSimpleInterfacePropertiesData;
 
 UCLASS(NotBlueprintable, BlueprintType)
 class TBSIMPLE_API UTbSimpleSimpleInterfaceOLinkClient : public UAbstractTbSimpleSimpleInterface
@@ -84,4 +87,7 @@ private:
 	void applyState(const nlohmann::json& fields);
 	void emitSignal(const std::string& signalName, const nlohmann::json& args);
 	std::shared_ptr<FUnrealOLinkSink> m_sink;
+
+	// member variable to store the last sent data
+	TPimplPtr<TbSimpleSimpleInterfacePropertiesData> _SentData;
 };

--- a/goldenmaster/Plugins/Testbed1/Source/Testbed1/Private/Generated/OLink/Testbed1StructArrayInterfaceOLinkClient.cpp
+++ b/goldenmaster/Plugins/Testbed1/Source/Testbed1/Private/Generated/OLink/Testbed1StructArrayInterfaceOLinkClient.cpp
@@ -43,8 +43,20 @@ bool IsTestbed1StructArrayInterfaceLogEnabled()
 }
 } // namespace
 
+/**
+   \brief data structure to hold the last sent property values
+*/
+struct Testbed1StructArrayInterfacePropertiesData
+{
+	TArray<FTestbed1StructBool> PropBool{TArray<FTestbed1StructBool>()};
+	TArray<FTestbed1StructInt> PropInt{TArray<FTestbed1StructInt>()};
+	TArray<FTestbed1StructFloat> PropFloat{TArray<FTestbed1StructFloat>()};
+	TArray<FTestbed1StructString> PropString{TArray<FTestbed1StructString>()};
+};
+
 UTestbed1StructArrayInterfaceOLinkClient::UTestbed1StructArrayInterfaceOLinkClient()
 	: UAbstractTestbed1StructArrayInterface()
+	, _SentData(MakePimpl<Testbed1StructArrayInterfacePropertiesData>())
 {
 	m_sink = std::make_shared<FUnrealOLinkSink>("testbed1.StructArrayInterface");
 }
@@ -101,7 +113,20 @@ void UTestbed1StructArrayInterfaceOLinkClient::SetPropBool_Implementation(const 
 	{
 		return;
 	}
+
+	// only send change requests if the value changed -> reduce network load
+	if (GetPropBool_Implementation() == InPropBool)
+	{
+		return;
+	}
+
+	// only send change requests if the value wasn't already sent -> reduce network load
+	if (_SentData->PropBool == InPropBool)
+	{
+		return;
+	}
 	m_sink->GetNode()->setRemoteProperty(ApiGear::ObjectLink::Name::createMemberId(m_sink->olinkObjectName(), "propBool"), InPropBool);
+	_SentData->PropBool = InPropBool;
 }
 
 TArray<FTestbed1StructInt> UTestbed1StructArrayInterfaceOLinkClient::GetPropInt_Implementation() const
@@ -115,7 +140,20 @@ void UTestbed1StructArrayInterfaceOLinkClient::SetPropInt_Implementation(const T
 	{
 		return;
 	}
+
+	// only send change requests if the value changed -> reduce network load
+	if (GetPropInt_Implementation() == InPropInt)
+	{
+		return;
+	}
+
+	// only send change requests if the value wasn't already sent -> reduce network load
+	if (_SentData->PropInt == InPropInt)
+	{
+		return;
+	}
 	m_sink->GetNode()->setRemoteProperty(ApiGear::ObjectLink::Name::createMemberId(m_sink->olinkObjectName(), "propInt"), InPropInt);
+	_SentData->PropInt = InPropInt;
 }
 
 TArray<FTestbed1StructFloat> UTestbed1StructArrayInterfaceOLinkClient::GetPropFloat_Implementation() const
@@ -129,7 +167,20 @@ void UTestbed1StructArrayInterfaceOLinkClient::SetPropFloat_Implementation(const
 	{
 		return;
 	}
+
+	// only send change requests if the value changed -> reduce network load
+	if (GetPropFloat_Implementation() == InPropFloat)
+	{
+		return;
+	}
+
+	// only send change requests if the value wasn't already sent -> reduce network load
+	if (_SentData->PropFloat == InPropFloat)
+	{
+		return;
+	}
 	m_sink->GetNode()->setRemoteProperty(ApiGear::ObjectLink::Name::createMemberId(m_sink->olinkObjectName(), "propFloat"), InPropFloat);
+	_SentData->PropFloat = InPropFloat;
 }
 
 TArray<FTestbed1StructString> UTestbed1StructArrayInterfaceOLinkClient::GetPropString_Implementation() const
@@ -143,7 +194,20 @@ void UTestbed1StructArrayInterfaceOLinkClient::SetPropString_Implementation(cons
 	{
 		return;
 	}
+
+	// only send change requests if the value changed -> reduce network load
+	if (GetPropString_Implementation() == InPropString)
+	{
+		return;
+	}
+
+	// only send change requests if the value wasn't already sent -> reduce network load
+	if (_SentData->PropString == InPropString)
+	{
+		return;
+	}
 	m_sink->GetNode()->setRemoteProperty(ApiGear::ObjectLink::Name::createMemberId(m_sink->olinkObjectName(), "propString"), InPropString);
+	_SentData->PropString = InPropString;
 }
 
 FTestbed1StructBool UTestbed1StructArrayInterfaceOLinkClient::FuncBool_Implementation(const TArray<FTestbed1StructBool>& ParamBool)

--- a/goldenmaster/Plugins/Testbed1/Source/Testbed1/Private/Generated/OLink/Testbed1StructInterfaceOLinkClient.cpp
+++ b/goldenmaster/Plugins/Testbed1/Source/Testbed1/Private/Generated/OLink/Testbed1StructInterfaceOLinkClient.cpp
@@ -43,8 +43,20 @@ bool IsTestbed1StructInterfaceLogEnabled()
 }
 } // namespace
 
+/**
+   \brief data structure to hold the last sent property values
+*/
+struct Testbed1StructInterfacePropertiesData
+{
+	FTestbed1StructBool PropBool{FTestbed1StructBool()};
+	FTestbed1StructInt PropInt{FTestbed1StructInt()};
+	FTestbed1StructFloat PropFloat{FTestbed1StructFloat()};
+	FTestbed1StructString PropString{FTestbed1StructString()};
+};
+
 UTestbed1StructInterfaceOLinkClient::UTestbed1StructInterfaceOLinkClient()
 	: UAbstractTestbed1StructInterface()
+	, _SentData(MakePimpl<Testbed1StructInterfacePropertiesData>())
 {
 	m_sink = std::make_shared<FUnrealOLinkSink>("testbed1.StructInterface");
 }
@@ -101,7 +113,20 @@ void UTestbed1StructInterfaceOLinkClient::SetPropBool_Implementation(const FTest
 	{
 		return;
 	}
+
+	// only send change requests if the value changed -> reduce network load
+	if (GetPropBool_Implementation() == InPropBool)
+	{
+		return;
+	}
+
+	// only send change requests if the value wasn't already sent -> reduce network load
+	if (_SentData->PropBool == InPropBool)
+	{
+		return;
+	}
 	m_sink->GetNode()->setRemoteProperty(ApiGear::ObjectLink::Name::createMemberId(m_sink->olinkObjectName(), "propBool"), InPropBool);
+	_SentData->PropBool = InPropBool;
 }
 
 FTestbed1StructInt UTestbed1StructInterfaceOLinkClient::GetPropInt_Implementation() const
@@ -115,7 +140,20 @@ void UTestbed1StructInterfaceOLinkClient::SetPropInt_Implementation(const FTestb
 	{
 		return;
 	}
+
+	// only send change requests if the value changed -> reduce network load
+	if (GetPropInt_Implementation() == InPropInt)
+	{
+		return;
+	}
+
+	// only send change requests if the value wasn't already sent -> reduce network load
+	if (_SentData->PropInt == InPropInt)
+	{
+		return;
+	}
 	m_sink->GetNode()->setRemoteProperty(ApiGear::ObjectLink::Name::createMemberId(m_sink->olinkObjectName(), "propInt"), InPropInt);
+	_SentData->PropInt = InPropInt;
 }
 
 FTestbed1StructFloat UTestbed1StructInterfaceOLinkClient::GetPropFloat_Implementation() const
@@ -129,7 +167,20 @@ void UTestbed1StructInterfaceOLinkClient::SetPropFloat_Implementation(const FTes
 	{
 		return;
 	}
+
+	// only send change requests if the value changed -> reduce network load
+	if (GetPropFloat_Implementation() == InPropFloat)
+	{
+		return;
+	}
+
+	// only send change requests if the value wasn't already sent -> reduce network load
+	if (_SentData->PropFloat == InPropFloat)
+	{
+		return;
+	}
 	m_sink->GetNode()->setRemoteProperty(ApiGear::ObjectLink::Name::createMemberId(m_sink->olinkObjectName(), "propFloat"), InPropFloat);
+	_SentData->PropFloat = InPropFloat;
 }
 
 FTestbed1StructString UTestbed1StructInterfaceOLinkClient::GetPropString_Implementation() const
@@ -143,7 +194,20 @@ void UTestbed1StructInterfaceOLinkClient::SetPropString_Implementation(const FTe
 	{
 		return;
 	}
+
+	// only send change requests if the value changed -> reduce network load
+	if (GetPropString_Implementation() == InPropString)
+	{
+		return;
+	}
+
+	// only send change requests if the value wasn't already sent -> reduce network load
+	if (_SentData->PropString == InPropString)
+	{
+		return;
+	}
 	m_sink->GetNode()->setRemoteProperty(ApiGear::ObjectLink::Name::createMemberId(m_sink->olinkObjectName(), "propString"), InPropString);
+	_SentData->PropString = InPropString;
 }
 
 FTestbed1StructBool UTestbed1StructInterfaceOLinkClient::FuncBool_Implementation(const FTestbed1StructBool& ParamBool)

--- a/goldenmaster/Plugins/Testbed1/Source/Testbed1/Public/Generated/OLink/Testbed1StructArrayInterfaceOLinkClient.h
+++ b/goldenmaster/Plugins/Testbed1/Source/Testbed1/Public/Generated/OLink/Testbed1StructArrayInterfaceOLinkClient.h
@@ -22,7 +22,10 @@ THIRD_PARTY_INCLUDES_START
 THIRD_PARTY_INCLUDES_END
 #include "unrealolinksink.h"
 #include "Subsystems/GameInstanceSubsystem.h"
+#include "Templates/PimplPtr.h"
 #include "Testbed1StructArrayInterfaceOLinkClient.generated.h"
+
+struct Testbed1StructArrayInterfacePropertiesData;
 
 UCLASS(NotBlueprintable, BlueprintType)
 class TESTBED1_API UTestbed1StructArrayInterfaceOLinkClient : public UAbstractTestbed1StructArrayInterface
@@ -62,4 +65,7 @@ private:
 	void applyState(const nlohmann::json& fields);
 	void emitSignal(const std::string& signalName, const nlohmann::json& args);
 	std::shared_ptr<FUnrealOLinkSink> m_sink;
+
+	// member variable to store the last sent data
+	TPimplPtr<Testbed1StructArrayInterfacePropertiesData> _SentData;
 };

--- a/goldenmaster/Plugins/Testbed1/Source/Testbed1/Public/Generated/OLink/Testbed1StructInterfaceOLinkClient.h
+++ b/goldenmaster/Plugins/Testbed1/Source/Testbed1/Public/Generated/OLink/Testbed1StructInterfaceOLinkClient.h
@@ -22,7 +22,10 @@ THIRD_PARTY_INCLUDES_START
 THIRD_PARTY_INCLUDES_END
 #include "unrealolinksink.h"
 #include "Subsystems/GameInstanceSubsystem.h"
+#include "Templates/PimplPtr.h"
 #include "Testbed1StructInterfaceOLinkClient.generated.h"
+
+struct Testbed1StructInterfacePropertiesData;
 
 UCLASS(NotBlueprintable, BlueprintType)
 class TESTBED1_API UTestbed1StructInterfaceOLinkClient : public UAbstractTestbed1StructInterface
@@ -62,4 +65,7 @@ private:
 	void applyState(const nlohmann::json& fields);
 	void emitSignal(const std::string& signalName, const nlohmann::json& args);
 	std::shared_ptr<FUnrealOLinkSink> m_sink;
+
+	// member variable to store the last sent data
+	TPimplPtr<Testbed1StructInterfacePropertiesData> _SentData;
 };

--- a/goldenmaster/Plugins/Testbed2/Source/Testbed2/Private/Generated/OLink/Testbed2ManyParamInterfaceOLinkClient.cpp
+++ b/goldenmaster/Plugins/Testbed2/Source/Testbed2/Private/Generated/OLink/Testbed2ManyParamInterfaceOLinkClient.cpp
@@ -43,8 +43,20 @@ bool IsTestbed2ManyParamInterfaceLogEnabled()
 }
 } // namespace
 
+/**
+   \brief data structure to hold the last sent property values
+*/
+struct Testbed2ManyParamInterfacePropertiesData
+{
+	int32 Prop1{0};
+	int32 Prop2{0};
+	int32 Prop3{0};
+	int32 Prop4{0};
+};
+
 UTestbed2ManyParamInterfaceOLinkClient::UTestbed2ManyParamInterfaceOLinkClient()
 	: UAbstractTestbed2ManyParamInterface()
+	, _SentData(MakePimpl<Testbed2ManyParamInterfacePropertiesData>())
 {
 	m_sink = std::make_shared<FUnrealOLinkSink>("testbed2.ManyParamInterface");
 }
@@ -101,7 +113,20 @@ void UTestbed2ManyParamInterfaceOLinkClient::SetProp1_Implementation(int32 InPro
 	{
 		return;
 	}
+
+	// only send change requests if the value changed -> reduce network load
+	if (GetProp1_Implementation() == InProp1)
+	{
+		return;
+	}
+
+	// only send change requests if the value wasn't already sent -> reduce network load
+	if (_SentData->Prop1 == InProp1)
+	{
+		return;
+	}
 	m_sink->GetNode()->setRemoteProperty(ApiGear::ObjectLink::Name::createMemberId(m_sink->olinkObjectName(), "prop1"), InProp1);
+	_SentData->Prop1 = InProp1;
 }
 
 int32 UTestbed2ManyParamInterfaceOLinkClient::GetProp2_Implementation() const
@@ -115,7 +140,20 @@ void UTestbed2ManyParamInterfaceOLinkClient::SetProp2_Implementation(int32 InPro
 	{
 		return;
 	}
+
+	// only send change requests if the value changed -> reduce network load
+	if (GetProp2_Implementation() == InProp2)
+	{
+		return;
+	}
+
+	// only send change requests if the value wasn't already sent -> reduce network load
+	if (_SentData->Prop2 == InProp2)
+	{
+		return;
+	}
 	m_sink->GetNode()->setRemoteProperty(ApiGear::ObjectLink::Name::createMemberId(m_sink->olinkObjectName(), "prop2"), InProp2);
+	_SentData->Prop2 = InProp2;
 }
 
 int32 UTestbed2ManyParamInterfaceOLinkClient::GetProp3_Implementation() const
@@ -129,7 +167,20 @@ void UTestbed2ManyParamInterfaceOLinkClient::SetProp3_Implementation(int32 InPro
 	{
 		return;
 	}
+
+	// only send change requests if the value changed -> reduce network load
+	if (GetProp3_Implementation() == InProp3)
+	{
+		return;
+	}
+
+	// only send change requests if the value wasn't already sent -> reduce network load
+	if (_SentData->Prop3 == InProp3)
+	{
+		return;
+	}
 	m_sink->GetNode()->setRemoteProperty(ApiGear::ObjectLink::Name::createMemberId(m_sink->olinkObjectName(), "prop3"), InProp3);
+	_SentData->Prop3 = InProp3;
 }
 
 int32 UTestbed2ManyParamInterfaceOLinkClient::GetProp4_Implementation() const
@@ -143,7 +194,20 @@ void UTestbed2ManyParamInterfaceOLinkClient::SetProp4_Implementation(int32 InPro
 	{
 		return;
 	}
+
+	// only send change requests if the value changed -> reduce network load
+	if (GetProp4_Implementation() == InProp4)
+	{
+		return;
+	}
+
+	// only send change requests if the value wasn't already sent -> reduce network load
+	if (_SentData->Prop4 == InProp4)
+	{
+		return;
+	}
 	m_sink->GetNode()->setRemoteProperty(ApiGear::ObjectLink::Name::createMemberId(m_sink->olinkObjectName(), "prop4"), InProp4);
+	_SentData->Prop4 = InProp4;
 }
 
 int32 UTestbed2ManyParamInterfaceOLinkClient::Func1_Implementation(int32 Param1)

--- a/goldenmaster/Plugins/Testbed2/Source/Testbed2/Private/Generated/OLink/Testbed2NestedStruct1InterfaceOLinkClient.cpp
+++ b/goldenmaster/Plugins/Testbed2/Source/Testbed2/Private/Generated/OLink/Testbed2NestedStruct1InterfaceOLinkClient.cpp
@@ -43,8 +43,17 @@ bool IsTestbed2NestedStruct1InterfaceLogEnabled()
 }
 } // namespace
 
+/**
+   \brief data structure to hold the last sent property values
+*/
+struct Testbed2NestedStruct1InterfacePropertiesData
+{
+	FTestbed2NestedStruct1 Prop1{FTestbed2NestedStruct1()};
+};
+
 UTestbed2NestedStruct1InterfaceOLinkClient::UTestbed2NestedStruct1InterfaceOLinkClient()
 	: UAbstractTestbed2NestedStruct1Interface()
+	, _SentData(MakePimpl<Testbed2NestedStruct1InterfacePropertiesData>())
 {
 	m_sink = std::make_shared<FUnrealOLinkSink>("testbed2.NestedStruct1Interface");
 }
@@ -101,7 +110,20 @@ void UTestbed2NestedStruct1InterfaceOLinkClient::SetProp1_Implementation(const F
 	{
 		return;
 	}
+
+	// only send change requests if the value changed -> reduce network load
+	if (GetProp1_Implementation() == InProp1)
+	{
+		return;
+	}
+
+	// only send change requests if the value wasn't already sent -> reduce network load
+	if (_SentData->Prop1 == InProp1)
+	{
+		return;
+	}
 	m_sink->GetNode()->setRemoteProperty(ApiGear::ObjectLink::Name::createMemberId(m_sink->olinkObjectName(), "prop1"), InProp1);
+	_SentData->Prop1 = InProp1;
 }
 
 FTestbed2NestedStruct1 UTestbed2NestedStruct1InterfaceOLinkClient::Func1_Implementation(const FTestbed2NestedStruct1& Param1)

--- a/goldenmaster/Plugins/Testbed2/Source/Testbed2/Private/Generated/OLink/Testbed2NestedStruct2InterfaceOLinkClient.cpp
+++ b/goldenmaster/Plugins/Testbed2/Source/Testbed2/Private/Generated/OLink/Testbed2NestedStruct2InterfaceOLinkClient.cpp
@@ -43,8 +43,18 @@ bool IsTestbed2NestedStruct2InterfaceLogEnabled()
 }
 } // namespace
 
+/**
+   \brief data structure to hold the last sent property values
+*/
+struct Testbed2NestedStruct2InterfacePropertiesData
+{
+	FTestbed2NestedStruct1 Prop1{FTestbed2NestedStruct1()};
+	FTestbed2NestedStruct2 Prop2{FTestbed2NestedStruct2()};
+};
+
 UTestbed2NestedStruct2InterfaceOLinkClient::UTestbed2NestedStruct2InterfaceOLinkClient()
 	: UAbstractTestbed2NestedStruct2Interface()
+	, _SentData(MakePimpl<Testbed2NestedStruct2InterfacePropertiesData>())
 {
 	m_sink = std::make_shared<FUnrealOLinkSink>("testbed2.NestedStruct2Interface");
 }
@@ -101,7 +111,20 @@ void UTestbed2NestedStruct2InterfaceOLinkClient::SetProp1_Implementation(const F
 	{
 		return;
 	}
+
+	// only send change requests if the value changed -> reduce network load
+	if (GetProp1_Implementation() == InProp1)
+	{
+		return;
+	}
+
+	// only send change requests if the value wasn't already sent -> reduce network load
+	if (_SentData->Prop1 == InProp1)
+	{
+		return;
+	}
 	m_sink->GetNode()->setRemoteProperty(ApiGear::ObjectLink::Name::createMemberId(m_sink->olinkObjectName(), "prop1"), InProp1);
+	_SentData->Prop1 = InProp1;
 }
 
 FTestbed2NestedStruct2 UTestbed2NestedStruct2InterfaceOLinkClient::GetProp2_Implementation() const
@@ -115,7 +138,20 @@ void UTestbed2NestedStruct2InterfaceOLinkClient::SetProp2_Implementation(const F
 	{
 		return;
 	}
+
+	// only send change requests if the value changed -> reduce network load
+	if (GetProp2_Implementation() == InProp2)
+	{
+		return;
+	}
+
+	// only send change requests if the value wasn't already sent -> reduce network load
+	if (_SentData->Prop2 == InProp2)
+	{
+		return;
+	}
 	m_sink->GetNode()->setRemoteProperty(ApiGear::ObjectLink::Name::createMemberId(m_sink->olinkObjectName(), "prop2"), InProp2);
+	_SentData->Prop2 = InProp2;
 }
 
 FTestbed2NestedStruct1 UTestbed2NestedStruct2InterfaceOLinkClient::Func1_Implementation(const FTestbed2NestedStruct1& Param1)

--- a/goldenmaster/Plugins/Testbed2/Source/Testbed2/Private/Generated/OLink/Testbed2NestedStruct3InterfaceOLinkClient.cpp
+++ b/goldenmaster/Plugins/Testbed2/Source/Testbed2/Private/Generated/OLink/Testbed2NestedStruct3InterfaceOLinkClient.cpp
@@ -43,8 +43,19 @@ bool IsTestbed2NestedStruct3InterfaceLogEnabled()
 }
 } // namespace
 
+/**
+   \brief data structure to hold the last sent property values
+*/
+struct Testbed2NestedStruct3InterfacePropertiesData
+{
+	FTestbed2NestedStruct1 Prop1{FTestbed2NestedStruct1()};
+	FTestbed2NestedStruct2 Prop2{FTestbed2NestedStruct2()};
+	FTestbed2NestedStruct3 Prop3{FTestbed2NestedStruct3()};
+};
+
 UTestbed2NestedStruct3InterfaceOLinkClient::UTestbed2NestedStruct3InterfaceOLinkClient()
 	: UAbstractTestbed2NestedStruct3Interface()
+	, _SentData(MakePimpl<Testbed2NestedStruct3InterfacePropertiesData>())
 {
 	m_sink = std::make_shared<FUnrealOLinkSink>("testbed2.NestedStruct3Interface");
 }
@@ -101,7 +112,20 @@ void UTestbed2NestedStruct3InterfaceOLinkClient::SetProp1_Implementation(const F
 	{
 		return;
 	}
+
+	// only send change requests if the value changed -> reduce network load
+	if (GetProp1_Implementation() == InProp1)
+	{
+		return;
+	}
+
+	// only send change requests if the value wasn't already sent -> reduce network load
+	if (_SentData->Prop1 == InProp1)
+	{
+		return;
+	}
 	m_sink->GetNode()->setRemoteProperty(ApiGear::ObjectLink::Name::createMemberId(m_sink->olinkObjectName(), "prop1"), InProp1);
+	_SentData->Prop1 = InProp1;
 }
 
 FTestbed2NestedStruct2 UTestbed2NestedStruct3InterfaceOLinkClient::GetProp2_Implementation() const
@@ -115,7 +139,20 @@ void UTestbed2NestedStruct3InterfaceOLinkClient::SetProp2_Implementation(const F
 	{
 		return;
 	}
+
+	// only send change requests if the value changed -> reduce network load
+	if (GetProp2_Implementation() == InProp2)
+	{
+		return;
+	}
+
+	// only send change requests if the value wasn't already sent -> reduce network load
+	if (_SentData->Prop2 == InProp2)
+	{
+		return;
+	}
 	m_sink->GetNode()->setRemoteProperty(ApiGear::ObjectLink::Name::createMemberId(m_sink->olinkObjectName(), "prop2"), InProp2);
+	_SentData->Prop2 = InProp2;
 }
 
 FTestbed2NestedStruct3 UTestbed2NestedStruct3InterfaceOLinkClient::GetProp3_Implementation() const
@@ -129,7 +166,20 @@ void UTestbed2NestedStruct3InterfaceOLinkClient::SetProp3_Implementation(const F
 	{
 		return;
 	}
+
+	// only send change requests if the value changed -> reduce network load
+	if (GetProp3_Implementation() == InProp3)
+	{
+		return;
+	}
+
+	// only send change requests if the value wasn't already sent -> reduce network load
+	if (_SentData->Prop3 == InProp3)
+	{
+		return;
+	}
 	m_sink->GetNode()->setRemoteProperty(ApiGear::ObjectLink::Name::createMemberId(m_sink->olinkObjectName(), "prop3"), InProp3);
+	_SentData->Prop3 = InProp3;
 }
 
 FTestbed2NestedStruct1 UTestbed2NestedStruct3InterfaceOLinkClient::Func1_Implementation(const FTestbed2NestedStruct1& Param1)

--- a/goldenmaster/Plugins/Testbed2/Source/Testbed2/Public/Generated/OLink/Testbed2ManyParamInterfaceOLinkClient.h
+++ b/goldenmaster/Plugins/Testbed2/Source/Testbed2/Public/Generated/OLink/Testbed2ManyParamInterfaceOLinkClient.h
@@ -22,7 +22,10 @@ THIRD_PARTY_INCLUDES_START
 THIRD_PARTY_INCLUDES_END
 #include "unrealolinksink.h"
 #include "Subsystems/GameInstanceSubsystem.h"
+#include "Templates/PimplPtr.h"
 #include "Testbed2ManyParamInterfaceOLinkClient.generated.h"
+
+struct Testbed2ManyParamInterfacePropertiesData;
 
 UCLASS(NotBlueprintable, BlueprintType)
 class TESTBED2_API UTestbed2ManyParamInterfaceOLinkClient : public UAbstractTestbed2ManyParamInterface
@@ -62,4 +65,7 @@ private:
 	void applyState(const nlohmann::json& fields);
 	void emitSignal(const std::string& signalName, const nlohmann::json& args);
 	std::shared_ptr<FUnrealOLinkSink> m_sink;
+
+	// member variable to store the last sent data
+	TPimplPtr<Testbed2ManyParamInterfacePropertiesData> _SentData;
 };

--- a/goldenmaster/Plugins/Testbed2/Source/Testbed2/Public/Generated/OLink/Testbed2NestedStruct1InterfaceOLinkClient.h
+++ b/goldenmaster/Plugins/Testbed2/Source/Testbed2/Public/Generated/OLink/Testbed2NestedStruct1InterfaceOLinkClient.h
@@ -22,7 +22,10 @@ THIRD_PARTY_INCLUDES_START
 THIRD_PARTY_INCLUDES_END
 #include "unrealolinksink.h"
 #include "Subsystems/GameInstanceSubsystem.h"
+#include "Templates/PimplPtr.h"
 #include "Testbed2NestedStruct1InterfaceOLinkClient.generated.h"
+
+struct Testbed2NestedStruct1InterfacePropertiesData;
 
 UCLASS(NotBlueprintable, BlueprintType)
 class TESTBED2_API UTestbed2NestedStruct1InterfaceOLinkClient : public UAbstractTestbed2NestedStruct1Interface
@@ -47,4 +50,7 @@ private:
 	void applyState(const nlohmann::json& fields);
 	void emitSignal(const std::string& signalName, const nlohmann::json& args);
 	std::shared_ptr<FUnrealOLinkSink> m_sink;
+
+	// member variable to store the last sent data
+	TPimplPtr<Testbed2NestedStruct1InterfacePropertiesData> _SentData;
 };

--- a/goldenmaster/Plugins/Testbed2/Source/Testbed2/Public/Generated/OLink/Testbed2NestedStruct2InterfaceOLinkClient.h
+++ b/goldenmaster/Plugins/Testbed2/Source/Testbed2/Public/Generated/OLink/Testbed2NestedStruct2InterfaceOLinkClient.h
@@ -22,7 +22,10 @@ THIRD_PARTY_INCLUDES_START
 THIRD_PARTY_INCLUDES_END
 #include "unrealolinksink.h"
 #include "Subsystems/GameInstanceSubsystem.h"
+#include "Templates/PimplPtr.h"
 #include "Testbed2NestedStruct2InterfaceOLinkClient.generated.h"
+
+struct Testbed2NestedStruct2InterfacePropertiesData;
 
 UCLASS(NotBlueprintable, BlueprintType)
 class TESTBED2_API UTestbed2NestedStruct2InterfaceOLinkClient : public UAbstractTestbed2NestedStruct2Interface
@@ -52,4 +55,7 @@ private:
 	void applyState(const nlohmann::json& fields);
 	void emitSignal(const std::string& signalName, const nlohmann::json& args);
 	std::shared_ptr<FUnrealOLinkSink> m_sink;
+
+	// member variable to store the last sent data
+	TPimplPtr<Testbed2NestedStruct2InterfacePropertiesData> _SentData;
 };

--- a/goldenmaster/Plugins/Testbed2/Source/Testbed2/Public/Generated/OLink/Testbed2NestedStruct3InterfaceOLinkClient.h
+++ b/goldenmaster/Plugins/Testbed2/Source/Testbed2/Public/Generated/OLink/Testbed2NestedStruct3InterfaceOLinkClient.h
@@ -22,7 +22,10 @@ THIRD_PARTY_INCLUDES_START
 THIRD_PARTY_INCLUDES_END
 #include "unrealolinksink.h"
 #include "Subsystems/GameInstanceSubsystem.h"
+#include "Templates/PimplPtr.h"
 #include "Testbed2NestedStruct3InterfaceOLinkClient.generated.h"
+
+struct Testbed2NestedStruct3InterfacePropertiesData;
 
 UCLASS(NotBlueprintable, BlueprintType)
 class TESTBED2_API UTestbed2NestedStruct3InterfaceOLinkClient : public UAbstractTestbed2NestedStruct3Interface
@@ -57,4 +60,7 @@ private:
 	void applyState(const nlohmann::json& fields);
 	void emitSignal(const std::string& signalName, const nlohmann::json& args);
 	std::shared_ptr<FUnrealOLinkSink> m_sink;
+
+	// member variable to store the last sent data
+	TPimplPtr<Testbed2NestedStruct3InterfacePropertiesData> _SentData;
 };

--- a/templates/module/Source/module/Public/Generated/OLink/olinkclient.h.tpl
+++ b/templates/module/Source/module/Public/Generated/OLink/olinkclient.h.tpl
@@ -17,7 +17,13 @@ THIRD_PARTY_INCLUDES_START
 THIRD_PARTY_INCLUDES_END
 #include "unrealolinksink.h"
 #include "Subsystems/GameInstanceSubsystem.h"
+#include "Templates/PimplPtr.h"
 #include "{{$Iface}}OLinkClient.generated.h"
+
+{{- if len .Interface.Properties }}
+
+struct {{$Iface}}PropertiesData;
+{{- end}}
 
 UCLASS(NotBlueprintable, BlueprintType)
 class {{ $API_MACRO }} {{$Class}} : public {{$abstractclass}}
@@ -46,4 +52,10 @@ private:
 	void applyState(const nlohmann::json& fields);
 	void emitSignal(const std::string& signalName, const nlohmann::json& args);
 	std::shared_ptr<FUnrealOLinkSink> m_sink;
+
+{{- if len .Interface.Properties }}
+
+	// member variable to store the last sent data
+	TPimplPtr<{{$Iface}}PropertiesData> _SentData;
+{{- end}}
 };


### PR DESCRIPTION
<!-- 
Thanks for creating this pull request 🤗

Please make sure that the pull request is limited to one type (docs, feature, etc.) and keep it as small as possible. You can open multiple prs instead of opening a huge one.
-->
## 📑 Description
<!-- Add a brief description of the pr -->Previously, every call to SetProperty immediately triggered a call to the olink protocol and sent the change request to the service. This way it was easily possible to flood the service with out providing any new information by just keep sending already set values. This change checks whether the value is already set on the service side or whether it was already requested - and only if it is really a new value we send the request to the service.
This adds a bit more performance load on the client side but keeps the service responsive.

<!-- You can also choose to add a list of changes and if they have been completed or not by using the markdown to-do list syntax
- [ ] Not Completed
- [x] Completed
-->

## ✅ Checks
<!-- Make sure your pr passes the CI checks and do check the following fields as needed - -->
- [x] My pull request adheres to the code style of this project
- [ ] My code requires changes to the documentation
- [x] I have updated the documentation as required
- [x] All the tests have passed
