### PR TITLE
fix(olink): listen to OnBinaryMessage

### DIFF
--- a/goldenmaster/Plugins/ApiGear/Source/ApiGear/Private/unrealolink.cpp
+++ b/goldenmaster/Plugins/ApiGear/Source/ApiGear/Private/unrealolink.cpp
@@ -176,9 +176,10 @@ void UUnrealOLink::open(const FString& url)
 				handleTextMessage(Message);
 			});
 
-		m_socket->OnRawMessage().AddLambda(
-			[this](const void* Data, SIZE_T Size, SIZE_T /*BytesRemaining*/) -> void
+		m_socket->OnBinaryMessage().AddLambda(
+			[this](const void* Data, SIZE_T Size, bool /* bIsLastFragment */) -> void
 			{
+				// we assume the incoming binary message is actually text
 				handleTextMessage(FString(std::string((uint8*)Data, (uint8*)Data + Size).c_str()));
 			});
 	}

--- a/templates/ApiGear/Source/ApiGear/Private/unrealolink.cpp
+++ b/templates/ApiGear/Source/ApiGear/Private/unrealolink.cpp
@@ -176,9 +176,10 @@ void UUnrealOLink::open(const FString& url)
 				handleTextMessage(Message);
 			});
 
-		m_socket->OnRawMessage().AddLambda(
-			[this](const void* Data, SIZE_T Size, SIZE_T /*BytesRemaining*/) -> void
+		m_socket->OnBinaryMessage().AddLambda(
+			[this](const void* Data, SIZE_T Size, bool /* bIsLastFragment */) -> void
 			{
+				// we assume the incoming binary message is actually text
 				handleTextMessage(FString(std::string((uint8*)Data, (uint8*)Data + Size).c_str()));
 			});
 	}


### PR DESCRIPTION

<!-- 
Thanks for creating this pull request 🤗

Please make sure that the pull request is limited to one type (docs, feature, etc.) and keep it as small as possible. You can open multiple prs instead of opening a huge one.
-->
## 📑 Description
The UE websocket documentation states that one should listen to OnRawMessage for binary messages. This is not correct. We need to listen to OnBinaryMessage since OnRawMessage is always triggered regardless of the format. This caused text messages to be triggered twice.

<!-- Add a brief description of the pr -->

<!-- You can also choose to add a list of changes and if they have been completed or not by using the markdown to-do list syntax
- [ ] Not Completed
- [x] Completed
-->

## ✅ Checks
<!-- Make sure your pr passes the CI checks and do check the following fields as needed - -->
- [ ] My pull request adheres to the code style of this project
- [ ] My code requires changes to the documentation
- [ ] I have updated the documentation as required
- [x] All the tests have passed
