### PR TITLE
fix(olink): use OnRawMessage for UE < 5.2

### DIFF
--- a/goldenmaster/Plugins/ApiGear/Source/ApiGear/Private/unrealolink.cpp
+++ b/goldenmaster/Plugins/ApiGear/Source/ApiGear/Private/unrealolink.cpp
@@ -5,6 +5,7 @@ THIRD_PARTY_INCLUDES_START
 #include "olink/iobjectsink.h"
 THIRD_PARTY_INCLUDES_END
 #include <UObject/Object.h>
+#include "Runtime/Launch/Resources/Version.h"
 #include <functional>
 #include <chrono>
 #include <future>
@@ -169,6 +170,7 @@ void UUnrealOLink::open(const FString& url)
 				OnDisconnected(bReconnect);
 			});
 
+#if (ENGINE_MAJOR_VERSION >= 5 && ENGINE_MINOR_VERSION > 1)
 		m_socket->OnMessage().AddLambda(
 			[this](const FString& Message) -> void
 			{
@@ -182,6 +184,14 @@ void UUnrealOLink::open(const FString& url)
 				// we assume the incoming binary message is actually text
 				handleTextMessage(FString(std::string((uint8*)Data, (uint8*)Data + Size).c_str()));
 			});
+#else
+		m_socket->OnRawMessage().AddLambda(
+			[this](const void* Data, SIZE_T Size, SIZE_T /* BytesRemaining */) -> void
+			{
+				// we assume the incoming raw message is actually text
+				handleTextMessage(FString(std::string((uint8*)Data, (uint8*)Data + Size).c_str()));
+			});
+#endif
 	}
 
 	if (!m_socket->IsConnected())

--- a/templates/ApiGear/Source/ApiGear/Private/unrealolink.cpp
+++ b/templates/ApiGear/Source/ApiGear/Private/unrealolink.cpp
@@ -5,6 +5,7 @@ THIRD_PARTY_INCLUDES_START
 #include "olink/iobjectsink.h"
 THIRD_PARTY_INCLUDES_END
 #include <UObject/Object.h>
+#include "Runtime/Launch/Resources/Version.h"
 #include <functional>
 #include <chrono>
 #include <future>
@@ -169,6 +170,7 @@ void UUnrealOLink::open(const FString& url)
 				OnDisconnected(bReconnect);
 			});
 
+#if (ENGINE_MAJOR_VERSION >= 5 && ENGINE_MINOR_VERSION > 1)
 		m_socket->OnMessage().AddLambda(
 			[this](const FString& Message) -> void
 			{
@@ -182,6 +184,14 @@ void UUnrealOLink::open(const FString& url)
 				// we assume the incoming binary message is actually text
 				handleTextMessage(FString(std::string((uint8*)Data, (uint8*)Data + Size).c_str()));
 			});
+#else
+		m_socket->OnRawMessage().AddLambda(
+			[this](const void* Data, SIZE_T Size, SIZE_T /* BytesRemaining */) -> void
+			{
+				// we assume the incoming raw message is actually text
+				handleTextMessage(FString(std::string((uint8*)Data, (uint8*)Data + Size).c_str()));
+			});
+#endif
 	}
 
 	if (!m_socket->IsConnected())


### PR DESCRIPTION
<!-- 
Thanks for creating this pull request 🤗

Please make sure that the pull request is limited to one type (docs, feature, etc.) and keep it as small as possible. You can open multiple prs instead of opening a huge one.
-->


## 📑 Description
The new OnBinaryMessage delegate has only been added with UE 5.2. Therefore, we use OnRawMessage in older versions.


<!-- You can also choose to add a list of changes and if they have been completed or not by using the markdown to-do list syntax
- [ ] Not Completed
- [x] Completed
-->

## ✅ Checks
<!-- Make sure your pr passes the CI checks and do check the following fields as needed - -->
- [ ] My pull request adheres to the code style of this project
- [ ] My code requires changes to the documentation
- [ ] I have updated the documentation as required
- [x] All the tests have passed