### PR TITLE
Fix/split module settings

### DIFF
--- a/goldenmaster/Plugins/ApiGear/Source/ApiGear/Public/ApiGearSettings.h
+++ b/goldenmaster/Plugins/ApiGear/Source/ApiGear/Public/ApiGearSettings.h
@@ -17,7 +17,7 @@ struct FApiGearConnectionSetting
 	 * Unique protocol identifier, based on which connection type can be recognized and created.
 	 * You can have more than one connection of the same protocol type with different urls
 	 */
-	FString ProtocolIdentifier{TEXT("olink")};
+	FString ProtocolIdentifier{"olink"};
 
 	/** Choose the server to connect to */
 	UPROPERTY(EditAnywhere, config, Category = ApiGearConnectionSetting)

--- a/goldenmaster/Plugins/ApiGear/Source/ApiGearOLink/Private/apigearolink.cpp
+++ b/goldenmaster/Plugins/ApiGear/Source/ApiGearOLink/Private/apigearolink.cpp
@@ -13,7 +13,7 @@ void FApiGearModuleOLink::StartupModule()
 	FWebSocketsModule& WebSocketsModule = FModuleManager::LoadModuleChecked<FWebSocketsModule>(TEXT("WebSockets"));
 
 	// register olink factory function
-	UApiGearConnectionsStore::RegisterConnectionFactory("olink", &OLinkFactory::Create);
+	UApiGearConnectionsStore::RegisterConnectionFactory(ApiGearOLinkProtocolIdentifier, &OLinkFactory::Create);
 }
 
 void FApiGearModuleOLink::ShutdownModule()

--- a/goldenmaster/Plugins/ApiGear/Source/ApiGearOLink/Public/apigearolink.h
+++ b/goldenmaster/Plugins/ApiGear/Source/ApiGearOLink/Public/apigearolink.h
@@ -2,6 +2,9 @@
 #pragma once
 
 #include "Modules/ModuleManager.h"
+#include "Containers/UnrealString.h"
+
+const FString ApiGearOLinkProtocolIdentifier = "olink";
 
 class FApiGearModuleOLink : public IModuleInterface
 {

--- a/goldenmaster/Plugins/ApiGear/Source/ApiGearOLink/Public/unrealolink.h
+++ b/goldenmaster/Plugins/ApiGear/Source/ApiGearOLink/Public/unrealolink.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include "AbstractApiGearConnection.h"
+#include "apigearolink.h"
 THIRD_PARTY_INCLUDES_START
 #include "olink/clientnode.h"
 #include "olink/clientregistry.h"
@@ -45,7 +46,7 @@ public:
 	FString GetUniqueEndpointIdentifier() const override;
 	FString GetConnectionProtocolIdentifier() const override
 	{
-		return "olink";
+		return ApiGearOLinkProtocolIdentifier;
 	};
 
 	std::shared_ptr<ApiGear::ObjectLink::ClientNode> node()

--- a/goldenmaster/Plugins/ApiGear/Source/ApiGearOLink/Public/unrealolink.h
+++ b/goldenmaster/Plugins/ApiGear/Source/ApiGearOLink/Public/unrealolink.h
@@ -67,7 +67,6 @@ private:
 
 	TSharedPtr<IWebSocket> m_socket;
 	FString m_serverURL;
-	FString ConnectionIdentifier;
 	ApiGear::ObjectLink::ClientRegistry m_registry;
 	std::shared_ptr<ApiGear::ObjectLink::ClientNode> m_node;
 	TQueue<std::string, EQueueMode::Mpsc> m_queue;

--- a/goldenmaster/Plugins/TbEnum/Source/TbEnum/Private/Generated/Monitor/TbEnumFactory.cpp
+++ b/goldenmaster/Plugins/TbEnum/Source/TbEnum/Private/Generated/Monitor/TbEnumFactory.cpp
@@ -74,13 +74,13 @@ TScriptInterface<ITbEnumEnumInterfaceInterface> FTbEnumModuleFactory::createITbE
 {
 	UTbEnumSettings* TbEnumSettings = GetMutableDefault<UTbEnumSettings>();
 
-	if (TbEnumSettings->ConnectionIdentifier == "Local")
+	if (TbEnumSettings->TracerServiceIdentifier == "Local")
 	{
 		return createTbEnumEnumInterface(GameInstance, Collection);
 	}
 
 	UApiGearSettings* ApiGearSettings = GetMutableDefault<UApiGearSettings>();
-	FApiGearConnectionSetting* ConnectionSetting = ApiGearSettings->Connections.Find(TbEnumSettings->ConnectionIdentifier);
+	FApiGearConnectionSetting* ConnectionSetting = ApiGearSettings->Connections.Find(TbEnumSettings->TracerServiceIdentifier);
 
 	// Other protocols not supported. To support it edit templates:
 	// add protocol handler class for this interface like createTbEnumEnumInterfaceOLink and other necessary infrastructure
@@ -122,13 +122,13 @@ TScriptInterface<ITbEnumEnumInterfaceInterface> FTbEnumModuleFactory::createITbE
 {
 	UTbEnumSettings* TbEnumSettings = GetMutableDefault<UTbEnumSettings>();
 
-	if (TbEnumSettings->ConnectionIdentifier == "Local")
+	if (TbEnumSettings->TracerServiceIdentifier == "Local")
 	{
 		return createTbEnumEnumInterface(Collection);
 	}
 
 	UApiGearSettings* ApiGearSettings = GetMutableDefault<UApiGearSettings>();
-	FApiGearConnectionSetting* ConnectionSetting = ApiGearSettings->Connections.Find(TbEnumSettings->ConnectionIdentifier);
+	FApiGearConnectionSetting* ConnectionSetting = ApiGearSettings->Connections.Find(TbEnumSettings->TracerServiceIdentifier);
 
 	// Other protocols not supported. To support it edit templates:
 	// add protocol handler class for this interface like createTbEnumEnumInterfaceOLink and other necessary infrastructure

--- a/goldenmaster/Plugins/TbEnum/Source/TbEnum/Private/Generated/Monitor/TbEnumFactory.cpp
+++ b/goldenmaster/Plugins/TbEnum/Source/TbEnum/Private/Generated/Monitor/TbEnumFactory.cpp
@@ -17,6 +17,7 @@ limitations under the License.
 
 #include "TbEnumFactory.h"
 #include "ApiGearSettings.h"
+#include "TbEnumSettings.h"
 #include "Implementation/TbEnumEnumInterface.h"
 #include "Generated/OLink/TbEnumEnumInterfaceOLinkClient.h"
 #include "TbEnumSettings.h"
@@ -74,7 +75,7 @@ TScriptInterface<ITbEnumEnumInterfaceInterface> FTbEnumModuleFactory::createITbE
 {
 	UTbEnumSettings* TbEnumSettings = GetMutableDefault<UTbEnumSettings>();
 
-	if (TbEnumSettings->TracerServiceIdentifier == "Local")
+	if (TbEnumSettings->TracerServiceIdentifier == TbEnumLocalBackendIdentifier)
 	{
 		return createTbEnumEnumInterface(GameInstance, Collection);
 	}
@@ -122,7 +123,7 @@ TScriptInterface<ITbEnumEnumInterfaceInterface> FTbEnumModuleFactory::createITbE
 {
 	UTbEnumSettings* TbEnumSettings = GetMutableDefault<UTbEnumSettings>();
 
-	if (TbEnumSettings->TracerServiceIdentifier == "Local")
+	if (TbEnumSettings->TracerServiceIdentifier == TbEnumLocalBackendIdentifier)
 	{
 		return createTbEnumEnumInterface(Collection);
 	}

--- a/goldenmaster/Plugins/TbEnum/Source/TbEnum/Private/Generated/Monitor/TbEnumFactory.cpp
+++ b/goldenmaster/Plugins/TbEnum/Source/TbEnum/Private/Generated/Monitor/TbEnumFactory.cpp
@@ -17,6 +17,7 @@ limitations under the License.
 
 #include "TbEnumFactory.h"
 #include "ApiGearSettings.h"
+#include "apigearolink.h"
 #include "TbEnumSettings.h"
 #include "Implementation/TbEnumEnumInterface.h"
 #include "Generated/OLink/TbEnumEnumInterfaceOLinkClient.h"
@@ -86,7 +87,7 @@ TScriptInterface<ITbEnumEnumInterfaceInterface> FTbEnumModuleFactory::createITbE
 	// Other protocols not supported. To support it edit templates:
 	// add protocol handler class for this interface like createTbEnumEnumInterfaceOLink and other necessary infrastructure
 	// extend this function in templates to handle protocol of your choice
-	if (ConnectionSetting && ConnectionSetting->ProtocolIdentifier == "olink")
+	if (ConnectionSetting && ConnectionSetting->ProtocolIdentifier == ApiGearOLinkProtocolIdentifier)
 	{
 		return createTbEnumEnumInterfaceOLink(GameInstance, Collection);
 	}
@@ -134,7 +135,7 @@ TScriptInterface<ITbEnumEnumInterfaceInterface> FTbEnumModuleFactory::createITbE
 	// Other protocols not supported. To support it edit templates:
 	// add protocol handler class for this interface like createTbEnumEnumInterfaceOLink and other necessary infrastructure
 	// extend this function in templates to handle protocol of your choice
-	if (ConnectionSetting && ConnectionSetting->ProtocolIdentifier == "olink")
+	if (ConnectionSetting && ConnectionSetting->ProtocolIdentifier == ApiGearOLinkProtocolIdentifier)
 	{
 		return createTbEnumEnumInterfaceOLink(Collection);
 	}

--- a/goldenmaster/Plugins/TbEnum/Source/TbEnum/Private/Generated/OLink/TbEnumEnumInterfaceOLinkClient.cpp
+++ b/goldenmaster/Plugins/TbEnum/Source/TbEnum/Private/Generated/OLink/TbEnumEnumInterfaceOLinkClient.cpp
@@ -85,8 +85,13 @@ void UTbEnumEnumInterfaceOLinkClient::Initialize(FSubsystemCollectionBase& Colle
 
 	UApiGearConnectionsStore* AGCM = GEngine->GetEngineSubsystem<UApiGearConnectionsStore>();
 
-	TScriptInterface<IApiGearConnection> OLinkConnection = AGCM->GetConnection(settings->ConnectionIdentifier);
+	TScriptInterface<IApiGearConnection> OLinkConnection = AGCM->GetConnection(settings->OLinkConnectionIdentifier);
 
+	if (!OLinkConnection.GetInterface())
+	{
+		UE_LOG(LogTbEnumEnumInterfaceOLinkClient, Log, TEXT("No valid olink connection for %s, please set during run time"), UTF8_TO_TCHAR(m_sink->olinkObjectName().c_str()));
+		return;
+	}
 	UseConnection(OLinkConnection);
 	OLinkConnection->Connect();
 }

--- a/goldenmaster/Plugins/TbEnum/Source/TbEnum/Private/Generated/OLink/TbEnumEnumInterfaceOLinkClient.cpp
+++ b/goldenmaster/Plugins/TbEnum/Source/TbEnum/Private/Generated/OLink/TbEnumEnumInterfaceOLinkClient.cpp
@@ -261,7 +261,17 @@ ETbEnumEnum0 UTbEnumEnumInterfaceOLinkClient::Func0_Implementation(ETbEnumEnum0 
 		[Param0, &Promise, this]()
 		{
 			ApiGear::ObjectLink::InvokeReplyFunc GetEnumInterfaceStateFunc = [&Promise](ApiGear::ObjectLink::InvokeReplyArg arg)
-			{ Promise.SetValue(arg.value.get<ETbEnumEnum0>()); };
+			{
+				if (!arg.value.empty())
+				{
+					Promise.SetValue(arg.value.get<ETbEnumEnum0>());
+				}
+				else
+				{
+					UE_LOG(LogTbEnumEnumInterfaceOLinkClient, Error, TEXT("Func0: OLink service returned empty value - should have returned type of ETbEnumEnum0"));
+					Promise.SetValue(ETbEnumEnum0());
+				}
+			};
 			static const auto memberId = ApiGear::ObjectLink::Name::createMemberId(m_sink->olinkObjectName(), "func0");
 			m_sink->GetNode()->invokeRemote(memberId, {Param0}, GetEnumInterfaceStateFunc);
 		});
@@ -282,7 +292,17 @@ ETbEnumEnum1 UTbEnumEnumInterfaceOLinkClient::Func1_Implementation(ETbEnumEnum1 
 		[Param1, &Promise, this]()
 		{
 			ApiGear::ObjectLink::InvokeReplyFunc GetEnumInterfaceStateFunc = [&Promise](ApiGear::ObjectLink::InvokeReplyArg arg)
-			{ Promise.SetValue(arg.value.get<ETbEnumEnum1>()); };
+			{
+				if (!arg.value.empty())
+				{
+					Promise.SetValue(arg.value.get<ETbEnumEnum1>());
+				}
+				else
+				{
+					UE_LOG(LogTbEnumEnumInterfaceOLinkClient, Error, TEXT("Func1: OLink service returned empty value - should have returned type of ETbEnumEnum1"));
+					Promise.SetValue(ETbEnumEnum1());
+				}
+			};
 			static const auto memberId = ApiGear::ObjectLink::Name::createMemberId(m_sink->olinkObjectName(), "func1");
 			m_sink->GetNode()->invokeRemote(memberId, {Param1}, GetEnumInterfaceStateFunc);
 		});
@@ -303,7 +323,17 @@ ETbEnumEnum2 UTbEnumEnumInterfaceOLinkClient::Func2_Implementation(ETbEnumEnum2 
 		[Param2, &Promise, this]()
 		{
 			ApiGear::ObjectLink::InvokeReplyFunc GetEnumInterfaceStateFunc = [&Promise](ApiGear::ObjectLink::InvokeReplyArg arg)
-			{ Promise.SetValue(arg.value.get<ETbEnumEnum2>()); };
+			{
+				if (!arg.value.empty())
+				{
+					Promise.SetValue(arg.value.get<ETbEnumEnum2>());
+				}
+				else
+				{
+					UE_LOG(LogTbEnumEnumInterfaceOLinkClient, Error, TEXT("Func2: OLink service returned empty value - should have returned type of ETbEnumEnum2"));
+					Promise.SetValue(ETbEnumEnum2());
+				}
+			};
 			static const auto memberId = ApiGear::ObjectLink::Name::createMemberId(m_sink->olinkObjectName(), "func2");
 			m_sink->GetNode()->invokeRemote(memberId, {Param2}, GetEnumInterfaceStateFunc);
 		});
@@ -324,7 +354,17 @@ ETbEnumEnum3 UTbEnumEnumInterfaceOLinkClient::Func3_Implementation(ETbEnumEnum3 
 		[Param3, &Promise, this]()
 		{
 			ApiGear::ObjectLink::InvokeReplyFunc GetEnumInterfaceStateFunc = [&Promise](ApiGear::ObjectLink::InvokeReplyArg arg)
-			{ Promise.SetValue(arg.value.get<ETbEnumEnum3>()); };
+			{
+				if (!arg.value.empty())
+				{
+					Promise.SetValue(arg.value.get<ETbEnumEnum3>());
+				}
+				else
+				{
+					UE_LOG(LogTbEnumEnumInterfaceOLinkClient, Error, TEXT("Func3: OLink service returned empty value - should have returned type of ETbEnumEnum3"));
+					Promise.SetValue(ETbEnumEnum3());
+				}
+			};
 			static const auto memberId = ApiGear::ObjectLink::Name::createMemberId(m_sink->olinkObjectName(), "func3");
 			m_sink->GetNode()->invokeRemote(memberId, {Param3}, GetEnumInterfaceStateFunc);
 		});

--- a/goldenmaster/Plugins/TbEnum/Source/TbEnum/Private/Generated/OLink/TbEnumEnumInterfaceOLinkClient.cpp
+++ b/goldenmaster/Plugins/TbEnum/Source/TbEnum/Private/Generated/OLink/TbEnumEnumInterfaceOLinkClient.cpp
@@ -22,6 +22,7 @@ limitations under the License.
 
 #include "Generated/OLink/TbEnumEnumInterfaceOLinkClient.h"
 #include "ApiGearSettings.h"
+#include "apigearolink.h"
 #include "Async/Async.h"
 #include "Generated/api/TbEnum.json.adapter.h"
 #include "unrealolink.h"
@@ -117,7 +118,7 @@ void UTbEnumEnumInterfaceOLinkClient::UseConnection(TScriptInterface<IApiGearCon
 	checkf(InConnection.GetInterface() != nullptr, TEXT("Cannot use connection - interface IApiGearConnection is not fully implemented"));
 
 	// only accept connections of type olink
-	checkf(InConnection->GetConnectionProtocolIdentifier() == "olink", TEXT("Cannot use connection - must be of type olink"));
+	checkf(InConnection->GetConnectionProtocolIdentifier() == ApiGearOLinkProtocolIdentifier, TEXT("Cannot use connection - must be of type olink"));
 
 	UUnrealOLink* UnrealOLinkConnection = nullptr;
 	// remove old connection

--- a/goldenmaster/Plugins/TbEnum/Source/TbEnum/Private/TbEnumSettings.cpp
+++ b/goldenmaster/Plugins/TbEnum/Source/TbEnum/Private/TbEnumSettings.cpp
@@ -37,7 +37,7 @@ void UTbEnumSettings::PostInitProperties()
 	}
 
 	// the local backend does not require configuration
-	if (TracerServiceIdentifier == "Local")
+	if (TracerServiceIdentifier == TbEnumLocalBackendIdentifier)
 	{
 		return;
 	}
@@ -45,6 +45,6 @@ void UTbEnumSettings::PostInitProperties()
 	if (!AGCM->DoesConnectionExist(TracerServiceIdentifier))
 	{
 		UE_LOG(LogTemp, Warning, TEXT("UTbEnumSettings could not find connection %s, falling back to local backend."), *TracerServiceIdentifier);
-		TracerServiceIdentifier = "Local";
+		TracerServiceIdentifier = TbEnumLocalBackendIdentifier;
 	}
 }

--- a/goldenmaster/Plugins/TbEnum/Source/TbEnum/Private/TbEnumSettings.cpp
+++ b/goldenmaster/Plugins/TbEnum/Source/TbEnum/Private/TbEnumSettings.cpp
@@ -27,18 +27,24 @@ void UTbEnumSettings::PostInitProperties()
 {
 	Super::PostInitProperties();
 
+	check(GEngine);
+	UApiGearConnectionsStore* AGCM = GEngine->GetEngineSubsystem<UApiGearConnectionsStore>();
+
+	if (!AGCM->DoesConnectionExist(OLinkConnectionIdentifier))
+	{
+		UE_LOG(LogTemp, Warning, TEXT("UTbEnumSettings could not find connection %s."), *OLinkConnectionIdentifier);
+		OLinkConnectionIdentifier = "";
+	}
+
 	// the local backend does not require configuration
-	if (ConnectionIdentifier == "Local")
+	if (TracerServiceIdentifier == "Local")
 	{
 		return;
 	}
 
-	check(GEngine);
-	UApiGearConnectionsStore* AGCM = GEngine->GetEngineSubsystem<UApiGearConnectionsStore>();
-
-	if (!AGCM->DoesConnectionExist(ConnectionIdentifier))
+	if (!AGCM->DoesConnectionExist(TracerServiceIdentifier))
 	{
-		UE_LOG(LogTemp, Warning, TEXT("UTbEnumSettings could not find connection %s, falling back to local backend."), *ConnectionIdentifier);
-		ConnectionIdentifier = "Local";
+		UE_LOG(LogTemp, Warning, TEXT("UTbEnumSettings could not find connection %s, falling back to local backend."), *TracerServiceIdentifier);
+		TracerServiceIdentifier = "Local";
 	}
 }

--- a/goldenmaster/Plugins/TbEnum/Source/TbEnum/Public/TbEnumSettings.h
+++ b/goldenmaster/Plugins/TbEnum/Source/TbEnum/Public/TbEnumSettings.h
@@ -33,6 +33,10 @@ class TBENUM_API UTbEnumSettings : public UObject
 	virtual void PostInitProperties() override;
 
 	// Choose the backend service for the logging decorator to use
-	UPROPERTY(EditAnywhere, config, Category = ServiceSetup)
-	FString ConnectionIdentifier;
+	UPROPERTY(EditAnywhere, config, Category = TracerServiceSetup)
+	FString TracerServiceIdentifier;
+
+	// Choose the olink connection to use
+	UPROPERTY(EditAnywhere, config, Category = OLinkConnectionSetup)
+	FString OLinkConnectionIdentifier;
 };

--- a/goldenmaster/Plugins/TbEnum/Source/TbEnum/Public/TbEnumSettings.h
+++ b/goldenmaster/Plugins/TbEnum/Source/TbEnum/Public/TbEnumSettings.h
@@ -22,6 +22,8 @@ limitations under the License.
 #include "Engine/EngineTypes.h"
 #include "TbEnumSettings.generated.h"
 
+const FString TbEnumLocalBackendIdentifier = "Local";
+
 /**
  * Implements the settings for the TbEnum plugin.
  */

--- a/goldenmaster/Plugins/TbEnum/Source/TbEnumEditor/Private/TbEnumConnectionSettings.cpp
+++ b/goldenmaster/Plugins/TbEnum/Source/TbEnumEditor/Private/TbEnumConnectionSettings.cpp
@@ -2,6 +2,7 @@
 #include "TbEnumConnectionSettings.h"
 
 #include "ApiGearSettings.h"
+#include "apigearolink.h"
 #include "TbEnumSettings.h"
 #include "Templates/SharedPointer.h"
 #include "IDetailCustomization.h"
@@ -106,7 +107,7 @@ TSharedRef<SWidget> FTbEnumConnectionSettingsDetails::MakeDefaultOLinkConnection
 
 	for (auto ConnectionSetting : settings->Connections)
 	{
-		if (ConnectionSetting.Value.ProtocolIdentifier == "olink")
+		if (ConnectionSetting.Value.ProtocolIdentifier == ApiGearOLinkProtocolIdentifier)
 		{
 			TSharedPtr<FText> ConnectionName = MakeShared<FText>(FText::FromString(*ConnectionSetting.Key));
 			AvailableOLinkConnectionNames->Add(ConnectionName);

--- a/goldenmaster/Plugins/TbEnum/Source/TbEnumEditor/Private/TbEnumConnectionSettings.cpp
+++ b/goldenmaster/Plugins/TbEnum/Source/TbEnumEditor/Private/TbEnumConnectionSettings.cpp
@@ -2,6 +2,7 @@
 #include "TbEnumConnectionSettings.h"
 
 #include "ApiGearSettings.h"
+#include "TbEnumSettings.h"
 #include "Templates/SharedPointer.h"
 #include "IDetailCustomization.h"
 #include "PropertyHandle.h"
@@ -32,7 +33,7 @@ TSharedRef<SWidget> FTbEnumConnectionSettingsDetails::MakeDefaultBackendServiceS
 	TArray<TSharedPtr<FText>>* AvailableServicesNames = &AvailableServices;
 	FText TooltipText = FText::FromString(TEXT("Choose which service should be used as default."));
 
-	TSharedPtr<FText> LocalServiceName = TSharedPtr<FText>(new FText(FText::FromString(TEXT("Local"))));
+	TSharedPtr<FText> LocalServiceName = TSharedPtr<FText>(new FText(FText::FromString(TbEnumLocalBackendIdentifier)));
 	AvailableServicesNames->Add(LocalServiceName);
 	SelectedDefaultBackendService = LocalServiceName;
 

--- a/goldenmaster/Plugins/TbEnum/Source/TbEnumEditor/Private/TbEnumConnectionSettings.cpp
+++ b/goldenmaster/Plugins/TbEnum/Source/TbEnumEditor/Private/TbEnumConnectionSettings.cpp
@@ -24,33 +24,38 @@ TSharedRef<IDetailCustomization> FTbEnumConnectionSettingsDetails::MakeInstance(
 	return MakeShareable(new FTbEnumConnectionSettingsDetails);
 }
 
-TSharedRef<SWidget> FTbEnumConnectionSettingsDetails::MakeDefaultConnectionSelectorWidget(const TSharedPtr<IPropertyHandle>& PropertyHandle)
+TSharedRef<SWidget> FTbEnumConnectionSettingsDetails::MakeDefaultBackendServiceSelectorWidget(const TSharedPtr<IPropertyHandle>& PropertyHandle)
 {
 	UApiGearSettings* settings = GetMutableDefault<UApiGearSettings>();
 	check(settings);
 
-	TArray<TSharedPtr<FText>>* AvailableConnectionNames = &AvailableConnections;
-	FText TooltipText = FText::FromString(TEXT("Choose which connection should be used as default. Please make sure to have at least one connection defined."));
+	TArray<TSharedPtr<FText>>* AvailableServicesNames = &AvailableServices;
+	FText TooltipText = FText::FromString(TEXT("Choose which service should be used as default."));
 
-	TSharedPtr<FText> DefaultEffectName = TSharedPtr<FText>(new FText(FText::FromString(TEXT("Local"))));
-	SelectedDefaultConnection = TSharedPtr<FText>(new FText(*DefaultEffectName));
-	PropertyHandle->GetValueAsDisplayText(*SelectedDefaultConnection);
+	TSharedPtr<FText> LocalServiceName = TSharedPtr<FText>(new FText(FText::FromString(TEXT("Local"))));
+	AvailableServicesNames->Add(LocalServiceName);
+	SelectedDefaultBackendService = LocalServiceName;
 
-	AvailableConnectionNames->Add(DefaultEffectName);
+	TSharedPtr<FText> CurrentServiceName = TSharedPtr<FText>(new FText(FText::GetEmpty()));
+	PropertyHandle->GetValueAsDisplayText(*CurrentServiceName);
+	if (!CurrentServiceName->EqualTo(FText::GetEmpty()))
+	{
+		SelectedDefaultBackendService = CurrentServiceName;
+	}
 
 	for (auto ConnectionSetting : settings->Connections)
 	{
-		AvailableConnectionNames->Add(MakeShared<FText>(FText::FromString(*ConnectionSetting.Key)));
+		AvailableServicesNames->Add(MakeShared<FText>(FText::FromString(*ConnectionSetting.Key)));
 	}
 
 	// clang-format off
 	// Text box component:
 	TSharedRef<STextBlock > EditableTextBox = SNew(STextBlock )
-		.Text_Lambda([this]() { return *SelectedDefaultConnection; });
+		.Text_Lambda([this]() { return *SelectedDefaultBackendService; });
 
 	// Combo box component:
 	TSharedRef<SWidget> ComboBox = SNew(SListView<TSharedPtr<FText>>)
-		.ListItemsSource(AvailableConnectionNames)
+		.ListItemsSource(AvailableServicesNames)
 		.OnGenerateRow_Lambda([](TSharedPtr<FText> InItem, const TSharedRef< class STableViewBase >& Owner)
 		{
 			return SNew(STableRow<TSharedPtr<FText>>, Owner)
@@ -61,7 +66,7 @@ TSharedRef<SWidget> FTbEnumConnectionSettingsDetails::MakeDefaultConnectionSelec
 		})
 		.OnSelectionChanged_Lambda([this, PropertyHandle](TSharedPtr<FText> InText, ESelectInfo::Type)
 		{
-			SelectedDefaultConnection = InText;
+			SelectedDefaultBackendService = InText;
 			PropertyHandle->SetValue(InText->ToString());
 		});
 
@@ -90,24 +95,133 @@ TSharedRef<SWidget> FTbEnumConnectionSettingsDetails::MakeDefaultConnectionSelec
 	return NewWidget;
 }
 
-void FTbEnumConnectionSettingsDetails::CustomizeDetails(IDetailLayoutBuilder& DetailBuilder)
+TSharedRef<SWidget> FTbEnumConnectionSettingsDetails::MakeDefaultOLinkConnectionSelectorWidget(const TSharedPtr<IPropertyHandle>& PropertyHandle)
 {
-	IDetailCategoryBuilder& ConnectionsCategory = DetailBuilder.EditCategory(TEXT("ServiceSetup"));
+	UApiGearSettings* settings = GetMutableDefault<UApiGearSettings>();
+	check(settings);
 
-	TSharedPtr<IPropertyHandle> ConnectionIdentifierPropertyHandle = DetailBuilder.GetProperty("ConnectionIdentifier", nullptr);
-	IDetailPropertyRow& DefaultConnectionIdentifierPropertyRow = ConnectionsCategory.AddProperty(ConnectionIdentifierPropertyHandle);
+	TArray<TSharedPtr<FText>>* AvailableOLinkConnectionNames = &AvailableOLinkConnections;
+	FText TooltipText = FText::FromString(TEXT("Choose which connection should be used as default. Please make sure to have at least one connection defined."));
+
+	for (auto ConnectionSetting : settings->Connections)
+	{
+		if (ConnectionSetting.Value.ProtocolIdentifier == "olink")
+		{
+			TSharedPtr<FText> ConnectionName = MakeShared<FText>(FText::FromString(*ConnectionSetting.Key));
+			AvailableOLinkConnectionNames->Add(ConnectionName);
+
+			if (!SelectedDefaultOLinkConnection)
+			{
+				SelectedDefaultOLinkConnection = ConnectionName;
+			}
+		}
+	}
+
+	TSharedPtr<FText> CurrentConnectionName = TSharedPtr<FText>(new FText(FText::GetEmpty()));
+	PropertyHandle->GetValueAsDisplayText(*CurrentConnectionName);
+	if (!CurrentConnectionName->EqualTo(FText::GetEmpty()))
+	{
+		SelectedDefaultOLinkConnection = CurrentConnectionName;
+	}
+
+	if (!SelectedDefaultOLinkConnection)
+	{
+		SelectedDefaultOLinkConnection = TSharedPtr<FText>(new FText(FText::FromString(TEXT("Please define a connection in the settings first!"))));
+	}
 
 	// clang-format off
-	DefaultConnectionIdentifierPropertyRow.CustomWidget()
+	// Text box component:
+	TSharedRef<STextBlock > EditableTextBox = SNew(STextBlock )
+		.Text_Lambda([this]() { return *SelectedDefaultOLinkConnection; });
+
+	// Combo box component:
+	TSharedRef<SWidget> ComboBox = SNew(SListView<TSharedPtr<FText>>)
+		.ListItemsSource(AvailableOLinkConnectionNames)
+		.OnGenerateRow_Lambda([](TSharedPtr<FText> InItem, const TSharedRef< class STableViewBase >& Owner)
+		{
+			return SNew(STableRow<TSharedPtr<FText>>, Owner)
+					.Padding(FMargin(16, 4, 16, 4))
+					[
+						SNew(STextBlock).Text(*InItem)
+					];
+		})
+		.OnSelectionChanged_Lambda([this, PropertyHandle](TSharedPtr<FText> InText, ESelectInfo::Type)
+		{
+			SelectedDefaultOLinkConnection = InText;
+			PropertyHandle->SetValue(InText->ToString());
+		});
+
+
+	//Generate widget:
+	const TSharedRef<SWidget> NewWidget = SNew(SComboButton)
+		.ContentPadding(FMargin(0, 0, 5, 0))
+		.ToolTipText(TooltipText)
+		.ButtonContent()
+		[
+			SNew(SBorder)
+#if (ENGINE_MAJOR_VERSION >= 5)
+			.BorderImage(FAppStyle::GetBrush("NoBorder"))
+#endif
+			.Padding(FMargin(0, 0, 5, 0))
+			[
+				EditableTextBox
+			]
+		]
+		.MenuContent()
+		[
+			ComboBox
+		];
+	// clang-format on
+
+	return NewWidget;
+}
+
+void FTbEnumConnectionSettingsDetails::CustomizeTracerDetails(IDetailLayoutBuilder& DetailBuilder)
+{
+	IDetailCategoryBuilder& TracerServiceCategory = DetailBuilder.EditCategory(TEXT("TracerServiceSetup"));
+
+	TSharedPtr<IPropertyHandle> BackendServiceIdentifierPropertyHandle = DetailBuilder.GetProperty("TracerServiceIdentifier", nullptr);
+	IDetailPropertyRow& DefaultBackendServiceIdentifierPropertyRow = TracerServiceCategory.AddProperty(BackendServiceIdentifierPropertyHandle);
+
+	// clang-format off
+	DefaultBackendServiceIdentifierPropertyRow.CustomWidget()
 		.NameContent()
 		[
-			ConnectionIdentifierPropertyHandle->CreatePropertyNameWidget()
+			BackendServiceIdentifierPropertyHandle->CreatePropertyNameWidget()
 		]
 		.ValueContent()
 		.MaxDesiredWidth(500.0f)
 		.MinDesiredWidth(100.0f)
 		[
-			MakeDefaultConnectionSelectorWidget(ConnectionIdentifierPropertyHandle)
+			MakeDefaultBackendServiceSelectorWidget(BackendServiceIdentifierPropertyHandle)
 		];
 	// clang-format on
+}
+
+void FTbEnumConnectionSettingsDetails::CustomizeOLinkDetails(IDetailLayoutBuilder& DetailBuilder)
+{
+	IDetailCategoryBuilder& OLinkConnectionsCategory = DetailBuilder.EditCategory(TEXT("OLinkConnectionSetup"));
+
+	TSharedPtr<IPropertyHandle> OLinkConnectionIdentifierPropertyHandle = DetailBuilder.GetProperty("OLinkConnectionIdentifier", nullptr);
+	IDetailPropertyRow& DefaultOLinkConnectionIdentifierPropertyRow = OLinkConnectionsCategory.AddProperty(OLinkConnectionIdentifierPropertyHandle);
+
+	// clang-format off
+	DefaultOLinkConnectionIdentifierPropertyRow.CustomWidget()
+		.NameContent()
+		[
+			OLinkConnectionIdentifierPropertyHandle->CreatePropertyNameWidget()
+		]
+		.ValueContent()
+		.MaxDesiredWidth(500.0f)
+		.MinDesiredWidth(100.0f)
+		[
+			MakeDefaultOLinkConnectionSelectorWidget(OLinkConnectionIdentifierPropertyHandle)
+		];
+	// clang-format on
+}
+
+void FTbEnumConnectionSettingsDetails::CustomizeDetails(IDetailLayoutBuilder& DetailBuilder)
+{
+	CustomizeTracerDetails(DetailBuilder);
+	CustomizeOLinkDetails(DetailBuilder);
 }

--- a/goldenmaster/Plugins/TbEnum/Source/TbEnumEditor/Public/TbEnumConnectionSettings.h
+++ b/goldenmaster/Plugins/TbEnum/Source/TbEnumEditor/Public/TbEnumConnectionSettings.h
@@ -21,8 +21,13 @@ public:
 	virtual void CustomizeDetails(IDetailLayoutBuilder& DetailBuilder) override;
 
 private:
-	TSharedRef<SWidget> MakeDefaultConnectionSelectorWidget(const TSharedPtr<IPropertyHandle>& PropertyHandle);
+	void CustomizeTracerDetails(IDetailLayoutBuilder& DetailBuilder);
+	TSharedRef<SWidget> MakeDefaultBackendServiceSelectorWidget(const TSharedPtr<IPropertyHandle>& PropertyHandle);
+	TSharedPtr<FText> SelectedDefaultBackendService;
+	TArray<TSharedPtr<FText>> AvailableServices;
 
-	TSharedPtr<FText> SelectedDefaultConnection;
-	TArray<TSharedPtr<FText>> AvailableConnections;
+	void CustomizeOLinkDetails(IDetailLayoutBuilder& DetailBuilder);
+	TSharedRef<SWidget> MakeDefaultOLinkConnectionSelectorWidget(const TSharedPtr<IPropertyHandle>& PropertyHandle);
+	TSharedPtr<FText> SelectedDefaultOLinkConnection;
+	TArray<TSharedPtr<FText>> AvailableOLinkConnections;
 };

--- a/goldenmaster/Plugins/TbEnum/Source/TbEnumEditor/TbEnumEditor.Build.cs
+++ b/goldenmaster/Plugins/TbEnum/Source/TbEnumEditor/TbEnumEditor.Build.cs
@@ -14,6 +14,7 @@ namespace UnrealBuildTool.Rules
 					"UnrealEd",
 					// modules below are needed for connection settings
 					"ApiGear",
+					"ApiGearOLink",
 					"InputCore",
 					"PropertyEditor",
 					"Slate",

--- a/goldenmaster/Plugins/TbSame1/Source/TbSame1/Private/Generated/Monitor/TbSame1Factory.cpp
+++ b/goldenmaster/Plugins/TbSame1/Source/TbSame1/Private/Generated/Monitor/TbSame1Factory.cpp
@@ -80,13 +80,13 @@ TScriptInterface<ITbSame1SameStruct1InterfaceInterface> FTbSame1ModuleFactory::c
 {
 	UTbSame1Settings* TbSame1Settings = GetMutableDefault<UTbSame1Settings>();
 
-	if (TbSame1Settings->ConnectionIdentifier == "Local")
+	if (TbSame1Settings->TracerServiceIdentifier == "Local")
 	{
 		return createTbSame1SameStruct1Interface(GameInstance, Collection);
 	}
 
 	UApiGearSettings* ApiGearSettings = GetMutableDefault<UApiGearSettings>();
-	FApiGearConnectionSetting* ConnectionSetting = ApiGearSettings->Connections.Find(TbSame1Settings->ConnectionIdentifier);
+	FApiGearConnectionSetting* ConnectionSetting = ApiGearSettings->Connections.Find(TbSame1Settings->TracerServiceIdentifier);
 
 	// Other protocols not supported. To support it edit templates:
 	// add protocol handler class for this interface like createTbSame1SameStruct1InterfaceOLink and other necessary infrastructure
@@ -128,13 +128,13 @@ TScriptInterface<ITbSame1SameStruct1InterfaceInterface> FTbSame1ModuleFactory::c
 {
 	UTbSame1Settings* TbSame1Settings = GetMutableDefault<UTbSame1Settings>();
 
-	if (TbSame1Settings->ConnectionIdentifier == "Local")
+	if (TbSame1Settings->TracerServiceIdentifier == "Local")
 	{
 		return createTbSame1SameStruct1Interface(Collection);
 	}
 
 	UApiGearSettings* ApiGearSettings = GetMutableDefault<UApiGearSettings>();
-	FApiGearConnectionSetting* ConnectionSetting = ApiGearSettings->Connections.Find(TbSame1Settings->ConnectionIdentifier);
+	FApiGearConnectionSetting* ConnectionSetting = ApiGearSettings->Connections.Find(TbSame1Settings->TracerServiceIdentifier);
 
 	// Other protocols not supported. To support it edit templates:
 	// add protocol handler class for this interface like createTbSame1SameStruct1InterfaceOLink and other necessary infrastructure
@@ -188,13 +188,13 @@ TScriptInterface<ITbSame1SameStruct2InterfaceInterface> FTbSame1ModuleFactory::c
 {
 	UTbSame1Settings* TbSame1Settings = GetMutableDefault<UTbSame1Settings>();
 
-	if (TbSame1Settings->ConnectionIdentifier == "Local")
+	if (TbSame1Settings->TracerServiceIdentifier == "Local")
 	{
 		return createTbSame1SameStruct2Interface(GameInstance, Collection);
 	}
 
 	UApiGearSettings* ApiGearSettings = GetMutableDefault<UApiGearSettings>();
-	FApiGearConnectionSetting* ConnectionSetting = ApiGearSettings->Connections.Find(TbSame1Settings->ConnectionIdentifier);
+	FApiGearConnectionSetting* ConnectionSetting = ApiGearSettings->Connections.Find(TbSame1Settings->TracerServiceIdentifier);
 
 	// Other protocols not supported. To support it edit templates:
 	// add protocol handler class for this interface like createTbSame1SameStruct2InterfaceOLink and other necessary infrastructure
@@ -236,13 +236,13 @@ TScriptInterface<ITbSame1SameStruct2InterfaceInterface> FTbSame1ModuleFactory::c
 {
 	UTbSame1Settings* TbSame1Settings = GetMutableDefault<UTbSame1Settings>();
 
-	if (TbSame1Settings->ConnectionIdentifier == "Local")
+	if (TbSame1Settings->TracerServiceIdentifier == "Local")
 	{
 		return createTbSame1SameStruct2Interface(Collection);
 	}
 
 	UApiGearSettings* ApiGearSettings = GetMutableDefault<UApiGearSettings>();
-	FApiGearConnectionSetting* ConnectionSetting = ApiGearSettings->Connections.Find(TbSame1Settings->ConnectionIdentifier);
+	FApiGearConnectionSetting* ConnectionSetting = ApiGearSettings->Connections.Find(TbSame1Settings->TracerServiceIdentifier);
 
 	// Other protocols not supported. To support it edit templates:
 	// add protocol handler class for this interface like createTbSame1SameStruct2InterfaceOLink and other necessary infrastructure
@@ -296,13 +296,13 @@ TScriptInterface<ITbSame1SameEnum1InterfaceInterface> FTbSame1ModuleFactory::cre
 {
 	UTbSame1Settings* TbSame1Settings = GetMutableDefault<UTbSame1Settings>();
 
-	if (TbSame1Settings->ConnectionIdentifier == "Local")
+	if (TbSame1Settings->TracerServiceIdentifier == "Local")
 	{
 		return createTbSame1SameEnum1Interface(GameInstance, Collection);
 	}
 
 	UApiGearSettings* ApiGearSettings = GetMutableDefault<UApiGearSettings>();
-	FApiGearConnectionSetting* ConnectionSetting = ApiGearSettings->Connections.Find(TbSame1Settings->ConnectionIdentifier);
+	FApiGearConnectionSetting* ConnectionSetting = ApiGearSettings->Connections.Find(TbSame1Settings->TracerServiceIdentifier);
 
 	// Other protocols not supported. To support it edit templates:
 	// add protocol handler class for this interface like createTbSame1SameEnum1InterfaceOLink and other necessary infrastructure
@@ -344,13 +344,13 @@ TScriptInterface<ITbSame1SameEnum1InterfaceInterface> FTbSame1ModuleFactory::cre
 {
 	UTbSame1Settings* TbSame1Settings = GetMutableDefault<UTbSame1Settings>();
 
-	if (TbSame1Settings->ConnectionIdentifier == "Local")
+	if (TbSame1Settings->TracerServiceIdentifier == "Local")
 	{
 		return createTbSame1SameEnum1Interface(Collection);
 	}
 
 	UApiGearSettings* ApiGearSettings = GetMutableDefault<UApiGearSettings>();
-	FApiGearConnectionSetting* ConnectionSetting = ApiGearSettings->Connections.Find(TbSame1Settings->ConnectionIdentifier);
+	FApiGearConnectionSetting* ConnectionSetting = ApiGearSettings->Connections.Find(TbSame1Settings->TracerServiceIdentifier);
 
 	// Other protocols not supported. To support it edit templates:
 	// add protocol handler class for this interface like createTbSame1SameEnum1InterfaceOLink and other necessary infrastructure
@@ -404,13 +404,13 @@ TScriptInterface<ITbSame1SameEnum2InterfaceInterface> FTbSame1ModuleFactory::cre
 {
 	UTbSame1Settings* TbSame1Settings = GetMutableDefault<UTbSame1Settings>();
 
-	if (TbSame1Settings->ConnectionIdentifier == "Local")
+	if (TbSame1Settings->TracerServiceIdentifier == "Local")
 	{
 		return createTbSame1SameEnum2Interface(GameInstance, Collection);
 	}
 
 	UApiGearSettings* ApiGearSettings = GetMutableDefault<UApiGearSettings>();
-	FApiGearConnectionSetting* ConnectionSetting = ApiGearSettings->Connections.Find(TbSame1Settings->ConnectionIdentifier);
+	FApiGearConnectionSetting* ConnectionSetting = ApiGearSettings->Connections.Find(TbSame1Settings->TracerServiceIdentifier);
 
 	// Other protocols not supported. To support it edit templates:
 	// add protocol handler class for this interface like createTbSame1SameEnum2InterfaceOLink and other necessary infrastructure
@@ -452,13 +452,13 @@ TScriptInterface<ITbSame1SameEnum2InterfaceInterface> FTbSame1ModuleFactory::cre
 {
 	UTbSame1Settings* TbSame1Settings = GetMutableDefault<UTbSame1Settings>();
 
-	if (TbSame1Settings->ConnectionIdentifier == "Local")
+	if (TbSame1Settings->TracerServiceIdentifier == "Local")
 	{
 		return createTbSame1SameEnum2Interface(Collection);
 	}
 
 	UApiGearSettings* ApiGearSettings = GetMutableDefault<UApiGearSettings>();
-	FApiGearConnectionSetting* ConnectionSetting = ApiGearSettings->Connections.Find(TbSame1Settings->ConnectionIdentifier);
+	FApiGearConnectionSetting* ConnectionSetting = ApiGearSettings->Connections.Find(TbSame1Settings->TracerServiceIdentifier);
 
 	// Other protocols not supported. To support it edit templates:
 	// add protocol handler class for this interface like createTbSame1SameEnum2InterfaceOLink and other necessary infrastructure

--- a/goldenmaster/Plugins/TbSame1/Source/TbSame1/Private/Generated/Monitor/TbSame1Factory.cpp
+++ b/goldenmaster/Plugins/TbSame1/Source/TbSame1/Private/Generated/Monitor/TbSame1Factory.cpp
@@ -17,6 +17,7 @@ limitations under the License.
 
 #include "TbSame1Factory.h"
 #include "ApiGearSettings.h"
+#include "TbSame1Settings.h"
 #include "Implementation/TbSame1SameStruct1Interface.h"
 #include "Generated/OLink/TbSame1SameStruct1InterfaceOLinkClient.h"
 #include "Implementation/TbSame1SameStruct2Interface.h"
@@ -80,7 +81,7 @@ TScriptInterface<ITbSame1SameStruct1InterfaceInterface> FTbSame1ModuleFactory::c
 {
 	UTbSame1Settings* TbSame1Settings = GetMutableDefault<UTbSame1Settings>();
 
-	if (TbSame1Settings->TracerServiceIdentifier == "Local")
+	if (TbSame1Settings->TracerServiceIdentifier == TbSame1LocalBackendIdentifier)
 	{
 		return createTbSame1SameStruct1Interface(GameInstance, Collection);
 	}
@@ -128,7 +129,7 @@ TScriptInterface<ITbSame1SameStruct1InterfaceInterface> FTbSame1ModuleFactory::c
 {
 	UTbSame1Settings* TbSame1Settings = GetMutableDefault<UTbSame1Settings>();
 
-	if (TbSame1Settings->TracerServiceIdentifier == "Local")
+	if (TbSame1Settings->TracerServiceIdentifier == TbSame1LocalBackendIdentifier)
 	{
 		return createTbSame1SameStruct1Interface(Collection);
 	}
@@ -188,7 +189,7 @@ TScriptInterface<ITbSame1SameStruct2InterfaceInterface> FTbSame1ModuleFactory::c
 {
 	UTbSame1Settings* TbSame1Settings = GetMutableDefault<UTbSame1Settings>();
 
-	if (TbSame1Settings->TracerServiceIdentifier == "Local")
+	if (TbSame1Settings->TracerServiceIdentifier == TbSame1LocalBackendIdentifier)
 	{
 		return createTbSame1SameStruct2Interface(GameInstance, Collection);
 	}
@@ -236,7 +237,7 @@ TScriptInterface<ITbSame1SameStruct2InterfaceInterface> FTbSame1ModuleFactory::c
 {
 	UTbSame1Settings* TbSame1Settings = GetMutableDefault<UTbSame1Settings>();
 
-	if (TbSame1Settings->TracerServiceIdentifier == "Local")
+	if (TbSame1Settings->TracerServiceIdentifier == TbSame1LocalBackendIdentifier)
 	{
 		return createTbSame1SameStruct2Interface(Collection);
 	}
@@ -296,7 +297,7 @@ TScriptInterface<ITbSame1SameEnum1InterfaceInterface> FTbSame1ModuleFactory::cre
 {
 	UTbSame1Settings* TbSame1Settings = GetMutableDefault<UTbSame1Settings>();
 
-	if (TbSame1Settings->TracerServiceIdentifier == "Local")
+	if (TbSame1Settings->TracerServiceIdentifier == TbSame1LocalBackendIdentifier)
 	{
 		return createTbSame1SameEnum1Interface(GameInstance, Collection);
 	}
@@ -344,7 +345,7 @@ TScriptInterface<ITbSame1SameEnum1InterfaceInterface> FTbSame1ModuleFactory::cre
 {
 	UTbSame1Settings* TbSame1Settings = GetMutableDefault<UTbSame1Settings>();
 
-	if (TbSame1Settings->TracerServiceIdentifier == "Local")
+	if (TbSame1Settings->TracerServiceIdentifier == TbSame1LocalBackendIdentifier)
 	{
 		return createTbSame1SameEnum1Interface(Collection);
 	}
@@ -404,7 +405,7 @@ TScriptInterface<ITbSame1SameEnum2InterfaceInterface> FTbSame1ModuleFactory::cre
 {
 	UTbSame1Settings* TbSame1Settings = GetMutableDefault<UTbSame1Settings>();
 
-	if (TbSame1Settings->TracerServiceIdentifier == "Local")
+	if (TbSame1Settings->TracerServiceIdentifier == TbSame1LocalBackendIdentifier)
 	{
 		return createTbSame1SameEnum2Interface(GameInstance, Collection);
 	}
@@ -452,7 +453,7 @@ TScriptInterface<ITbSame1SameEnum2InterfaceInterface> FTbSame1ModuleFactory::cre
 {
 	UTbSame1Settings* TbSame1Settings = GetMutableDefault<UTbSame1Settings>();
 
-	if (TbSame1Settings->TracerServiceIdentifier == "Local")
+	if (TbSame1Settings->TracerServiceIdentifier == TbSame1LocalBackendIdentifier)
 	{
 		return createTbSame1SameEnum2Interface(Collection);
 	}

--- a/goldenmaster/Plugins/TbSame1/Source/TbSame1/Private/Generated/Monitor/TbSame1Factory.cpp
+++ b/goldenmaster/Plugins/TbSame1/Source/TbSame1/Private/Generated/Monitor/TbSame1Factory.cpp
@@ -17,6 +17,7 @@ limitations under the License.
 
 #include "TbSame1Factory.h"
 #include "ApiGearSettings.h"
+#include "apigearolink.h"
 #include "TbSame1Settings.h"
 #include "Implementation/TbSame1SameStruct1Interface.h"
 #include "Generated/OLink/TbSame1SameStruct1InterfaceOLinkClient.h"
@@ -92,7 +93,7 @@ TScriptInterface<ITbSame1SameStruct1InterfaceInterface> FTbSame1ModuleFactory::c
 	// Other protocols not supported. To support it edit templates:
 	// add protocol handler class for this interface like createTbSame1SameStruct1InterfaceOLink and other necessary infrastructure
 	// extend this function in templates to handle protocol of your choice
-	if (ConnectionSetting && ConnectionSetting->ProtocolIdentifier == "olink")
+	if (ConnectionSetting && ConnectionSetting->ProtocolIdentifier == ApiGearOLinkProtocolIdentifier)
 	{
 		return createTbSame1SameStruct1InterfaceOLink(GameInstance, Collection);
 	}
@@ -140,7 +141,7 @@ TScriptInterface<ITbSame1SameStruct1InterfaceInterface> FTbSame1ModuleFactory::c
 	// Other protocols not supported. To support it edit templates:
 	// add protocol handler class for this interface like createTbSame1SameStruct1InterfaceOLink and other necessary infrastructure
 	// extend this function in templates to handle protocol of your choice
-	if (ConnectionSetting && ConnectionSetting->ProtocolIdentifier == "olink")
+	if (ConnectionSetting && ConnectionSetting->ProtocolIdentifier == ApiGearOLinkProtocolIdentifier)
 	{
 		return createTbSame1SameStruct1InterfaceOLink(Collection);
 	}
@@ -200,7 +201,7 @@ TScriptInterface<ITbSame1SameStruct2InterfaceInterface> FTbSame1ModuleFactory::c
 	// Other protocols not supported. To support it edit templates:
 	// add protocol handler class for this interface like createTbSame1SameStruct2InterfaceOLink and other necessary infrastructure
 	// extend this function in templates to handle protocol of your choice
-	if (ConnectionSetting && ConnectionSetting->ProtocolIdentifier == "olink")
+	if (ConnectionSetting && ConnectionSetting->ProtocolIdentifier == ApiGearOLinkProtocolIdentifier)
 	{
 		return createTbSame1SameStruct2InterfaceOLink(GameInstance, Collection);
 	}
@@ -248,7 +249,7 @@ TScriptInterface<ITbSame1SameStruct2InterfaceInterface> FTbSame1ModuleFactory::c
 	// Other protocols not supported. To support it edit templates:
 	// add protocol handler class for this interface like createTbSame1SameStruct2InterfaceOLink and other necessary infrastructure
 	// extend this function in templates to handle protocol of your choice
-	if (ConnectionSetting && ConnectionSetting->ProtocolIdentifier == "olink")
+	if (ConnectionSetting && ConnectionSetting->ProtocolIdentifier == ApiGearOLinkProtocolIdentifier)
 	{
 		return createTbSame1SameStruct2InterfaceOLink(Collection);
 	}
@@ -308,7 +309,7 @@ TScriptInterface<ITbSame1SameEnum1InterfaceInterface> FTbSame1ModuleFactory::cre
 	// Other protocols not supported. To support it edit templates:
 	// add protocol handler class for this interface like createTbSame1SameEnum1InterfaceOLink and other necessary infrastructure
 	// extend this function in templates to handle protocol of your choice
-	if (ConnectionSetting && ConnectionSetting->ProtocolIdentifier == "olink")
+	if (ConnectionSetting && ConnectionSetting->ProtocolIdentifier == ApiGearOLinkProtocolIdentifier)
 	{
 		return createTbSame1SameEnum1InterfaceOLink(GameInstance, Collection);
 	}
@@ -356,7 +357,7 @@ TScriptInterface<ITbSame1SameEnum1InterfaceInterface> FTbSame1ModuleFactory::cre
 	// Other protocols not supported. To support it edit templates:
 	// add protocol handler class for this interface like createTbSame1SameEnum1InterfaceOLink and other necessary infrastructure
 	// extend this function in templates to handle protocol of your choice
-	if (ConnectionSetting && ConnectionSetting->ProtocolIdentifier == "olink")
+	if (ConnectionSetting && ConnectionSetting->ProtocolIdentifier == ApiGearOLinkProtocolIdentifier)
 	{
 		return createTbSame1SameEnum1InterfaceOLink(Collection);
 	}
@@ -416,7 +417,7 @@ TScriptInterface<ITbSame1SameEnum2InterfaceInterface> FTbSame1ModuleFactory::cre
 	// Other protocols not supported. To support it edit templates:
 	// add protocol handler class for this interface like createTbSame1SameEnum2InterfaceOLink and other necessary infrastructure
 	// extend this function in templates to handle protocol of your choice
-	if (ConnectionSetting && ConnectionSetting->ProtocolIdentifier == "olink")
+	if (ConnectionSetting && ConnectionSetting->ProtocolIdentifier == ApiGearOLinkProtocolIdentifier)
 	{
 		return createTbSame1SameEnum2InterfaceOLink(GameInstance, Collection);
 	}
@@ -464,7 +465,7 @@ TScriptInterface<ITbSame1SameEnum2InterfaceInterface> FTbSame1ModuleFactory::cre
 	// Other protocols not supported. To support it edit templates:
 	// add protocol handler class for this interface like createTbSame1SameEnum2InterfaceOLink and other necessary infrastructure
 	// extend this function in templates to handle protocol of your choice
-	if (ConnectionSetting && ConnectionSetting->ProtocolIdentifier == "olink")
+	if (ConnectionSetting && ConnectionSetting->ProtocolIdentifier == ApiGearOLinkProtocolIdentifier)
 	{
 		return createTbSame1SameEnum2InterfaceOLink(Collection);
 	}

--- a/goldenmaster/Plugins/TbSame1/Source/TbSame1/Private/Generated/OLink/TbSame1SameEnum1InterfaceOLinkClient.cpp
+++ b/goldenmaster/Plugins/TbSame1/Source/TbSame1/Private/Generated/OLink/TbSame1SameEnum1InterfaceOLinkClient.cpp
@@ -171,7 +171,17 @@ ETbSame1Enum1 UTbSame1SameEnum1InterfaceOLinkClient::Func1_Implementation(ETbSam
 		[Param1, &Promise, this]()
 		{
 			ApiGear::ObjectLink::InvokeReplyFunc GetSameEnum1InterfaceStateFunc = [&Promise](ApiGear::ObjectLink::InvokeReplyArg arg)
-			{ Promise.SetValue(arg.value.get<ETbSame1Enum1>()); };
+			{
+				if (!arg.value.empty())
+				{
+					Promise.SetValue(arg.value.get<ETbSame1Enum1>());
+				}
+				else
+				{
+					UE_LOG(LogTbSame1SameEnum1InterfaceOLinkClient, Error, TEXT("Func1: OLink service returned empty value - should have returned type of ETbSame1Enum1"));
+					Promise.SetValue(ETbSame1Enum1());
+				}
+			};
 			static const auto memberId = ApiGear::ObjectLink::Name::createMemberId(m_sink->olinkObjectName(), "func1");
 			m_sink->GetNode()->invokeRemote(memberId, {Param1}, GetSameEnum1InterfaceStateFunc);
 		});

--- a/goldenmaster/Plugins/TbSame1/Source/TbSame1/Private/Generated/OLink/TbSame1SameEnum1InterfaceOLinkClient.cpp
+++ b/goldenmaster/Plugins/TbSame1/Source/TbSame1/Private/Generated/OLink/TbSame1SameEnum1InterfaceOLinkClient.cpp
@@ -22,6 +22,7 @@ limitations under the License.
 
 #include "Generated/OLink/TbSame1SameEnum1InterfaceOLinkClient.h"
 #include "ApiGearSettings.h"
+#include "apigearolink.h"
 #include "Async/Async.h"
 #include "Generated/api/TbSame1.json.adapter.h"
 #include "unrealolink.h"
@@ -114,7 +115,7 @@ void UTbSame1SameEnum1InterfaceOLinkClient::UseConnection(TScriptInterface<IApiG
 	checkf(InConnection.GetInterface() != nullptr, TEXT("Cannot use connection - interface IApiGearConnection is not fully implemented"));
 
 	// only accept connections of type olink
-	checkf(InConnection->GetConnectionProtocolIdentifier() == "olink", TEXT("Cannot use connection - must be of type olink"));
+	checkf(InConnection->GetConnectionProtocolIdentifier() == ApiGearOLinkProtocolIdentifier, TEXT("Cannot use connection - must be of type olink"));
 
 	UUnrealOLink* UnrealOLinkConnection = nullptr;
 	// remove old connection

--- a/goldenmaster/Plugins/TbSame1/Source/TbSame1/Private/Generated/OLink/TbSame1SameEnum1InterfaceOLinkClient.cpp
+++ b/goldenmaster/Plugins/TbSame1/Source/TbSame1/Private/Generated/OLink/TbSame1SameEnum1InterfaceOLinkClient.cpp
@@ -82,8 +82,13 @@ void UTbSame1SameEnum1InterfaceOLinkClient::Initialize(FSubsystemCollectionBase&
 
 	UApiGearConnectionsStore* AGCM = GEngine->GetEngineSubsystem<UApiGearConnectionsStore>();
 
-	TScriptInterface<IApiGearConnection> OLinkConnection = AGCM->GetConnection(settings->ConnectionIdentifier);
+	TScriptInterface<IApiGearConnection> OLinkConnection = AGCM->GetConnection(settings->OLinkConnectionIdentifier);
 
+	if (!OLinkConnection.GetInterface())
+	{
+		UE_LOG(LogTbSame1SameEnum1InterfaceOLinkClient, Log, TEXT("No valid olink connection for %s, please set during run time"), UTF8_TO_TCHAR(m_sink->olinkObjectName().c_str()));
+		return;
+	}
 	UseConnection(OLinkConnection);
 	OLinkConnection->Connect();
 }

--- a/goldenmaster/Plugins/TbSame1/Source/TbSame1/Private/Generated/OLink/TbSame1SameEnum2InterfaceOLinkClient.cpp
+++ b/goldenmaster/Plugins/TbSame1/Source/TbSame1/Private/Generated/OLink/TbSame1SameEnum2InterfaceOLinkClient.cpp
@@ -201,7 +201,17 @@ ETbSame1Enum1 UTbSame1SameEnum2InterfaceOLinkClient::Func1_Implementation(ETbSam
 		[Param1, &Promise, this]()
 		{
 			ApiGear::ObjectLink::InvokeReplyFunc GetSameEnum2InterfaceStateFunc = [&Promise](ApiGear::ObjectLink::InvokeReplyArg arg)
-			{ Promise.SetValue(arg.value.get<ETbSame1Enum1>()); };
+			{
+				if (!arg.value.empty())
+				{
+					Promise.SetValue(arg.value.get<ETbSame1Enum1>());
+				}
+				else
+				{
+					UE_LOG(LogTbSame1SameEnum2InterfaceOLinkClient, Error, TEXT("Func1: OLink service returned empty value - should have returned type of ETbSame1Enum1"));
+					Promise.SetValue(ETbSame1Enum1());
+				}
+			};
 			static const auto memberId = ApiGear::ObjectLink::Name::createMemberId(m_sink->olinkObjectName(), "func1");
 			m_sink->GetNode()->invokeRemote(memberId, {Param1}, GetSameEnum2InterfaceStateFunc);
 		});
@@ -222,7 +232,17 @@ ETbSame1Enum1 UTbSame1SameEnum2InterfaceOLinkClient::Func2_Implementation(ETbSam
 		[Param1, Param2, &Promise, this]()
 		{
 			ApiGear::ObjectLink::InvokeReplyFunc GetSameEnum2InterfaceStateFunc = [&Promise](ApiGear::ObjectLink::InvokeReplyArg arg)
-			{ Promise.SetValue(arg.value.get<ETbSame1Enum1>()); };
+			{
+				if (!arg.value.empty())
+				{
+					Promise.SetValue(arg.value.get<ETbSame1Enum1>());
+				}
+				else
+				{
+					UE_LOG(LogTbSame1SameEnum2InterfaceOLinkClient, Error, TEXT("Func2: OLink service returned empty value - should have returned type of ETbSame1Enum1"));
+					Promise.SetValue(ETbSame1Enum1());
+				}
+			};
 			static const auto memberId = ApiGear::ObjectLink::Name::createMemberId(m_sink->olinkObjectName(), "func2");
 			m_sink->GetNode()->invokeRemote(memberId, {Param1, Param2}, GetSameEnum2InterfaceStateFunc);
 		});

--- a/goldenmaster/Plugins/TbSame1/Source/TbSame1/Private/Generated/OLink/TbSame1SameEnum2InterfaceOLinkClient.cpp
+++ b/goldenmaster/Plugins/TbSame1/Source/TbSame1/Private/Generated/OLink/TbSame1SameEnum2InterfaceOLinkClient.cpp
@@ -83,8 +83,13 @@ void UTbSame1SameEnum2InterfaceOLinkClient::Initialize(FSubsystemCollectionBase&
 
 	UApiGearConnectionsStore* AGCM = GEngine->GetEngineSubsystem<UApiGearConnectionsStore>();
 
-	TScriptInterface<IApiGearConnection> OLinkConnection = AGCM->GetConnection(settings->ConnectionIdentifier);
+	TScriptInterface<IApiGearConnection> OLinkConnection = AGCM->GetConnection(settings->OLinkConnectionIdentifier);
 
+	if (!OLinkConnection.GetInterface())
+	{
+		UE_LOG(LogTbSame1SameEnum2InterfaceOLinkClient, Log, TEXT("No valid olink connection for %s, please set during run time"), UTF8_TO_TCHAR(m_sink->olinkObjectName().c_str()));
+		return;
+	}
 	UseConnection(OLinkConnection);
 	OLinkConnection->Connect();
 }

--- a/goldenmaster/Plugins/TbSame1/Source/TbSame1/Private/Generated/OLink/TbSame1SameEnum2InterfaceOLinkClient.cpp
+++ b/goldenmaster/Plugins/TbSame1/Source/TbSame1/Private/Generated/OLink/TbSame1SameEnum2InterfaceOLinkClient.cpp
@@ -22,6 +22,7 @@ limitations under the License.
 
 #include "Generated/OLink/TbSame1SameEnum2InterfaceOLinkClient.h"
 #include "ApiGearSettings.h"
+#include "apigearolink.h"
 #include "Async/Async.h"
 #include "Generated/api/TbSame1.json.adapter.h"
 #include "unrealolink.h"
@@ -115,7 +116,7 @@ void UTbSame1SameEnum2InterfaceOLinkClient::UseConnection(TScriptInterface<IApiG
 	checkf(InConnection.GetInterface() != nullptr, TEXT("Cannot use connection - interface IApiGearConnection is not fully implemented"));
 
 	// only accept connections of type olink
-	checkf(InConnection->GetConnectionProtocolIdentifier() == "olink", TEXT("Cannot use connection - must be of type olink"));
+	checkf(InConnection->GetConnectionProtocolIdentifier() == ApiGearOLinkProtocolIdentifier, TEXT("Cannot use connection - must be of type olink"));
 
 	UUnrealOLink* UnrealOLinkConnection = nullptr;
 	// remove old connection

--- a/goldenmaster/Plugins/TbSame1/Source/TbSame1/Private/Generated/OLink/TbSame1SameStruct1InterfaceOLinkClient.cpp
+++ b/goldenmaster/Plugins/TbSame1/Source/TbSame1/Private/Generated/OLink/TbSame1SameStruct1InterfaceOLinkClient.cpp
@@ -171,7 +171,17 @@ FTbSame1Struct1 UTbSame1SameStruct1InterfaceOLinkClient::Func1_Implementation(co
 		[Param1, &Promise, this]()
 		{
 			ApiGear::ObjectLink::InvokeReplyFunc GetSameStruct1InterfaceStateFunc = [&Promise](ApiGear::ObjectLink::InvokeReplyArg arg)
-			{ Promise.SetValue(arg.value.get<FTbSame1Struct1>()); };
+			{
+				if (!arg.value.empty())
+				{
+					Promise.SetValue(arg.value.get<FTbSame1Struct1>());
+				}
+				else
+				{
+					UE_LOG(LogTbSame1SameStruct1InterfaceOLinkClient, Error, TEXT("Func1: OLink service returned empty value - should have returned type of FTbSame1Struct1"));
+					Promise.SetValue(FTbSame1Struct1());
+				}
+			};
 			static const auto memberId = ApiGear::ObjectLink::Name::createMemberId(m_sink->olinkObjectName(), "func1");
 			m_sink->GetNode()->invokeRemote(memberId, {Param1}, GetSameStruct1InterfaceStateFunc);
 		});

--- a/goldenmaster/Plugins/TbSame1/Source/TbSame1/Private/Generated/OLink/TbSame1SameStruct1InterfaceOLinkClient.cpp
+++ b/goldenmaster/Plugins/TbSame1/Source/TbSame1/Private/Generated/OLink/TbSame1SameStruct1InterfaceOLinkClient.cpp
@@ -22,6 +22,7 @@ limitations under the License.
 
 #include "Generated/OLink/TbSame1SameStruct1InterfaceOLinkClient.h"
 #include "ApiGearSettings.h"
+#include "apigearolink.h"
 #include "Async/Async.h"
 #include "Generated/api/TbSame1.json.adapter.h"
 #include "unrealolink.h"
@@ -114,7 +115,7 @@ void UTbSame1SameStruct1InterfaceOLinkClient::UseConnection(TScriptInterface<IAp
 	checkf(InConnection.GetInterface() != nullptr, TEXT("Cannot use connection - interface IApiGearConnection is not fully implemented"));
 
 	// only accept connections of type olink
-	checkf(InConnection->GetConnectionProtocolIdentifier() == "olink", TEXT("Cannot use connection - must be of type olink"));
+	checkf(InConnection->GetConnectionProtocolIdentifier() == ApiGearOLinkProtocolIdentifier, TEXT("Cannot use connection - must be of type olink"));
 
 	UUnrealOLink* UnrealOLinkConnection = nullptr;
 	// remove old connection

--- a/goldenmaster/Plugins/TbSame1/Source/TbSame1/Private/Generated/OLink/TbSame1SameStruct1InterfaceOLinkClient.cpp
+++ b/goldenmaster/Plugins/TbSame1/Source/TbSame1/Private/Generated/OLink/TbSame1SameStruct1InterfaceOLinkClient.cpp
@@ -82,8 +82,13 @@ void UTbSame1SameStruct1InterfaceOLinkClient::Initialize(FSubsystemCollectionBas
 
 	UApiGearConnectionsStore* AGCM = GEngine->GetEngineSubsystem<UApiGearConnectionsStore>();
 
-	TScriptInterface<IApiGearConnection> OLinkConnection = AGCM->GetConnection(settings->ConnectionIdentifier);
+	TScriptInterface<IApiGearConnection> OLinkConnection = AGCM->GetConnection(settings->OLinkConnectionIdentifier);
 
+	if (!OLinkConnection.GetInterface())
+	{
+		UE_LOG(LogTbSame1SameStruct1InterfaceOLinkClient, Log, TEXT("No valid olink connection for %s, please set during run time"), UTF8_TO_TCHAR(m_sink->olinkObjectName().c_str()));
+		return;
+	}
 	UseConnection(OLinkConnection);
 	OLinkConnection->Connect();
 }

--- a/goldenmaster/Plugins/TbSame1/Source/TbSame1/Private/Generated/OLink/TbSame1SameStruct2InterfaceOLinkClient.cpp
+++ b/goldenmaster/Plugins/TbSame1/Source/TbSame1/Private/Generated/OLink/TbSame1SameStruct2InterfaceOLinkClient.cpp
@@ -83,8 +83,13 @@ void UTbSame1SameStruct2InterfaceOLinkClient::Initialize(FSubsystemCollectionBas
 
 	UApiGearConnectionsStore* AGCM = GEngine->GetEngineSubsystem<UApiGearConnectionsStore>();
 
-	TScriptInterface<IApiGearConnection> OLinkConnection = AGCM->GetConnection(settings->ConnectionIdentifier);
+	TScriptInterface<IApiGearConnection> OLinkConnection = AGCM->GetConnection(settings->OLinkConnectionIdentifier);
 
+	if (!OLinkConnection.GetInterface())
+	{
+		UE_LOG(LogTbSame1SameStruct2InterfaceOLinkClient, Log, TEXT("No valid olink connection for %s, please set during run time"), UTF8_TO_TCHAR(m_sink->olinkObjectName().c_str()));
+		return;
+	}
 	UseConnection(OLinkConnection);
 	OLinkConnection->Connect();
 }

--- a/goldenmaster/Plugins/TbSame1/Source/TbSame1/Private/Generated/OLink/TbSame1SameStruct2InterfaceOLinkClient.cpp
+++ b/goldenmaster/Plugins/TbSame1/Source/TbSame1/Private/Generated/OLink/TbSame1SameStruct2InterfaceOLinkClient.cpp
@@ -22,6 +22,7 @@ limitations under the License.
 
 #include "Generated/OLink/TbSame1SameStruct2InterfaceOLinkClient.h"
 #include "ApiGearSettings.h"
+#include "apigearolink.h"
 #include "Async/Async.h"
 #include "Generated/api/TbSame1.json.adapter.h"
 #include "unrealolink.h"
@@ -115,7 +116,7 @@ void UTbSame1SameStruct2InterfaceOLinkClient::UseConnection(TScriptInterface<IAp
 	checkf(InConnection.GetInterface() != nullptr, TEXT("Cannot use connection - interface IApiGearConnection is not fully implemented"));
 
 	// only accept connections of type olink
-	checkf(InConnection->GetConnectionProtocolIdentifier() == "olink", TEXT("Cannot use connection - must be of type olink"));
+	checkf(InConnection->GetConnectionProtocolIdentifier() == ApiGearOLinkProtocolIdentifier, TEXT("Cannot use connection - must be of type olink"));
 
 	UUnrealOLink* UnrealOLinkConnection = nullptr;
 	// remove old connection

--- a/goldenmaster/Plugins/TbSame1/Source/TbSame1/Private/Generated/OLink/TbSame1SameStruct2InterfaceOLinkClient.cpp
+++ b/goldenmaster/Plugins/TbSame1/Source/TbSame1/Private/Generated/OLink/TbSame1SameStruct2InterfaceOLinkClient.cpp
@@ -201,7 +201,17 @@ FTbSame1Struct1 UTbSame1SameStruct2InterfaceOLinkClient::Func1_Implementation(co
 		[Param1, &Promise, this]()
 		{
 			ApiGear::ObjectLink::InvokeReplyFunc GetSameStruct2InterfaceStateFunc = [&Promise](ApiGear::ObjectLink::InvokeReplyArg arg)
-			{ Promise.SetValue(arg.value.get<FTbSame1Struct1>()); };
+			{
+				if (!arg.value.empty())
+				{
+					Promise.SetValue(arg.value.get<FTbSame1Struct1>());
+				}
+				else
+				{
+					UE_LOG(LogTbSame1SameStruct2InterfaceOLinkClient, Error, TEXT("Func1: OLink service returned empty value - should have returned type of FTbSame1Struct1"));
+					Promise.SetValue(FTbSame1Struct1());
+				}
+			};
 			static const auto memberId = ApiGear::ObjectLink::Name::createMemberId(m_sink->olinkObjectName(), "func1");
 			m_sink->GetNode()->invokeRemote(memberId, {Param1}, GetSameStruct2InterfaceStateFunc);
 		});
@@ -222,7 +232,17 @@ FTbSame1Struct1 UTbSame1SameStruct2InterfaceOLinkClient::Func2_Implementation(co
 		[Param1, Param2, &Promise, this]()
 		{
 			ApiGear::ObjectLink::InvokeReplyFunc GetSameStruct2InterfaceStateFunc = [&Promise](ApiGear::ObjectLink::InvokeReplyArg arg)
-			{ Promise.SetValue(arg.value.get<FTbSame1Struct1>()); };
+			{
+				if (!arg.value.empty())
+				{
+					Promise.SetValue(arg.value.get<FTbSame1Struct1>());
+				}
+				else
+				{
+					UE_LOG(LogTbSame1SameStruct2InterfaceOLinkClient, Error, TEXT("Func2: OLink service returned empty value - should have returned type of FTbSame1Struct1"));
+					Promise.SetValue(FTbSame1Struct1());
+				}
+			};
 			static const auto memberId = ApiGear::ObjectLink::Name::createMemberId(m_sink->olinkObjectName(), "func2");
 			m_sink->GetNode()->invokeRemote(memberId, {Param1, Param2}, GetSameStruct2InterfaceStateFunc);
 		});

--- a/goldenmaster/Plugins/TbSame1/Source/TbSame1/Private/TbSame1Settings.cpp
+++ b/goldenmaster/Plugins/TbSame1/Source/TbSame1/Private/TbSame1Settings.cpp
@@ -37,7 +37,7 @@ void UTbSame1Settings::PostInitProperties()
 	}
 
 	// the local backend does not require configuration
-	if (TracerServiceIdentifier == "Local")
+	if (TracerServiceIdentifier == TbSame1LocalBackendIdentifier)
 	{
 		return;
 	}
@@ -45,6 +45,6 @@ void UTbSame1Settings::PostInitProperties()
 	if (!AGCM->DoesConnectionExist(TracerServiceIdentifier))
 	{
 		UE_LOG(LogTemp, Warning, TEXT("UTbSame1Settings could not find connection %s, falling back to local backend."), *TracerServiceIdentifier);
-		TracerServiceIdentifier = "Local";
+		TracerServiceIdentifier = TbSame1LocalBackendIdentifier;
 	}
 }

--- a/goldenmaster/Plugins/TbSame1/Source/TbSame1/Private/TbSame1Settings.cpp
+++ b/goldenmaster/Plugins/TbSame1/Source/TbSame1/Private/TbSame1Settings.cpp
@@ -27,18 +27,24 @@ void UTbSame1Settings::PostInitProperties()
 {
 	Super::PostInitProperties();
 
+	check(GEngine);
+	UApiGearConnectionsStore* AGCM = GEngine->GetEngineSubsystem<UApiGearConnectionsStore>();
+
+	if (!AGCM->DoesConnectionExist(OLinkConnectionIdentifier))
+	{
+		UE_LOG(LogTemp, Warning, TEXT("UTbSame1Settings could not find connection %s."), *OLinkConnectionIdentifier);
+		OLinkConnectionIdentifier = "";
+	}
+
 	// the local backend does not require configuration
-	if (ConnectionIdentifier == "Local")
+	if (TracerServiceIdentifier == "Local")
 	{
 		return;
 	}
 
-	check(GEngine);
-	UApiGearConnectionsStore* AGCM = GEngine->GetEngineSubsystem<UApiGearConnectionsStore>();
-
-	if (!AGCM->DoesConnectionExist(ConnectionIdentifier))
+	if (!AGCM->DoesConnectionExist(TracerServiceIdentifier))
 	{
-		UE_LOG(LogTemp, Warning, TEXT("UTbSame1Settings could not find connection %s, falling back to local backend."), *ConnectionIdentifier);
-		ConnectionIdentifier = "Local";
+		UE_LOG(LogTemp, Warning, TEXT("UTbSame1Settings could not find connection %s, falling back to local backend."), *TracerServiceIdentifier);
+		TracerServiceIdentifier = "Local";
 	}
 }

--- a/goldenmaster/Plugins/TbSame1/Source/TbSame1/Public/TbSame1Settings.h
+++ b/goldenmaster/Plugins/TbSame1/Source/TbSame1/Public/TbSame1Settings.h
@@ -33,6 +33,10 @@ class TBSAME1_API UTbSame1Settings : public UObject
 	virtual void PostInitProperties() override;
 
 	// Choose the backend service for the logging decorator to use
-	UPROPERTY(EditAnywhere, config, Category = ServiceSetup)
-	FString ConnectionIdentifier;
+	UPROPERTY(EditAnywhere, config, Category = TracerServiceSetup)
+	FString TracerServiceIdentifier;
+
+	// Choose the olink connection to use
+	UPROPERTY(EditAnywhere, config, Category = OLinkConnectionSetup)
+	FString OLinkConnectionIdentifier;
 };

--- a/goldenmaster/Plugins/TbSame1/Source/TbSame1/Public/TbSame1Settings.h
+++ b/goldenmaster/Plugins/TbSame1/Source/TbSame1/Public/TbSame1Settings.h
@@ -22,6 +22,8 @@ limitations under the License.
 #include "Engine/EngineTypes.h"
 #include "TbSame1Settings.generated.h"
 
+const FString TbSame1LocalBackendIdentifier = "Local";
+
 /**
  * Implements the settings for the TbSame1 plugin.
  */

--- a/goldenmaster/Plugins/TbSame1/Source/TbSame1Editor/Private/TbSame1ConnectionSettings.cpp
+++ b/goldenmaster/Plugins/TbSame1/Source/TbSame1Editor/Private/TbSame1ConnectionSettings.cpp
@@ -24,33 +24,38 @@ TSharedRef<IDetailCustomization> FTbSame1ConnectionSettingsDetails::MakeInstance
 	return MakeShareable(new FTbSame1ConnectionSettingsDetails);
 }
 
-TSharedRef<SWidget> FTbSame1ConnectionSettingsDetails::MakeDefaultConnectionSelectorWidget(const TSharedPtr<IPropertyHandle>& PropertyHandle)
+TSharedRef<SWidget> FTbSame1ConnectionSettingsDetails::MakeDefaultBackendServiceSelectorWidget(const TSharedPtr<IPropertyHandle>& PropertyHandle)
 {
 	UApiGearSettings* settings = GetMutableDefault<UApiGearSettings>();
 	check(settings);
 
-	TArray<TSharedPtr<FText>>* AvailableConnectionNames = &AvailableConnections;
-	FText TooltipText = FText::FromString(TEXT("Choose which connection should be used as default. Please make sure to have at least one connection defined."));
+	TArray<TSharedPtr<FText>>* AvailableServicesNames = &AvailableServices;
+	FText TooltipText = FText::FromString(TEXT("Choose which service should be used as default."));
 
-	TSharedPtr<FText> DefaultEffectName = TSharedPtr<FText>(new FText(FText::FromString(TEXT("Local"))));
-	SelectedDefaultConnection = TSharedPtr<FText>(new FText(*DefaultEffectName));
-	PropertyHandle->GetValueAsDisplayText(*SelectedDefaultConnection);
+	TSharedPtr<FText> LocalServiceName = TSharedPtr<FText>(new FText(FText::FromString(TEXT("Local"))));
+	AvailableServicesNames->Add(LocalServiceName);
+	SelectedDefaultBackendService = LocalServiceName;
 
-	AvailableConnectionNames->Add(DefaultEffectName);
+	TSharedPtr<FText> CurrentServiceName = TSharedPtr<FText>(new FText(FText::GetEmpty()));
+	PropertyHandle->GetValueAsDisplayText(*CurrentServiceName);
+	if (!CurrentServiceName->EqualTo(FText::GetEmpty()))
+	{
+		SelectedDefaultBackendService = CurrentServiceName;
+	}
 
 	for (auto ConnectionSetting : settings->Connections)
 	{
-		AvailableConnectionNames->Add(MakeShared<FText>(FText::FromString(*ConnectionSetting.Key)));
+		AvailableServicesNames->Add(MakeShared<FText>(FText::FromString(*ConnectionSetting.Key)));
 	}
 
 	// clang-format off
 	// Text box component:
 	TSharedRef<STextBlock > EditableTextBox = SNew(STextBlock )
-		.Text_Lambda([this]() { return *SelectedDefaultConnection; });
+		.Text_Lambda([this]() { return *SelectedDefaultBackendService; });
 
 	// Combo box component:
 	TSharedRef<SWidget> ComboBox = SNew(SListView<TSharedPtr<FText>>)
-		.ListItemsSource(AvailableConnectionNames)
+		.ListItemsSource(AvailableServicesNames)
 		.OnGenerateRow_Lambda([](TSharedPtr<FText> InItem, const TSharedRef< class STableViewBase >& Owner)
 		{
 			return SNew(STableRow<TSharedPtr<FText>>, Owner)
@@ -61,7 +66,7 @@ TSharedRef<SWidget> FTbSame1ConnectionSettingsDetails::MakeDefaultConnectionSele
 		})
 		.OnSelectionChanged_Lambda([this, PropertyHandle](TSharedPtr<FText> InText, ESelectInfo::Type)
 		{
-			SelectedDefaultConnection = InText;
+			SelectedDefaultBackendService = InText;
 			PropertyHandle->SetValue(InText->ToString());
 		});
 
@@ -90,24 +95,133 @@ TSharedRef<SWidget> FTbSame1ConnectionSettingsDetails::MakeDefaultConnectionSele
 	return NewWidget;
 }
 
-void FTbSame1ConnectionSettingsDetails::CustomizeDetails(IDetailLayoutBuilder& DetailBuilder)
+TSharedRef<SWidget> FTbSame1ConnectionSettingsDetails::MakeDefaultOLinkConnectionSelectorWidget(const TSharedPtr<IPropertyHandle>& PropertyHandle)
 {
-	IDetailCategoryBuilder& ConnectionsCategory = DetailBuilder.EditCategory(TEXT("ServiceSetup"));
+	UApiGearSettings* settings = GetMutableDefault<UApiGearSettings>();
+	check(settings);
 
-	TSharedPtr<IPropertyHandle> ConnectionIdentifierPropertyHandle = DetailBuilder.GetProperty("ConnectionIdentifier", nullptr);
-	IDetailPropertyRow& DefaultConnectionIdentifierPropertyRow = ConnectionsCategory.AddProperty(ConnectionIdentifierPropertyHandle);
+	TArray<TSharedPtr<FText>>* AvailableOLinkConnectionNames = &AvailableOLinkConnections;
+	FText TooltipText = FText::FromString(TEXT("Choose which connection should be used as default. Please make sure to have at least one connection defined."));
+
+	for (auto ConnectionSetting : settings->Connections)
+	{
+		if (ConnectionSetting.Value.ProtocolIdentifier == "olink")
+		{
+			TSharedPtr<FText> ConnectionName = MakeShared<FText>(FText::FromString(*ConnectionSetting.Key));
+			AvailableOLinkConnectionNames->Add(ConnectionName);
+
+			if (!SelectedDefaultOLinkConnection)
+			{
+				SelectedDefaultOLinkConnection = ConnectionName;
+			}
+		}
+	}
+
+	TSharedPtr<FText> CurrentConnectionName = TSharedPtr<FText>(new FText(FText::GetEmpty()));
+	PropertyHandle->GetValueAsDisplayText(*CurrentConnectionName);
+	if (!CurrentConnectionName->EqualTo(FText::GetEmpty()))
+	{
+		SelectedDefaultOLinkConnection = CurrentConnectionName;
+	}
+
+	if (!SelectedDefaultOLinkConnection)
+	{
+		SelectedDefaultOLinkConnection = TSharedPtr<FText>(new FText(FText::FromString(TEXT("Please define a connection in the settings first!"))));
+	}
 
 	// clang-format off
-	DefaultConnectionIdentifierPropertyRow.CustomWidget()
+	// Text box component:
+	TSharedRef<STextBlock > EditableTextBox = SNew(STextBlock )
+		.Text_Lambda([this]() { return *SelectedDefaultOLinkConnection; });
+
+	// Combo box component:
+	TSharedRef<SWidget> ComboBox = SNew(SListView<TSharedPtr<FText>>)
+		.ListItemsSource(AvailableOLinkConnectionNames)
+		.OnGenerateRow_Lambda([](TSharedPtr<FText> InItem, const TSharedRef< class STableViewBase >& Owner)
+		{
+			return SNew(STableRow<TSharedPtr<FText>>, Owner)
+					.Padding(FMargin(16, 4, 16, 4))
+					[
+						SNew(STextBlock).Text(*InItem)
+					];
+		})
+		.OnSelectionChanged_Lambda([this, PropertyHandle](TSharedPtr<FText> InText, ESelectInfo::Type)
+		{
+			SelectedDefaultOLinkConnection = InText;
+			PropertyHandle->SetValue(InText->ToString());
+		});
+
+
+	//Generate widget:
+	const TSharedRef<SWidget> NewWidget = SNew(SComboButton)
+		.ContentPadding(FMargin(0, 0, 5, 0))
+		.ToolTipText(TooltipText)
+		.ButtonContent()
+		[
+			SNew(SBorder)
+#if (ENGINE_MAJOR_VERSION >= 5)
+			.BorderImage(FAppStyle::GetBrush("NoBorder"))
+#endif
+			.Padding(FMargin(0, 0, 5, 0))
+			[
+				EditableTextBox
+			]
+		]
+		.MenuContent()
+		[
+			ComboBox
+		];
+	// clang-format on
+
+	return NewWidget;
+}
+
+void FTbSame1ConnectionSettingsDetails::CustomizeTracerDetails(IDetailLayoutBuilder& DetailBuilder)
+{
+	IDetailCategoryBuilder& TracerServiceCategory = DetailBuilder.EditCategory(TEXT("TracerServiceSetup"));
+
+	TSharedPtr<IPropertyHandle> BackendServiceIdentifierPropertyHandle = DetailBuilder.GetProperty("TracerServiceIdentifier", nullptr);
+	IDetailPropertyRow& DefaultBackendServiceIdentifierPropertyRow = TracerServiceCategory.AddProperty(BackendServiceIdentifierPropertyHandle);
+
+	// clang-format off
+	DefaultBackendServiceIdentifierPropertyRow.CustomWidget()
 		.NameContent()
 		[
-			ConnectionIdentifierPropertyHandle->CreatePropertyNameWidget()
+			BackendServiceIdentifierPropertyHandle->CreatePropertyNameWidget()
 		]
 		.ValueContent()
 		.MaxDesiredWidth(500.0f)
 		.MinDesiredWidth(100.0f)
 		[
-			MakeDefaultConnectionSelectorWidget(ConnectionIdentifierPropertyHandle)
+			MakeDefaultBackendServiceSelectorWidget(BackendServiceIdentifierPropertyHandle)
 		];
 	// clang-format on
+}
+
+void FTbSame1ConnectionSettingsDetails::CustomizeOLinkDetails(IDetailLayoutBuilder& DetailBuilder)
+{
+	IDetailCategoryBuilder& OLinkConnectionsCategory = DetailBuilder.EditCategory(TEXT("OLinkConnectionSetup"));
+
+	TSharedPtr<IPropertyHandle> OLinkConnectionIdentifierPropertyHandle = DetailBuilder.GetProperty("OLinkConnectionIdentifier", nullptr);
+	IDetailPropertyRow& DefaultOLinkConnectionIdentifierPropertyRow = OLinkConnectionsCategory.AddProperty(OLinkConnectionIdentifierPropertyHandle);
+
+	// clang-format off
+	DefaultOLinkConnectionIdentifierPropertyRow.CustomWidget()
+		.NameContent()
+		[
+			OLinkConnectionIdentifierPropertyHandle->CreatePropertyNameWidget()
+		]
+		.ValueContent()
+		.MaxDesiredWidth(500.0f)
+		.MinDesiredWidth(100.0f)
+		[
+			MakeDefaultOLinkConnectionSelectorWidget(OLinkConnectionIdentifierPropertyHandle)
+		];
+	// clang-format on
+}
+
+void FTbSame1ConnectionSettingsDetails::CustomizeDetails(IDetailLayoutBuilder& DetailBuilder)
+{
+	CustomizeTracerDetails(DetailBuilder);
+	CustomizeOLinkDetails(DetailBuilder);
 }

--- a/goldenmaster/Plugins/TbSame1/Source/TbSame1Editor/Private/TbSame1ConnectionSettings.cpp
+++ b/goldenmaster/Plugins/TbSame1/Source/TbSame1Editor/Private/TbSame1ConnectionSettings.cpp
@@ -2,6 +2,7 @@
 #include "TbSame1ConnectionSettings.h"
 
 #include "ApiGearSettings.h"
+#include "TbSame1Settings.h"
 #include "Templates/SharedPointer.h"
 #include "IDetailCustomization.h"
 #include "PropertyHandle.h"
@@ -32,7 +33,7 @@ TSharedRef<SWidget> FTbSame1ConnectionSettingsDetails::MakeDefaultBackendService
 	TArray<TSharedPtr<FText>>* AvailableServicesNames = &AvailableServices;
 	FText TooltipText = FText::FromString(TEXT("Choose which service should be used as default."));
 
-	TSharedPtr<FText> LocalServiceName = TSharedPtr<FText>(new FText(FText::FromString(TEXT("Local"))));
+	TSharedPtr<FText> LocalServiceName = TSharedPtr<FText>(new FText(FText::FromString(TbSame1LocalBackendIdentifier)));
 	AvailableServicesNames->Add(LocalServiceName);
 	SelectedDefaultBackendService = LocalServiceName;
 

--- a/goldenmaster/Plugins/TbSame1/Source/TbSame1Editor/Private/TbSame1ConnectionSettings.cpp
+++ b/goldenmaster/Plugins/TbSame1/Source/TbSame1Editor/Private/TbSame1ConnectionSettings.cpp
@@ -2,6 +2,7 @@
 #include "TbSame1ConnectionSettings.h"
 
 #include "ApiGearSettings.h"
+#include "apigearolink.h"
 #include "TbSame1Settings.h"
 #include "Templates/SharedPointer.h"
 #include "IDetailCustomization.h"
@@ -106,7 +107,7 @@ TSharedRef<SWidget> FTbSame1ConnectionSettingsDetails::MakeDefaultOLinkConnectio
 
 	for (auto ConnectionSetting : settings->Connections)
 	{
-		if (ConnectionSetting.Value.ProtocolIdentifier == "olink")
+		if (ConnectionSetting.Value.ProtocolIdentifier == ApiGearOLinkProtocolIdentifier)
 		{
 			TSharedPtr<FText> ConnectionName = MakeShared<FText>(FText::FromString(*ConnectionSetting.Key));
 			AvailableOLinkConnectionNames->Add(ConnectionName);

--- a/goldenmaster/Plugins/TbSame1/Source/TbSame1Editor/Public/TbSame1ConnectionSettings.h
+++ b/goldenmaster/Plugins/TbSame1/Source/TbSame1Editor/Public/TbSame1ConnectionSettings.h
@@ -21,8 +21,13 @@ public:
 	virtual void CustomizeDetails(IDetailLayoutBuilder& DetailBuilder) override;
 
 private:
-	TSharedRef<SWidget> MakeDefaultConnectionSelectorWidget(const TSharedPtr<IPropertyHandle>& PropertyHandle);
+	void CustomizeTracerDetails(IDetailLayoutBuilder& DetailBuilder);
+	TSharedRef<SWidget> MakeDefaultBackendServiceSelectorWidget(const TSharedPtr<IPropertyHandle>& PropertyHandle);
+	TSharedPtr<FText> SelectedDefaultBackendService;
+	TArray<TSharedPtr<FText>> AvailableServices;
 
-	TSharedPtr<FText> SelectedDefaultConnection;
-	TArray<TSharedPtr<FText>> AvailableConnections;
+	void CustomizeOLinkDetails(IDetailLayoutBuilder& DetailBuilder);
+	TSharedRef<SWidget> MakeDefaultOLinkConnectionSelectorWidget(const TSharedPtr<IPropertyHandle>& PropertyHandle);
+	TSharedPtr<FText> SelectedDefaultOLinkConnection;
+	TArray<TSharedPtr<FText>> AvailableOLinkConnections;
 };

--- a/goldenmaster/Plugins/TbSame1/Source/TbSame1Editor/TbSame1Editor.Build.cs
+++ b/goldenmaster/Plugins/TbSame1/Source/TbSame1Editor/TbSame1Editor.Build.cs
@@ -14,6 +14,7 @@ namespace UnrealBuildTool.Rules
 					"UnrealEd",
 					// modules below are needed for connection settings
 					"ApiGear",
+					"ApiGearOLink",
 					"InputCore",
 					"PropertyEditor",
 					"Slate",

--- a/goldenmaster/Plugins/TbSame2/Source/TbSame2/Private/Generated/Monitor/TbSame2Factory.cpp
+++ b/goldenmaster/Plugins/TbSame2/Source/TbSame2/Private/Generated/Monitor/TbSame2Factory.cpp
@@ -80,13 +80,13 @@ TScriptInterface<ITbSame2SameStruct1InterfaceInterface> FTbSame2ModuleFactory::c
 {
 	UTbSame2Settings* TbSame2Settings = GetMutableDefault<UTbSame2Settings>();
 
-	if (TbSame2Settings->ConnectionIdentifier == "Local")
+	if (TbSame2Settings->TracerServiceIdentifier == "Local")
 	{
 		return createTbSame2SameStruct1Interface(GameInstance, Collection);
 	}
 
 	UApiGearSettings* ApiGearSettings = GetMutableDefault<UApiGearSettings>();
-	FApiGearConnectionSetting* ConnectionSetting = ApiGearSettings->Connections.Find(TbSame2Settings->ConnectionIdentifier);
+	FApiGearConnectionSetting* ConnectionSetting = ApiGearSettings->Connections.Find(TbSame2Settings->TracerServiceIdentifier);
 
 	// Other protocols not supported. To support it edit templates:
 	// add protocol handler class for this interface like createTbSame2SameStruct1InterfaceOLink and other necessary infrastructure
@@ -128,13 +128,13 @@ TScriptInterface<ITbSame2SameStruct1InterfaceInterface> FTbSame2ModuleFactory::c
 {
 	UTbSame2Settings* TbSame2Settings = GetMutableDefault<UTbSame2Settings>();
 
-	if (TbSame2Settings->ConnectionIdentifier == "Local")
+	if (TbSame2Settings->TracerServiceIdentifier == "Local")
 	{
 		return createTbSame2SameStruct1Interface(Collection);
 	}
 
 	UApiGearSettings* ApiGearSettings = GetMutableDefault<UApiGearSettings>();
-	FApiGearConnectionSetting* ConnectionSetting = ApiGearSettings->Connections.Find(TbSame2Settings->ConnectionIdentifier);
+	FApiGearConnectionSetting* ConnectionSetting = ApiGearSettings->Connections.Find(TbSame2Settings->TracerServiceIdentifier);
 
 	// Other protocols not supported. To support it edit templates:
 	// add protocol handler class for this interface like createTbSame2SameStruct1InterfaceOLink and other necessary infrastructure
@@ -188,13 +188,13 @@ TScriptInterface<ITbSame2SameStruct2InterfaceInterface> FTbSame2ModuleFactory::c
 {
 	UTbSame2Settings* TbSame2Settings = GetMutableDefault<UTbSame2Settings>();
 
-	if (TbSame2Settings->ConnectionIdentifier == "Local")
+	if (TbSame2Settings->TracerServiceIdentifier == "Local")
 	{
 		return createTbSame2SameStruct2Interface(GameInstance, Collection);
 	}
 
 	UApiGearSettings* ApiGearSettings = GetMutableDefault<UApiGearSettings>();
-	FApiGearConnectionSetting* ConnectionSetting = ApiGearSettings->Connections.Find(TbSame2Settings->ConnectionIdentifier);
+	FApiGearConnectionSetting* ConnectionSetting = ApiGearSettings->Connections.Find(TbSame2Settings->TracerServiceIdentifier);
 
 	// Other protocols not supported. To support it edit templates:
 	// add protocol handler class for this interface like createTbSame2SameStruct2InterfaceOLink and other necessary infrastructure
@@ -236,13 +236,13 @@ TScriptInterface<ITbSame2SameStruct2InterfaceInterface> FTbSame2ModuleFactory::c
 {
 	UTbSame2Settings* TbSame2Settings = GetMutableDefault<UTbSame2Settings>();
 
-	if (TbSame2Settings->ConnectionIdentifier == "Local")
+	if (TbSame2Settings->TracerServiceIdentifier == "Local")
 	{
 		return createTbSame2SameStruct2Interface(Collection);
 	}
 
 	UApiGearSettings* ApiGearSettings = GetMutableDefault<UApiGearSettings>();
-	FApiGearConnectionSetting* ConnectionSetting = ApiGearSettings->Connections.Find(TbSame2Settings->ConnectionIdentifier);
+	FApiGearConnectionSetting* ConnectionSetting = ApiGearSettings->Connections.Find(TbSame2Settings->TracerServiceIdentifier);
 
 	// Other protocols not supported. To support it edit templates:
 	// add protocol handler class for this interface like createTbSame2SameStruct2InterfaceOLink and other necessary infrastructure
@@ -296,13 +296,13 @@ TScriptInterface<ITbSame2SameEnum1InterfaceInterface> FTbSame2ModuleFactory::cre
 {
 	UTbSame2Settings* TbSame2Settings = GetMutableDefault<UTbSame2Settings>();
 
-	if (TbSame2Settings->ConnectionIdentifier == "Local")
+	if (TbSame2Settings->TracerServiceIdentifier == "Local")
 	{
 		return createTbSame2SameEnum1Interface(GameInstance, Collection);
 	}
 
 	UApiGearSettings* ApiGearSettings = GetMutableDefault<UApiGearSettings>();
-	FApiGearConnectionSetting* ConnectionSetting = ApiGearSettings->Connections.Find(TbSame2Settings->ConnectionIdentifier);
+	FApiGearConnectionSetting* ConnectionSetting = ApiGearSettings->Connections.Find(TbSame2Settings->TracerServiceIdentifier);
 
 	// Other protocols not supported. To support it edit templates:
 	// add protocol handler class for this interface like createTbSame2SameEnum1InterfaceOLink and other necessary infrastructure
@@ -344,13 +344,13 @@ TScriptInterface<ITbSame2SameEnum1InterfaceInterface> FTbSame2ModuleFactory::cre
 {
 	UTbSame2Settings* TbSame2Settings = GetMutableDefault<UTbSame2Settings>();
 
-	if (TbSame2Settings->ConnectionIdentifier == "Local")
+	if (TbSame2Settings->TracerServiceIdentifier == "Local")
 	{
 		return createTbSame2SameEnum1Interface(Collection);
 	}
 
 	UApiGearSettings* ApiGearSettings = GetMutableDefault<UApiGearSettings>();
-	FApiGearConnectionSetting* ConnectionSetting = ApiGearSettings->Connections.Find(TbSame2Settings->ConnectionIdentifier);
+	FApiGearConnectionSetting* ConnectionSetting = ApiGearSettings->Connections.Find(TbSame2Settings->TracerServiceIdentifier);
 
 	// Other protocols not supported. To support it edit templates:
 	// add protocol handler class for this interface like createTbSame2SameEnum1InterfaceOLink and other necessary infrastructure
@@ -404,13 +404,13 @@ TScriptInterface<ITbSame2SameEnum2InterfaceInterface> FTbSame2ModuleFactory::cre
 {
 	UTbSame2Settings* TbSame2Settings = GetMutableDefault<UTbSame2Settings>();
 
-	if (TbSame2Settings->ConnectionIdentifier == "Local")
+	if (TbSame2Settings->TracerServiceIdentifier == "Local")
 	{
 		return createTbSame2SameEnum2Interface(GameInstance, Collection);
 	}
 
 	UApiGearSettings* ApiGearSettings = GetMutableDefault<UApiGearSettings>();
-	FApiGearConnectionSetting* ConnectionSetting = ApiGearSettings->Connections.Find(TbSame2Settings->ConnectionIdentifier);
+	FApiGearConnectionSetting* ConnectionSetting = ApiGearSettings->Connections.Find(TbSame2Settings->TracerServiceIdentifier);
 
 	// Other protocols not supported. To support it edit templates:
 	// add protocol handler class for this interface like createTbSame2SameEnum2InterfaceOLink and other necessary infrastructure
@@ -452,13 +452,13 @@ TScriptInterface<ITbSame2SameEnum2InterfaceInterface> FTbSame2ModuleFactory::cre
 {
 	UTbSame2Settings* TbSame2Settings = GetMutableDefault<UTbSame2Settings>();
 
-	if (TbSame2Settings->ConnectionIdentifier == "Local")
+	if (TbSame2Settings->TracerServiceIdentifier == "Local")
 	{
 		return createTbSame2SameEnum2Interface(Collection);
 	}
 
 	UApiGearSettings* ApiGearSettings = GetMutableDefault<UApiGearSettings>();
-	FApiGearConnectionSetting* ConnectionSetting = ApiGearSettings->Connections.Find(TbSame2Settings->ConnectionIdentifier);
+	FApiGearConnectionSetting* ConnectionSetting = ApiGearSettings->Connections.Find(TbSame2Settings->TracerServiceIdentifier);
 
 	// Other protocols not supported. To support it edit templates:
 	// add protocol handler class for this interface like createTbSame2SameEnum2InterfaceOLink and other necessary infrastructure

--- a/goldenmaster/Plugins/TbSame2/Source/TbSame2/Private/Generated/Monitor/TbSame2Factory.cpp
+++ b/goldenmaster/Plugins/TbSame2/Source/TbSame2/Private/Generated/Monitor/TbSame2Factory.cpp
@@ -17,6 +17,7 @@ limitations under the License.
 
 #include "TbSame2Factory.h"
 #include "ApiGearSettings.h"
+#include "TbSame2Settings.h"
 #include "Implementation/TbSame2SameStruct1Interface.h"
 #include "Generated/OLink/TbSame2SameStruct1InterfaceOLinkClient.h"
 #include "Implementation/TbSame2SameStruct2Interface.h"
@@ -80,7 +81,7 @@ TScriptInterface<ITbSame2SameStruct1InterfaceInterface> FTbSame2ModuleFactory::c
 {
 	UTbSame2Settings* TbSame2Settings = GetMutableDefault<UTbSame2Settings>();
 
-	if (TbSame2Settings->TracerServiceIdentifier == "Local")
+	if (TbSame2Settings->TracerServiceIdentifier == TbSame2LocalBackendIdentifier)
 	{
 		return createTbSame2SameStruct1Interface(GameInstance, Collection);
 	}
@@ -128,7 +129,7 @@ TScriptInterface<ITbSame2SameStruct1InterfaceInterface> FTbSame2ModuleFactory::c
 {
 	UTbSame2Settings* TbSame2Settings = GetMutableDefault<UTbSame2Settings>();
 
-	if (TbSame2Settings->TracerServiceIdentifier == "Local")
+	if (TbSame2Settings->TracerServiceIdentifier == TbSame2LocalBackendIdentifier)
 	{
 		return createTbSame2SameStruct1Interface(Collection);
 	}
@@ -188,7 +189,7 @@ TScriptInterface<ITbSame2SameStruct2InterfaceInterface> FTbSame2ModuleFactory::c
 {
 	UTbSame2Settings* TbSame2Settings = GetMutableDefault<UTbSame2Settings>();
 
-	if (TbSame2Settings->TracerServiceIdentifier == "Local")
+	if (TbSame2Settings->TracerServiceIdentifier == TbSame2LocalBackendIdentifier)
 	{
 		return createTbSame2SameStruct2Interface(GameInstance, Collection);
 	}
@@ -236,7 +237,7 @@ TScriptInterface<ITbSame2SameStruct2InterfaceInterface> FTbSame2ModuleFactory::c
 {
 	UTbSame2Settings* TbSame2Settings = GetMutableDefault<UTbSame2Settings>();
 
-	if (TbSame2Settings->TracerServiceIdentifier == "Local")
+	if (TbSame2Settings->TracerServiceIdentifier == TbSame2LocalBackendIdentifier)
 	{
 		return createTbSame2SameStruct2Interface(Collection);
 	}
@@ -296,7 +297,7 @@ TScriptInterface<ITbSame2SameEnum1InterfaceInterface> FTbSame2ModuleFactory::cre
 {
 	UTbSame2Settings* TbSame2Settings = GetMutableDefault<UTbSame2Settings>();
 
-	if (TbSame2Settings->TracerServiceIdentifier == "Local")
+	if (TbSame2Settings->TracerServiceIdentifier == TbSame2LocalBackendIdentifier)
 	{
 		return createTbSame2SameEnum1Interface(GameInstance, Collection);
 	}
@@ -344,7 +345,7 @@ TScriptInterface<ITbSame2SameEnum1InterfaceInterface> FTbSame2ModuleFactory::cre
 {
 	UTbSame2Settings* TbSame2Settings = GetMutableDefault<UTbSame2Settings>();
 
-	if (TbSame2Settings->TracerServiceIdentifier == "Local")
+	if (TbSame2Settings->TracerServiceIdentifier == TbSame2LocalBackendIdentifier)
 	{
 		return createTbSame2SameEnum1Interface(Collection);
 	}
@@ -404,7 +405,7 @@ TScriptInterface<ITbSame2SameEnum2InterfaceInterface> FTbSame2ModuleFactory::cre
 {
 	UTbSame2Settings* TbSame2Settings = GetMutableDefault<UTbSame2Settings>();
 
-	if (TbSame2Settings->TracerServiceIdentifier == "Local")
+	if (TbSame2Settings->TracerServiceIdentifier == TbSame2LocalBackendIdentifier)
 	{
 		return createTbSame2SameEnum2Interface(GameInstance, Collection);
 	}
@@ -452,7 +453,7 @@ TScriptInterface<ITbSame2SameEnum2InterfaceInterface> FTbSame2ModuleFactory::cre
 {
 	UTbSame2Settings* TbSame2Settings = GetMutableDefault<UTbSame2Settings>();
 
-	if (TbSame2Settings->TracerServiceIdentifier == "Local")
+	if (TbSame2Settings->TracerServiceIdentifier == TbSame2LocalBackendIdentifier)
 	{
 		return createTbSame2SameEnum2Interface(Collection);
 	}

--- a/goldenmaster/Plugins/TbSame2/Source/TbSame2/Private/Generated/Monitor/TbSame2Factory.cpp
+++ b/goldenmaster/Plugins/TbSame2/Source/TbSame2/Private/Generated/Monitor/TbSame2Factory.cpp
@@ -17,6 +17,7 @@ limitations under the License.
 
 #include "TbSame2Factory.h"
 #include "ApiGearSettings.h"
+#include "apigearolink.h"
 #include "TbSame2Settings.h"
 #include "Implementation/TbSame2SameStruct1Interface.h"
 #include "Generated/OLink/TbSame2SameStruct1InterfaceOLinkClient.h"
@@ -92,7 +93,7 @@ TScriptInterface<ITbSame2SameStruct1InterfaceInterface> FTbSame2ModuleFactory::c
 	// Other protocols not supported. To support it edit templates:
 	// add protocol handler class for this interface like createTbSame2SameStruct1InterfaceOLink and other necessary infrastructure
 	// extend this function in templates to handle protocol of your choice
-	if (ConnectionSetting && ConnectionSetting->ProtocolIdentifier == "olink")
+	if (ConnectionSetting && ConnectionSetting->ProtocolIdentifier == ApiGearOLinkProtocolIdentifier)
 	{
 		return createTbSame2SameStruct1InterfaceOLink(GameInstance, Collection);
 	}
@@ -140,7 +141,7 @@ TScriptInterface<ITbSame2SameStruct1InterfaceInterface> FTbSame2ModuleFactory::c
 	// Other protocols not supported. To support it edit templates:
 	// add protocol handler class for this interface like createTbSame2SameStruct1InterfaceOLink and other necessary infrastructure
 	// extend this function in templates to handle protocol of your choice
-	if (ConnectionSetting && ConnectionSetting->ProtocolIdentifier == "olink")
+	if (ConnectionSetting && ConnectionSetting->ProtocolIdentifier == ApiGearOLinkProtocolIdentifier)
 	{
 		return createTbSame2SameStruct1InterfaceOLink(Collection);
 	}
@@ -200,7 +201,7 @@ TScriptInterface<ITbSame2SameStruct2InterfaceInterface> FTbSame2ModuleFactory::c
 	// Other protocols not supported. To support it edit templates:
 	// add protocol handler class for this interface like createTbSame2SameStruct2InterfaceOLink and other necessary infrastructure
 	// extend this function in templates to handle protocol of your choice
-	if (ConnectionSetting && ConnectionSetting->ProtocolIdentifier == "olink")
+	if (ConnectionSetting && ConnectionSetting->ProtocolIdentifier == ApiGearOLinkProtocolIdentifier)
 	{
 		return createTbSame2SameStruct2InterfaceOLink(GameInstance, Collection);
 	}
@@ -248,7 +249,7 @@ TScriptInterface<ITbSame2SameStruct2InterfaceInterface> FTbSame2ModuleFactory::c
 	// Other protocols not supported. To support it edit templates:
 	// add protocol handler class for this interface like createTbSame2SameStruct2InterfaceOLink and other necessary infrastructure
 	// extend this function in templates to handle protocol of your choice
-	if (ConnectionSetting && ConnectionSetting->ProtocolIdentifier == "olink")
+	if (ConnectionSetting && ConnectionSetting->ProtocolIdentifier == ApiGearOLinkProtocolIdentifier)
 	{
 		return createTbSame2SameStruct2InterfaceOLink(Collection);
 	}
@@ -308,7 +309,7 @@ TScriptInterface<ITbSame2SameEnum1InterfaceInterface> FTbSame2ModuleFactory::cre
 	// Other protocols not supported. To support it edit templates:
 	// add protocol handler class for this interface like createTbSame2SameEnum1InterfaceOLink and other necessary infrastructure
 	// extend this function in templates to handle protocol of your choice
-	if (ConnectionSetting && ConnectionSetting->ProtocolIdentifier == "olink")
+	if (ConnectionSetting && ConnectionSetting->ProtocolIdentifier == ApiGearOLinkProtocolIdentifier)
 	{
 		return createTbSame2SameEnum1InterfaceOLink(GameInstance, Collection);
 	}
@@ -356,7 +357,7 @@ TScriptInterface<ITbSame2SameEnum1InterfaceInterface> FTbSame2ModuleFactory::cre
 	// Other protocols not supported. To support it edit templates:
 	// add protocol handler class for this interface like createTbSame2SameEnum1InterfaceOLink and other necessary infrastructure
 	// extend this function in templates to handle protocol of your choice
-	if (ConnectionSetting && ConnectionSetting->ProtocolIdentifier == "olink")
+	if (ConnectionSetting && ConnectionSetting->ProtocolIdentifier == ApiGearOLinkProtocolIdentifier)
 	{
 		return createTbSame2SameEnum1InterfaceOLink(Collection);
 	}
@@ -416,7 +417,7 @@ TScriptInterface<ITbSame2SameEnum2InterfaceInterface> FTbSame2ModuleFactory::cre
 	// Other protocols not supported. To support it edit templates:
 	// add protocol handler class for this interface like createTbSame2SameEnum2InterfaceOLink and other necessary infrastructure
 	// extend this function in templates to handle protocol of your choice
-	if (ConnectionSetting && ConnectionSetting->ProtocolIdentifier == "olink")
+	if (ConnectionSetting && ConnectionSetting->ProtocolIdentifier == ApiGearOLinkProtocolIdentifier)
 	{
 		return createTbSame2SameEnum2InterfaceOLink(GameInstance, Collection);
 	}
@@ -464,7 +465,7 @@ TScriptInterface<ITbSame2SameEnum2InterfaceInterface> FTbSame2ModuleFactory::cre
 	// Other protocols not supported. To support it edit templates:
 	// add protocol handler class for this interface like createTbSame2SameEnum2InterfaceOLink and other necessary infrastructure
 	// extend this function in templates to handle protocol of your choice
-	if (ConnectionSetting && ConnectionSetting->ProtocolIdentifier == "olink")
+	if (ConnectionSetting && ConnectionSetting->ProtocolIdentifier == ApiGearOLinkProtocolIdentifier)
 	{
 		return createTbSame2SameEnum2InterfaceOLink(Collection);
 	}

--- a/goldenmaster/Plugins/TbSame2/Source/TbSame2/Private/Generated/OLink/TbSame2SameEnum1InterfaceOLinkClient.cpp
+++ b/goldenmaster/Plugins/TbSame2/Source/TbSame2/Private/Generated/OLink/TbSame2SameEnum1InterfaceOLinkClient.cpp
@@ -171,7 +171,17 @@ ETbSame2Enum1 UTbSame2SameEnum1InterfaceOLinkClient::Func1_Implementation(ETbSam
 		[Param1, &Promise, this]()
 		{
 			ApiGear::ObjectLink::InvokeReplyFunc GetSameEnum1InterfaceStateFunc = [&Promise](ApiGear::ObjectLink::InvokeReplyArg arg)
-			{ Promise.SetValue(arg.value.get<ETbSame2Enum1>()); };
+			{
+				if (!arg.value.empty())
+				{
+					Promise.SetValue(arg.value.get<ETbSame2Enum1>());
+				}
+				else
+				{
+					UE_LOG(LogTbSame2SameEnum1InterfaceOLinkClient, Error, TEXT("Func1: OLink service returned empty value - should have returned type of ETbSame2Enum1"));
+					Promise.SetValue(ETbSame2Enum1());
+				}
+			};
 			static const auto memberId = ApiGear::ObjectLink::Name::createMemberId(m_sink->olinkObjectName(), "func1");
 			m_sink->GetNode()->invokeRemote(memberId, {Param1}, GetSameEnum1InterfaceStateFunc);
 		});

--- a/goldenmaster/Plugins/TbSame2/Source/TbSame2/Private/Generated/OLink/TbSame2SameEnum1InterfaceOLinkClient.cpp
+++ b/goldenmaster/Plugins/TbSame2/Source/TbSame2/Private/Generated/OLink/TbSame2SameEnum1InterfaceOLinkClient.cpp
@@ -22,6 +22,7 @@ limitations under the License.
 
 #include "Generated/OLink/TbSame2SameEnum1InterfaceOLinkClient.h"
 #include "ApiGearSettings.h"
+#include "apigearolink.h"
 #include "Async/Async.h"
 #include "Generated/api/TbSame2.json.adapter.h"
 #include "unrealolink.h"
@@ -114,7 +115,7 @@ void UTbSame2SameEnum1InterfaceOLinkClient::UseConnection(TScriptInterface<IApiG
 	checkf(InConnection.GetInterface() != nullptr, TEXT("Cannot use connection - interface IApiGearConnection is not fully implemented"));
 
 	// only accept connections of type olink
-	checkf(InConnection->GetConnectionProtocolIdentifier() == "olink", TEXT("Cannot use connection - must be of type olink"));
+	checkf(InConnection->GetConnectionProtocolIdentifier() == ApiGearOLinkProtocolIdentifier, TEXT("Cannot use connection - must be of type olink"));
 
 	UUnrealOLink* UnrealOLinkConnection = nullptr;
 	// remove old connection

--- a/goldenmaster/Plugins/TbSame2/Source/TbSame2/Private/Generated/OLink/TbSame2SameEnum1InterfaceOLinkClient.cpp
+++ b/goldenmaster/Plugins/TbSame2/Source/TbSame2/Private/Generated/OLink/TbSame2SameEnum1InterfaceOLinkClient.cpp
@@ -82,8 +82,13 @@ void UTbSame2SameEnum1InterfaceOLinkClient::Initialize(FSubsystemCollectionBase&
 
 	UApiGearConnectionsStore* AGCM = GEngine->GetEngineSubsystem<UApiGearConnectionsStore>();
 
-	TScriptInterface<IApiGearConnection> OLinkConnection = AGCM->GetConnection(settings->ConnectionIdentifier);
+	TScriptInterface<IApiGearConnection> OLinkConnection = AGCM->GetConnection(settings->OLinkConnectionIdentifier);
 
+	if (!OLinkConnection.GetInterface())
+	{
+		UE_LOG(LogTbSame2SameEnum1InterfaceOLinkClient, Log, TEXT("No valid olink connection for %s, please set during run time"), UTF8_TO_TCHAR(m_sink->olinkObjectName().c_str()));
+		return;
+	}
 	UseConnection(OLinkConnection);
 	OLinkConnection->Connect();
 }

--- a/goldenmaster/Plugins/TbSame2/Source/TbSame2/Private/Generated/OLink/TbSame2SameEnum2InterfaceOLinkClient.cpp
+++ b/goldenmaster/Plugins/TbSame2/Source/TbSame2/Private/Generated/OLink/TbSame2SameEnum2InterfaceOLinkClient.cpp
@@ -22,6 +22,7 @@ limitations under the License.
 
 #include "Generated/OLink/TbSame2SameEnum2InterfaceOLinkClient.h"
 #include "ApiGearSettings.h"
+#include "apigearolink.h"
 #include "Async/Async.h"
 #include "Generated/api/TbSame2.json.adapter.h"
 #include "unrealolink.h"
@@ -115,7 +116,7 @@ void UTbSame2SameEnum2InterfaceOLinkClient::UseConnection(TScriptInterface<IApiG
 	checkf(InConnection.GetInterface() != nullptr, TEXT("Cannot use connection - interface IApiGearConnection is not fully implemented"));
 
 	// only accept connections of type olink
-	checkf(InConnection->GetConnectionProtocolIdentifier() == "olink", TEXT("Cannot use connection - must be of type olink"));
+	checkf(InConnection->GetConnectionProtocolIdentifier() == ApiGearOLinkProtocolIdentifier, TEXT("Cannot use connection - must be of type olink"));
 
 	UUnrealOLink* UnrealOLinkConnection = nullptr;
 	// remove old connection

--- a/goldenmaster/Plugins/TbSame2/Source/TbSame2/Private/Generated/OLink/TbSame2SameEnum2InterfaceOLinkClient.cpp
+++ b/goldenmaster/Plugins/TbSame2/Source/TbSame2/Private/Generated/OLink/TbSame2SameEnum2InterfaceOLinkClient.cpp
@@ -201,7 +201,17 @@ ETbSame2Enum1 UTbSame2SameEnum2InterfaceOLinkClient::Func1_Implementation(ETbSam
 		[Param1, &Promise, this]()
 		{
 			ApiGear::ObjectLink::InvokeReplyFunc GetSameEnum2InterfaceStateFunc = [&Promise](ApiGear::ObjectLink::InvokeReplyArg arg)
-			{ Promise.SetValue(arg.value.get<ETbSame2Enum1>()); };
+			{
+				if (!arg.value.empty())
+				{
+					Promise.SetValue(arg.value.get<ETbSame2Enum1>());
+				}
+				else
+				{
+					UE_LOG(LogTbSame2SameEnum2InterfaceOLinkClient, Error, TEXT("Func1: OLink service returned empty value - should have returned type of ETbSame2Enum1"));
+					Promise.SetValue(ETbSame2Enum1());
+				}
+			};
 			static const auto memberId = ApiGear::ObjectLink::Name::createMemberId(m_sink->olinkObjectName(), "func1");
 			m_sink->GetNode()->invokeRemote(memberId, {Param1}, GetSameEnum2InterfaceStateFunc);
 		});
@@ -222,7 +232,17 @@ ETbSame2Enum1 UTbSame2SameEnum2InterfaceOLinkClient::Func2_Implementation(ETbSam
 		[Param1, Param2, &Promise, this]()
 		{
 			ApiGear::ObjectLink::InvokeReplyFunc GetSameEnum2InterfaceStateFunc = [&Promise](ApiGear::ObjectLink::InvokeReplyArg arg)
-			{ Promise.SetValue(arg.value.get<ETbSame2Enum1>()); };
+			{
+				if (!arg.value.empty())
+				{
+					Promise.SetValue(arg.value.get<ETbSame2Enum1>());
+				}
+				else
+				{
+					UE_LOG(LogTbSame2SameEnum2InterfaceOLinkClient, Error, TEXT("Func2: OLink service returned empty value - should have returned type of ETbSame2Enum1"));
+					Promise.SetValue(ETbSame2Enum1());
+				}
+			};
 			static const auto memberId = ApiGear::ObjectLink::Name::createMemberId(m_sink->olinkObjectName(), "func2");
 			m_sink->GetNode()->invokeRemote(memberId, {Param1, Param2}, GetSameEnum2InterfaceStateFunc);
 		});

--- a/goldenmaster/Plugins/TbSame2/Source/TbSame2/Private/Generated/OLink/TbSame2SameEnum2InterfaceOLinkClient.cpp
+++ b/goldenmaster/Plugins/TbSame2/Source/TbSame2/Private/Generated/OLink/TbSame2SameEnum2InterfaceOLinkClient.cpp
@@ -83,8 +83,13 @@ void UTbSame2SameEnum2InterfaceOLinkClient::Initialize(FSubsystemCollectionBase&
 
 	UApiGearConnectionsStore* AGCM = GEngine->GetEngineSubsystem<UApiGearConnectionsStore>();
 
-	TScriptInterface<IApiGearConnection> OLinkConnection = AGCM->GetConnection(settings->ConnectionIdentifier);
+	TScriptInterface<IApiGearConnection> OLinkConnection = AGCM->GetConnection(settings->OLinkConnectionIdentifier);
 
+	if (!OLinkConnection.GetInterface())
+	{
+		UE_LOG(LogTbSame2SameEnum2InterfaceOLinkClient, Log, TEXT("No valid olink connection for %s, please set during run time"), UTF8_TO_TCHAR(m_sink->olinkObjectName().c_str()));
+		return;
+	}
 	UseConnection(OLinkConnection);
 	OLinkConnection->Connect();
 }

--- a/goldenmaster/Plugins/TbSame2/Source/TbSame2/Private/Generated/OLink/TbSame2SameStruct1InterfaceOLinkClient.cpp
+++ b/goldenmaster/Plugins/TbSame2/Source/TbSame2/Private/Generated/OLink/TbSame2SameStruct1InterfaceOLinkClient.cpp
@@ -22,6 +22,7 @@ limitations under the License.
 
 #include "Generated/OLink/TbSame2SameStruct1InterfaceOLinkClient.h"
 #include "ApiGearSettings.h"
+#include "apigearolink.h"
 #include "Async/Async.h"
 #include "Generated/api/TbSame2.json.adapter.h"
 #include "unrealolink.h"
@@ -114,7 +115,7 @@ void UTbSame2SameStruct1InterfaceOLinkClient::UseConnection(TScriptInterface<IAp
 	checkf(InConnection.GetInterface() != nullptr, TEXT("Cannot use connection - interface IApiGearConnection is not fully implemented"));
 
 	// only accept connections of type olink
-	checkf(InConnection->GetConnectionProtocolIdentifier() == "olink", TEXT("Cannot use connection - must be of type olink"));
+	checkf(InConnection->GetConnectionProtocolIdentifier() == ApiGearOLinkProtocolIdentifier, TEXT("Cannot use connection - must be of type olink"));
 
 	UUnrealOLink* UnrealOLinkConnection = nullptr;
 	// remove old connection

--- a/goldenmaster/Plugins/TbSame2/Source/TbSame2/Private/Generated/OLink/TbSame2SameStruct1InterfaceOLinkClient.cpp
+++ b/goldenmaster/Plugins/TbSame2/Source/TbSame2/Private/Generated/OLink/TbSame2SameStruct1InterfaceOLinkClient.cpp
@@ -82,8 +82,13 @@ void UTbSame2SameStruct1InterfaceOLinkClient::Initialize(FSubsystemCollectionBas
 
 	UApiGearConnectionsStore* AGCM = GEngine->GetEngineSubsystem<UApiGearConnectionsStore>();
 
-	TScriptInterface<IApiGearConnection> OLinkConnection = AGCM->GetConnection(settings->ConnectionIdentifier);
+	TScriptInterface<IApiGearConnection> OLinkConnection = AGCM->GetConnection(settings->OLinkConnectionIdentifier);
 
+	if (!OLinkConnection.GetInterface())
+	{
+		UE_LOG(LogTbSame2SameStruct1InterfaceOLinkClient, Log, TEXT("No valid olink connection for %s, please set during run time"), UTF8_TO_TCHAR(m_sink->olinkObjectName().c_str()));
+		return;
+	}
 	UseConnection(OLinkConnection);
 	OLinkConnection->Connect();
 }

--- a/goldenmaster/Plugins/TbSame2/Source/TbSame2/Private/Generated/OLink/TbSame2SameStruct1InterfaceOLinkClient.cpp
+++ b/goldenmaster/Plugins/TbSame2/Source/TbSame2/Private/Generated/OLink/TbSame2SameStruct1InterfaceOLinkClient.cpp
@@ -171,7 +171,17 @@ FTbSame2Struct1 UTbSame2SameStruct1InterfaceOLinkClient::Func1_Implementation(co
 		[Param1, &Promise, this]()
 		{
 			ApiGear::ObjectLink::InvokeReplyFunc GetSameStruct1InterfaceStateFunc = [&Promise](ApiGear::ObjectLink::InvokeReplyArg arg)
-			{ Promise.SetValue(arg.value.get<FTbSame2Struct1>()); };
+			{
+				if (!arg.value.empty())
+				{
+					Promise.SetValue(arg.value.get<FTbSame2Struct1>());
+				}
+				else
+				{
+					UE_LOG(LogTbSame2SameStruct1InterfaceOLinkClient, Error, TEXT("Func1: OLink service returned empty value - should have returned type of FTbSame2Struct1"));
+					Promise.SetValue(FTbSame2Struct1());
+				}
+			};
 			static const auto memberId = ApiGear::ObjectLink::Name::createMemberId(m_sink->olinkObjectName(), "func1");
 			m_sink->GetNode()->invokeRemote(memberId, {Param1}, GetSameStruct1InterfaceStateFunc);
 		});

--- a/goldenmaster/Plugins/TbSame2/Source/TbSame2/Private/Generated/OLink/TbSame2SameStruct2InterfaceOLinkClient.cpp
+++ b/goldenmaster/Plugins/TbSame2/Source/TbSame2/Private/Generated/OLink/TbSame2SameStruct2InterfaceOLinkClient.cpp
@@ -22,6 +22,7 @@ limitations under the License.
 
 #include "Generated/OLink/TbSame2SameStruct2InterfaceOLinkClient.h"
 #include "ApiGearSettings.h"
+#include "apigearolink.h"
 #include "Async/Async.h"
 #include "Generated/api/TbSame2.json.adapter.h"
 #include "unrealolink.h"
@@ -115,7 +116,7 @@ void UTbSame2SameStruct2InterfaceOLinkClient::UseConnection(TScriptInterface<IAp
 	checkf(InConnection.GetInterface() != nullptr, TEXT("Cannot use connection - interface IApiGearConnection is not fully implemented"));
 
 	// only accept connections of type olink
-	checkf(InConnection->GetConnectionProtocolIdentifier() == "olink", TEXT("Cannot use connection - must be of type olink"));
+	checkf(InConnection->GetConnectionProtocolIdentifier() == ApiGearOLinkProtocolIdentifier, TEXT("Cannot use connection - must be of type olink"));
 
 	UUnrealOLink* UnrealOLinkConnection = nullptr;
 	// remove old connection

--- a/goldenmaster/Plugins/TbSame2/Source/TbSame2/Private/Generated/OLink/TbSame2SameStruct2InterfaceOLinkClient.cpp
+++ b/goldenmaster/Plugins/TbSame2/Source/TbSame2/Private/Generated/OLink/TbSame2SameStruct2InterfaceOLinkClient.cpp
@@ -83,8 +83,13 @@ void UTbSame2SameStruct2InterfaceOLinkClient::Initialize(FSubsystemCollectionBas
 
 	UApiGearConnectionsStore* AGCM = GEngine->GetEngineSubsystem<UApiGearConnectionsStore>();
 
-	TScriptInterface<IApiGearConnection> OLinkConnection = AGCM->GetConnection(settings->ConnectionIdentifier);
+	TScriptInterface<IApiGearConnection> OLinkConnection = AGCM->GetConnection(settings->OLinkConnectionIdentifier);
 
+	if (!OLinkConnection.GetInterface())
+	{
+		UE_LOG(LogTbSame2SameStruct2InterfaceOLinkClient, Log, TEXT("No valid olink connection for %s, please set during run time"), UTF8_TO_TCHAR(m_sink->olinkObjectName().c_str()));
+		return;
+	}
 	UseConnection(OLinkConnection);
 	OLinkConnection->Connect();
 }

--- a/goldenmaster/Plugins/TbSame2/Source/TbSame2/Private/Generated/OLink/TbSame2SameStruct2InterfaceOLinkClient.cpp
+++ b/goldenmaster/Plugins/TbSame2/Source/TbSame2/Private/Generated/OLink/TbSame2SameStruct2InterfaceOLinkClient.cpp
@@ -201,7 +201,17 @@ FTbSame2Struct1 UTbSame2SameStruct2InterfaceOLinkClient::Func1_Implementation(co
 		[Param1, &Promise, this]()
 		{
 			ApiGear::ObjectLink::InvokeReplyFunc GetSameStruct2InterfaceStateFunc = [&Promise](ApiGear::ObjectLink::InvokeReplyArg arg)
-			{ Promise.SetValue(arg.value.get<FTbSame2Struct1>()); };
+			{
+				if (!arg.value.empty())
+				{
+					Promise.SetValue(arg.value.get<FTbSame2Struct1>());
+				}
+				else
+				{
+					UE_LOG(LogTbSame2SameStruct2InterfaceOLinkClient, Error, TEXT("Func1: OLink service returned empty value - should have returned type of FTbSame2Struct1"));
+					Promise.SetValue(FTbSame2Struct1());
+				}
+			};
 			static const auto memberId = ApiGear::ObjectLink::Name::createMemberId(m_sink->olinkObjectName(), "func1");
 			m_sink->GetNode()->invokeRemote(memberId, {Param1}, GetSameStruct2InterfaceStateFunc);
 		});
@@ -222,7 +232,17 @@ FTbSame2Struct1 UTbSame2SameStruct2InterfaceOLinkClient::Func2_Implementation(co
 		[Param1, Param2, &Promise, this]()
 		{
 			ApiGear::ObjectLink::InvokeReplyFunc GetSameStruct2InterfaceStateFunc = [&Promise](ApiGear::ObjectLink::InvokeReplyArg arg)
-			{ Promise.SetValue(arg.value.get<FTbSame2Struct1>()); };
+			{
+				if (!arg.value.empty())
+				{
+					Promise.SetValue(arg.value.get<FTbSame2Struct1>());
+				}
+				else
+				{
+					UE_LOG(LogTbSame2SameStruct2InterfaceOLinkClient, Error, TEXT("Func2: OLink service returned empty value - should have returned type of FTbSame2Struct1"));
+					Promise.SetValue(FTbSame2Struct1());
+				}
+			};
 			static const auto memberId = ApiGear::ObjectLink::Name::createMemberId(m_sink->olinkObjectName(), "func2");
 			m_sink->GetNode()->invokeRemote(memberId, {Param1, Param2}, GetSameStruct2InterfaceStateFunc);
 		});

--- a/goldenmaster/Plugins/TbSame2/Source/TbSame2/Private/TbSame2Settings.cpp
+++ b/goldenmaster/Plugins/TbSame2/Source/TbSame2/Private/TbSame2Settings.cpp
@@ -37,7 +37,7 @@ void UTbSame2Settings::PostInitProperties()
 	}
 
 	// the local backend does not require configuration
-	if (TracerServiceIdentifier == "Local")
+	if (TracerServiceIdentifier == TbSame2LocalBackendIdentifier)
 	{
 		return;
 	}
@@ -45,6 +45,6 @@ void UTbSame2Settings::PostInitProperties()
 	if (!AGCM->DoesConnectionExist(TracerServiceIdentifier))
 	{
 		UE_LOG(LogTemp, Warning, TEXT("UTbSame2Settings could not find connection %s, falling back to local backend."), *TracerServiceIdentifier);
-		TracerServiceIdentifier = "Local";
+		TracerServiceIdentifier = TbSame2LocalBackendIdentifier;
 	}
 }

--- a/goldenmaster/Plugins/TbSame2/Source/TbSame2/Private/TbSame2Settings.cpp
+++ b/goldenmaster/Plugins/TbSame2/Source/TbSame2/Private/TbSame2Settings.cpp
@@ -27,18 +27,24 @@ void UTbSame2Settings::PostInitProperties()
 {
 	Super::PostInitProperties();
 
+	check(GEngine);
+	UApiGearConnectionsStore* AGCM = GEngine->GetEngineSubsystem<UApiGearConnectionsStore>();
+
+	if (!AGCM->DoesConnectionExist(OLinkConnectionIdentifier))
+	{
+		UE_LOG(LogTemp, Warning, TEXT("UTbSame2Settings could not find connection %s."), *OLinkConnectionIdentifier);
+		OLinkConnectionIdentifier = "";
+	}
+
 	// the local backend does not require configuration
-	if (ConnectionIdentifier == "Local")
+	if (TracerServiceIdentifier == "Local")
 	{
 		return;
 	}
 
-	check(GEngine);
-	UApiGearConnectionsStore* AGCM = GEngine->GetEngineSubsystem<UApiGearConnectionsStore>();
-
-	if (!AGCM->DoesConnectionExist(ConnectionIdentifier))
+	if (!AGCM->DoesConnectionExist(TracerServiceIdentifier))
 	{
-		UE_LOG(LogTemp, Warning, TEXT("UTbSame2Settings could not find connection %s, falling back to local backend."), *ConnectionIdentifier);
-		ConnectionIdentifier = "Local";
+		UE_LOG(LogTemp, Warning, TEXT("UTbSame2Settings could not find connection %s, falling back to local backend."), *TracerServiceIdentifier);
+		TracerServiceIdentifier = "Local";
 	}
 }

--- a/goldenmaster/Plugins/TbSame2/Source/TbSame2/Public/TbSame2Settings.h
+++ b/goldenmaster/Plugins/TbSame2/Source/TbSame2/Public/TbSame2Settings.h
@@ -33,6 +33,10 @@ class TBSAME2_API UTbSame2Settings : public UObject
 	virtual void PostInitProperties() override;
 
 	// Choose the backend service for the logging decorator to use
-	UPROPERTY(EditAnywhere, config, Category = ServiceSetup)
-	FString ConnectionIdentifier;
+	UPROPERTY(EditAnywhere, config, Category = TracerServiceSetup)
+	FString TracerServiceIdentifier;
+
+	// Choose the olink connection to use
+	UPROPERTY(EditAnywhere, config, Category = OLinkConnectionSetup)
+	FString OLinkConnectionIdentifier;
 };

--- a/goldenmaster/Plugins/TbSame2/Source/TbSame2/Public/TbSame2Settings.h
+++ b/goldenmaster/Plugins/TbSame2/Source/TbSame2/Public/TbSame2Settings.h
@@ -22,6 +22,8 @@ limitations under the License.
 #include "Engine/EngineTypes.h"
 #include "TbSame2Settings.generated.h"
 
+const FString TbSame2LocalBackendIdentifier = "Local";
+
 /**
  * Implements the settings for the TbSame2 plugin.
  */

--- a/goldenmaster/Plugins/TbSame2/Source/TbSame2Editor/Private/TbSame2ConnectionSettings.cpp
+++ b/goldenmaster/Plugins/TbSame2/Source/TbSame2Editor/Private/TbSame2ConnectionSettings.cpp
@@ -2,6 +2,7 @@
 #include "TbSame2ConnectionSettings.h"
 
 #include "ApiGearSettings.h"
+#include "apigearolink.h"
 #include "TbSame2Settings.h"
 #include "Templates/SharedPointer.h"
 #include "IDetailCustomization.h"
@@ -106,7 +107,7 @@ TSharedRef<SWidget> FTbSame2ConnectionSettingsDetails::MakeDefaultOLinkConnectio
 
 	for (auto ConnectionSetting : settings->Connections)
 	{
-		if (ConnectionSetting.Value.ProtocolIdentifier == "olink")
+		if (ConnectionSetting.Value.ProtocolIdentifier == ApiGearOLinkProtocolIdentifier)
 		{
 			TSharedPtr<FText> ConnectionName = MakeShared<FText>(FText::FromString(*ConnectionSetting.Key));
 			AvailableOLinkConnectionNames->Add(ConnectionName);

--- a/goldenmaster/Plugins/TbSame2/Source/TbSame2Editor/Private/TbSame2ConnectionSettings.cpp
+++ b/goldenmaster/Plugins/TbSame2/Source/TbSame2Editor/Private/TbSame2ConnectionSettings.cpp
@@ -2,6 +2,7 @@
 #include "TbSame2ConnectionSettings.h"
 
 #include "ApiGearSettings.h"
+#include "TbSame2Settings.h"
 #include "Templates/SharedPointer.h"
 #include "IDetailCustomization.h"
 #include "PropertyHandle.h"
@@ -32,7 +33,7 @@ TSharedRef<SWidget> FTbSame2ConnectionSettingsDetails::MakeDefaultBackendService
 	TArray<TSharedPtr<FText>>* AvailableServicesNames = &AvailableServices;
 	FText TooltipText = FText::FromString(TEXT("Choose which service should be used as default."));
 
-	TSharedPtr<FText> LocalServiceName = TSharedPtr<FText>(new FText(FText::FromString(TEXT("Local"))));
+	TSharedPtr<FText> LocalServiceName = TSharedPtr<FText>(new FText(FText::FromString(TbSame2LocalBackendIdentifier)));
 	AvailableServicesNames->Add(LocalServiceName);
 	SelectedDefaultBackendService = LocalServiceName;
 

--- a/goldenmaster/Plugins/TbSame2/Source/TbSame2Editor/Private/TbSame2ConnectionSettings.cpp
+++ b/goldenmaster/Plugins/TbSame2/Source/TbSame2Editor/Private/TbSame2ConnectionSettings.cpp
@@ -24,33 +24,38 @@ TSharedRef<IDetailCustomization> FTbSame2ConnectionSettingsDetails::MakeInstance
 	return MakeShareable(new FTbSame2ConnectionSettingsDetails);
 }
 
-TSharedRef<SWidget> FTbSame2ConnectionSettingsDetails::MakeDefaultConnectionSelectorWidget(const TSharedPtr<IPropertyHandle>& PropertyHandle)
+TSharedRef<SWidget> FTbSame2ConnectionSettingsDetails::MakeDefaultBackendServiceSelectorWidget(const TSharedPtr<IPropertyHandle>& PropertyHandle)
 {
 	UApiGearSettings* settings = GetMutableDefault<UApiGearSettings>();
 	check(settings);
 
-	TArray<TSharedPtr<FText>>* AvailableConnectionNames = &AvailableConnections;
-	FText TooltipText = FText::FromString(TEXT("Choose which connection should be used as default. Please make sure to have at least one connection defined."));
+	TArray<TSharedPtr<FText>>* AvailableServicesNames = &AvailableServices;
+	FText TooltipText = FText::FromString(TEXT("Choose which service should be used as default."));
 
-	TSharedPtr<FText> DefaultEffectName = TSharedPtr<FText>(new FText(FText::FromString(TEXT("Local"))));
-	SelectedDefaultConnection = TSharedPtr<FText>(new FText(*DefaultEffectName));
-	PropertyHandle->GetValueAsDisplayText(*SelectedDefaultConnection);
+	TSharedPtr<FText> LocalServiceName = TSharedPtr<FText>(new FText(FText::FromString(TEXT("Local"))));
+	AvailableServicesNames->Add(LocalServiceName);
+	SelectedDefaultBackendService = LocalServiceName;
 
-	AvailableConnectionNames->Add(DefaultEffectName);
+	TSharedPtr<FText> CurrentServiceName = TSharedPtr<FText>(new FText(FText::GetEmpty()));
+	PropertyHandle->GetValueAsDisplayText(*CurrentServiceName);
+	if (!CurrentServiceName->EqualTo(FText::GetEmpty()))
+	{
+		SelectedDefaultBackendService = CurrentServiceName;
+	}
 
 	for (auto ConnectionSetting : settings->Connections)
 	{
-		AvailableConnectionNames->Add(MakeShared<FText>(FText::FromString(*ConnectionSetting.Key)));
+		AvailableServicesNames->Add(MakeShared<FText>(FText::FromString(*ConnectionSetting.Key)));
 	}
 
 	// clang-format off
 	// Text box component:
 	TSharedRef<STextBlock > EditableTextBox = SNew(STextBlock )
-		.Text_Lambda([this]() { return *SelectedDefaultConnection; });
+		.Text_Lambda([this]() { return *SelectedDefaultBackendService; });
 
 	// Combo box component:
 	TSharedRef<SWidget> ComboBox = SNew(SListView<TSharedPtr<FText>>)
-		.ListItemsSource(AvailableConnectionNames)
+		.ListItemsSource(AvailableServicesNames)
 		.OnGenerateRow_Lambda([](TSharedPtr<FText> InItem, const TSharedRef< class STableViewBase >& Owner)
 		{
 			return SNew(STableRow<TSharedPtr<FText>>, Owner)
@@ -61,7 +66,7 @@ TSharedRef<SWidget> FTbSame2ConnectionSettingsDetails::MakeDefaultConnectionSele
 		})
 		.OnSelectionChanged_Lambda([this, PropertyHandle](TSharedPtr<FText> InText, ESelectInfo::Type)
 		{
-			SelectedDefaultConnection = InText;
+			SelectedDefaultBackendService = InText;
 			PropertyHandle->SetValue(InText->ToString());
 		});
 
@@ -90,24 +95,133 @@ TSharedRef<SWidget> FTbSame2ConnectionSettingsDetails::MakeDefaultConnectionSele
 	return NewWidget;
 }
 
-void FTbSame2ConnectionSettingsDetails::CustomizeDetails(IDetailLayoutBuilder& DetailBuilder)
+TSharedRef<SWidget> FTbSame2ConnectionSettingsDetails::MakeDefaultOLinkConnectionSelectorWidget(const TSharedPtr<IPropertyHandle>& PropertyHandle)
 {
-	IDetailCategoryBuilder& ConnectionsCategory = DetailBuilder.EditCategory(TEXT("ServiceSetup"));
+	UApiGearSettings* settings = GetMutableDefault<UApiGearSettings>();
+	check(settings);
 
-	TSharedPtr<IPropertyHandle> ConnectionIdentifierPropertyHandle = DetailBuilder.GetProperty("ConnectionIdentifier", nullptr);
-	IDetailPropertyRow& DefaultConnectionIdentifierPropertyRow = ConnectionsCategory.AddProperty(ConnectionIdentifierPropertyHandle);
+	TArray<TSharedPtr<FText>>* AvailableOLinkConnectionNames = &AvailableOLinkConnections;
+	FText TooltipText = FText::FromString(TEXT("Choose which connection should be used as default. Please make sure to have at least one connection defined."));
+
+	for (auto ConnectionSetting : settings->Connections)
+	{
+		if (ConnectionSetting.Value.ProtocolIdentifier == "olink")
+		{
+			TSharedPtr<FText> ConnectionName = MakeShared<FText>(FText::FromString(*ConnectionSetting.Key));
+			AvailableOLinkConnectionNames->Add(ConnectionName);
+
+			if (!SelectedDefaultOLinkConnection)
+			{
+				SelectedDefaultOLinkConnection = ConnectionName;
+			}
+		}
+	}
+
+	TSharedPtr<FText> CurrentConnectionName = TSharedPtr<FText>(new FText(FText::GetEmpty()));
+	PropertyHandle->GetValueAsDisplayText(*CurrentConnectionName);
+	if (!CurrentConnectionName->EqualTo(FText::GetEmpty()))
+	{
+		SelectedDefaultOLinkConnection = CurrentConnectionName;
+	}
+
+	if (!SelectedDefaultOLinkConnection)
+	{
+		SelectedDefaultOLinkConnection = TSharedPtr<FText>(new FText(FText::FromString(TEXT("Please define a connection in the settings first!"))));
+	}
 
 	// clang-format off
-	DefaultConnectionIdentifierPropertyRow.CustomWidget()
+	// Text box component:
+	TSharedRef<STextBlock > EditableTextBox = SNew(STextBlock )
+		.Text_Lambda([this]() { return *SelectedDefaultOLinkConnection; });
+
+	// Combo box component:
+	TSharedRef<SWidget> ComboBox = SNew(SListView<TSharedPtr<FText>>)
+		.ListItemsSource(AvailableOLinkConnectionNames)
+		.OnGenerateRow_Lambda([](TSharedPtr<FText> InItem, const TSharedRef< class STableViewBase >& Owner)
+		{
+			return SNew(STableRow<TSharedPtr<FText>>, Owner)
+					.Padding(FMargin(16, 4, 16, 4))
+					[
+						SNew(STextBlock).Text(*InItem)
+					];
+		})
+		.OnSelectionChanged_Lambda([this, PropertyHandle](TSharedPtr<FText> InText, ESelectInfo::Type)
+		{
+			SelectedDefaultOLinkConnection = InText;
+			PropertyHandle->SetValue(InText->ToString());
+		});
+
+
+	//Generate widget:
+	const TSharedRef<SWidget> NewWidget = SNew(SComboButton)
+		.ContentPadding(FMargin(0, 0, 5, 0))
+		.ToolTipText(TooltipText)
+		.ButtonContent()
+		[
+			SNew(SBorder)
+#if (ENGINE_MAJOR_VERSION >= 5)
+			.BorderImage(FAppStyle::GetBrush("NoBorder"))
+#endif
+			.Padding(FMargin(0, 0, 5, 0))
+			[
+				EditableTextBox
+			]
+		]
+		.MenuContent()
+		[
+			ComboBox
+		];
+	// clang-format on
+
+	return NewWidget;
+}
+
+void FTbSame2ConnectionSettingsDetails::CustomizeTracerDetails(IDetailLayoutBuilder& DetailBuilder)
+{
+	IDetailCategoryBuilder& TracerServiceCategory = DetailBuilder.EditCategory(TEXT("TracerServiceSetup"));
+
+	TSharedPtr<IPropertyHandle> BackendServiceIdentifierPropertyHandle = DetailBuilder.GetProperty("TracerServiceIdentifier", nullptr);
+	IDetailPropertyRow& DefaultBackendServiceIdentifierPropertyRow = TracerServiceCategory.AddProperty(BackendServiceIdentifierPropertyHandle);
+
+	// clang-format off
+	DefaultBackendServiceIdentifierPropertyRow.CustomWidget()
 		.NameContent()
 		[
-			ConnectionIdentifierPropertyHandle->CreatePropertyNameWidget()
+			BackendServiceIdentifierPropertyHandle->CreatePropertyNameWidget()
 		]
 		.ValueContent()
 		.MaxDesiredWidth(500.0f)
 		.MinDesiredWidth(100.0f)
 		[
-			MakeDefaultConnectionSelectorWidget(ConnectionIdentifierPropertyHandle)
+			MakeDefaultBackendServiceSelectorWidget(BackendServiceIdentifierPropertyHandle)
 		];
 	// clang-format on
+}
+
+void FTbSame2ConnectionSettingsDetails::CustomizeOLinkDetails(IDetailLayoutBuilder& DetailBuilder)
+{
+	IDetailCategoryBuilder& OLinkConnectionsCategory = DetailBuilder.EditCategory(TEXT("OLinkConnectionSetup"));
+
+	TSharedPtr<IPropertyHandle> OLinkConnectionIdentifierPropertyHandle = DetailBuilder.GetProperty("OLinkConnectionIdentifier", nullptr);
+	IDetailPropertyRow& DefaultOLinkConnectionIdentifierPropertyRow = OLinkConnectionsCategory.AddProperty(OLinkConnectionIdentifierPropertyHandle);
+
+	// clang-format off
+	DefaultOLinkConnectionIdentifierPropertyRow.CustomWidget()
+		.NameContent()
+		[
+			OLinkConnectionIdentifierPropertyHandle->CreatePropertyNameWidget()
+		]
+		.ValueContent()
+		.MaxDesiredWidth(500.0f)
+		.MinDesiredWidth(100.0f)
+		[
+			MakeDefaultOLinkConnectionSelectorWidget(OLinkConnectionIdentifierPropertyHandle)
+		];
+	// clang-format on
+}
+
+void FTbSame2ConnectionSettingsDetails::CustomizeDetails(IDetailLayoutBuilder& DetailBuilder)
+{
+	CustomizeTracerDetails(DetailBuilder);
+	CustomizeOLinkDetails(DetailBuilder);
 }

--- a/goldenmaster/Plugins/TbSame2/Source/TbSame2Editor/Public/TbSame2ConnectionSettings.h
+++ b/goldenmaster/Plugins/TbSame2/Source/TbSame2Editor/Public/TbSame2ConnectionSettings.h
@@ -21,8 +21,13 @@ public:
 	virtual void CustomizeDetails(IDetailLayoutBuilder& DetailBuilder) override;
 
 private:
-	TSharedRef<SWidget> MakeDefaultConnectionSelectorWidget(const TSharedPtr<IPropertyHandle>& PropertyHandle);
+	void CustomizeTracerDetails(IDetailLayoutBuilder& DetailBuilder);
+	TSharedRef<SWidget> MakeDefaultBackendServiceSelectorWidget(const TSharedPtr<IPropertyHandle>& PropertyHandle);
+	TSharedPtr<FText> SelectedDefaultBackendService;
+	TArray<TSharedPtr<FText>> AvailableServices;
 
-	TSharedPtr<FText> SelectedDefaultConnection;
-	TArray<TSharedPtr<FText>> AvailableConnections;
+	void CustomizeOLinkDetails(IDetailLayoutBuilder& DetailBuilder);
+	TSharedRef<SWidget> MakeDefaultOLinkConnectionSelectorWidget(const TSharedPtr<IPropertyHandle>& PropertyHandle);
+	TSharedPtr<FText> SelectedDefaultOLinkConnection;
+	TArray<TSharedPtr<FText>> AvailableOLinkConnections;
 };

--- a/goldenmaster/Plugins/TbSame2/Source/TbSame2Editor/TbSame2Editor.Build.cs
+++ b/goldenmaster/Plugins/TbSame2/Source/TbSame2Editor/TbSame2Editor.Build.cs
@@ -14,6 +14,7 @@ namespace UnrealBuildTool.Rules
 					"UnrealEd",
 					// modules below are needed for connection settings
 					"ApiGear",
+					"ApiGearOLink",
 					"InputCore",
 					"PropertyEditor",
 					"Slate",

--- a/goldenmaster/Plugins/TbSimple/Source/TbSimple/Private/Generated/Monitor/TbSimpleFactory.cpp
+++ b/goldenmaster/Plugins/TbSimple/Source/TbSimple/Private/Generated/Monitor/TbSimpleFactory.cpp
@@ -84,13 +84,13 @@ TScriptInterface<ITbSimpleSimpleInterfaceInterface> FTbSimpleModuleFactory::crea
 {
 	UTbSimpleSettings* TbSimpleSettings = GetMutableDefault<UTbSimpleSettings>();
 
-	if (TbSimpleSettings->ConnectionIdentifier == "Local")
+	if (TbSimpleSettings->TracerServiceIdentifier == "Local")
 	{
 		return createTbSimpleSimpleInterface(GameInstance, Collection);
 	}
 
 	UApiGearSettings* ApiGearSettings = GetMutableDefault<UApiGearSettings>();
-	FApiGearConnectionSetting* ConnectionSetting = ApiGearSettings->Connections.Find(TbSimpleSettings->ConnectionIdentifier);
+	FApiGearConnectionSetting* ConnectionSetting = ApiGearSettings->Connections.Find(TbSimpleSettings->TracerServiceIdentifier);
 
 	// Other protocols not supported. To support it edit templates:
 	// add protocol handler class for this interface like createTbSimpleSimpleInterfaceOLink and other necessary infrastructure
@@ -132,13 +132,13 @@ TScriptInterface<ITbSimpleSimpleInterfaceInterface> FTbSimpleModuleFactory::crea
 {
 	UTbSimpleSettings* TbSimpleSettings = GetMutableDefault<UTbSimpleSettings>();
 
-	if (TbSimpleSettings->ConnectionIdentifier == "Local")
+	if (TbSimpleSettings->TracerServiceIdentifier == "Local")
 	{
 		return createTbSimpleSimpleInterface(Collection);
 	}
 
 	UApiGearSettings* ApiGearSettings = GetMutableDefault<UApiGearSettings>();
-	FApiGearConnectionSetting* ConnectionSetting = ApiGearSettings->Connections.Find(TbSimpleSettings->ConnectionIdentifier);
+	FApiGearConnectionSetting* ConnectionSetting = ApiGearSettings->Connections.Find(TbSimpleSettings->TracerServiceIdentifier);
 
 	// Other protocols not supported. To support it edit templates:
 	// add protocol handler class for this interface like createTbSimpleSimpleInterfaceOLink and other necessary infrastructure
@@ -192,13 +192,13 @@ TScriptInterface<ITbSimpleSimpleArrayInterfaceInterface> FTbSimpleModuleFactory:
 {
 	UTbSimpleSettings* TbSimpleSettings = GetMutableDefault<UTbSimpleSettings>();
 
-	if (TbSimpleSettings->ConnectionIdentifier == "Local")
+	if (TbSimpleSettings->TracerServiceIdentifier == "Local")
 	{
 		return createTbSimpleSimpleArrayInterface(GameInstance, Collection);
 	}
 
 	UApiGearSettings* ApiGearSettings = GetMutableDefault<UApiGearSettings>();
-	FApiGearConnectionSetting* ConnectionSetting = ApiGearSettings->Connections.Find(TbSimpleSettings->ConnectionIdentifier);
+	FApiGearConnectionSetting* ConnectionSetting = ApiGearSettings->Connections.Find(TbSimpleSettings->TracerServiceIdentifier);
 
 	// Other protocols not supported. To support it edit templates:
 	// add protocol handler class for this interface like createTbSimpleSimpleArrayInterfaceOLink and other necessary infrastructure
@@ -240,13 +240,13 @@ TScriptInterface<ITbSimpleSimpleArrayInterfaceInterface> FTbSimpleModuleFactory:
 {
 	UTbSimpleSettings* TbSimpleSettings = GetMutableDefault<UTbSimpleSettings>();
 
-	if (TbSimpleSettings->ConnectionIdentifier == "Local")
+	if (TbSimpleSettings->TracerServiceIdentifier == "Local")
 	{
 		return createTbSimpleSimpleArrayInterface(Collection);
 	}
 
 	UApiGearSettings* ApiGearSettings = GetMutableDefault<UApiGearSettings>();
-	FApiGearConnectionSetting* ConnectionSetting = ApiGearSettings->Connections.Find(TbSimpleSettings->ConnectionIdentifier);
+	FApiGearConnectionSetting* ConnectionSetting = ApiGearSettings->Connections.Find(TbSimpleSettings->TracerServiceIdentifier);
 
 	// Other protocols not supported. To support it edit templates:
 	// add protocol handler class for this interface like createTbSimpleSimpleArrayInterfaceOLink and other necessary infrastructure
@@ -300,13 +300,13 @@ TScriptInterface<ITbSimpleNoPropertiesInterfaceInterface> FTbSimpleModuleFactory
 {
 	UTbSimpleSettings* TbSimpleSettings = GetMutableDefault<UTbSimpleSettings>();
 
-	if (TbSimpleSettings->ConnectionIdentifier == "Local")
+	if (TbSimpleSettings->TracerServiceIdentifier == "Local")
 	{
 		return createTbSimpleNoPropertiesInterface(GameInstance, Collection);
 	}
 
 	UApiGearSettings* ApiGearSettings = GetMutableDefault<UApiGearSettings>();
-	FApiGearConnectionSetting* ConnectionSetting = ApiGearSettings->Connections.Find(TbSimpleSettings->ConnectionIdentifier);
+	FApiGearConnectionSetting* ConnectionSetting = ApiGearSettings->Connections.Find(TbSimpleSettings->TracerServiceIdentifier);
 
 	// Other protocols not supported. To support it edit templates:
 	// add protocol handler class for this interface like createTbSimpleNoPropertiesInterfaceOLink and other necessary infrastructure
@@ -348,13 +348,13 @@ TScriptInterface<ITbSimpleNoPropertiesInterfaceInterface> FTbSimpleModuleFactory
 {
 	UTbSimpleSettings* TbSimpleSettings = GetMutableDefault<UTbSimpleSettings>();
 
-	if (TbSimpleSettings->ConnectionIdentifier == "Local")
+	if (TbSimpleSettings->TracerServiceIdentifier == "Local")
 	{
 		return createTbSimpleNoPropertiesInterface(Collection);
 	}
 
 	UApiGearSettings* ApiGearSettings = GetMutableDefault<UApiGearSettings>();
-	FApiGearConnectionSetting* ConnectionSetting = ApiGearSettings->Connections.Find(TbSimpleSettings->ConnectionIdentifier);
+	FApiGearConnectionSetting* ConnectionSetting = ApiGearSettings->Connections.Find(TbSimpleSettings->TracerServiceIdentifier);
 
 	// Other protocols not supported. To support it edit templates:
 	// add protocol handler class for this interface like createTbSimpleNoPropertiesInterfaceOLink and other necessary infrastructure
@@ -408,13 +408,13 @@ TScriptInterface<ITbSimpleNoOperationsInterfaceInterface> FTbSimpleModuleFactory
 {
 	UTbSimpleSettings* TbSimpleSettings = GetMutableDefault<UTbSimpleSettings>();
 
-	if (TbSimpleSettings->ConnectionIdentifier == "Local")
+	if (TbSimpleSettings->TracerServiceIdentifier == "Local")
 	{
 		return createTbSimpleNoOperationsInterface(GameInstance, Collection);
 	}
 
 	UApiGearSettings* ApiGearSettings = GetMutableDefault<UApiGearSettings>();
-	FApiGearConnectionSetting* ConnectionSetting = ApiGearSettings->Connections.Find(TbSimpleSettings->ConnectionIdentifier);
+	FApiGearConnectionSetting* ConnectionSetting = ApiGearSettings->Connections.Find(TbSimpleSettings->TracerServiceIdentifier);
 
 	// Other protocols not supported. To support it edit templates:
 	// add protocol handler class for this interface like createTbSimpleNoOperationsInterfaceOLink and other necessary infrastructure
@@ -456,13 +456,13 @@ TScriptInterface<ITbSimpleNoOperationsInterfaceInterface> FTbSimpleModuleFactory
 {
 	UTbSimpleSettings* TbSimpleSettings = GetMutableDefault<UTbSimpleSettings>();
 
-	if (TbSimpleSettings->ConnectionIdentifier == "Local")
+	if (TbSimpleSettings->TracerServiceIdentifier == "Local")
 	{
 		return createTbSimpleNoOperationsInterface(Collection);
 	}
 
 	UApiGearSettings* ApiGearSettings = GetMutableDefault<UApiGearSettings>();
-	FApiGearConnectionSetting* ConnectionSetting = ApiGearSettings->Connections.Find(TbSimpleSettings->ConnectionIdentifier);
+	FApiGearConnectionSetting* ConnectionSetting = ApiGearSettings->Connections.Find(TbSimpleSettings->TracerServiceIdentifier);
 
 	// Other protocols not supported. To support it edit templates:
 	// add protocol handler class for this interface like createTbSimpleNoOperationsInterfaceOLink and other necessary infrastructure
@@ -516,13 +516,13 @@ TScriptInterface<ITbSimpleNoSignalsInterfaceInterface> FTbSimpleModuleFactory::c
 {
 	UTbSimpleSettings* TbSimpleSettings = GetMutableDefault<UTbSimpleSettings>();
 
-	if (TbSimpleSettings->ConnectionIdentifier == "Local")
+	if (TbSimpleSettings->TracerServiceIdentifier == "Local")
 	{
 		return createTbSimpleNoSignalsInterface(GameInstance, Collection);
 	}
 
 	UApiGearSettings* ApiGearSettings = GetMutableDefault<UApiGearSettings>();
-	FApiGearConnectionSetting* ConnectionSetting = ApiGearSettings->Connections.Find(TbSimpleSettings->ConnectionIdentifier);
+	FApiGearConnectionSetting* ConnectionSetting = ApiGearSettings->Connections.Find(TbSimpleSettings->TracerServiceIdentifier);
 
 	// Other protocols not supported. To support it edit templates:
 	// add protocol handler class for this interface like createTbSimpleNoSignalsInterfaceOLink and other necessary infrastructure
@@ -564,13 +564,13 @@ TScriptInterface<ITbSimpleNoSignalsInterfaceInterface> FTbSimpleModuleFactory::c
 {
 	UTbSimpleSettings* TbSimpleSettings = GetMutableDefault<UTbSimpleSettings>();
 
-	if (TbSimpleSettings->ConnectionIdentifier == "Local")
+	if (TbSimpleSettings->TracerServiceIdentifier == "Local")
 	{
 		return createTbSimpleNoSignalsInterface(Collection);
 	}
 
 	UApiGearSettings* ApiGearSettings = GetMutableDefault<UApiGearSettings>();
-	FApiGearConnectionSetting* ConnectionSetting = ApiGearSettings->Connections.Find(TbSimpleSettings->ConnectionIdentifier);
+	FApiGearConnectionSetting* ConnectionSetting = ApiGearSettings->Connections.Find(TbSimpleSettings->TracerServiceIdentifier);
 
 	// Other protocols not supported. To support it edit templates:
 	// add protocol handler class for this interface like createTbSimpleNoSignalsInterfaceOLink and other necessary infrastructure
@@ -624,13 +624,13 @@ TScriptInterface<ITbSimpleEmptyInterfaceInterface> FTbSimpleModuleFactory::creat
 {
 	UTbSimpleSettings* TbSimpleSettings = GetMutableDefault<UTbSimpleSettings>();
 
-	if (TbSimpleSettings->ConnectionIdentifier == "Local")
+	if (TbSimpleSettings->TracerServiceIdentifier == "Local")
 	{
 		return createTbSimpleEmptyInterface(GameInstance, Collection);
 	}
 
 	UApiGearSettings* ApiGearSettings = GetMutableDefault<UApiGearSettings>();
-	FApiGearConnectionSetting* ConnectionSetting = ApiGearSettings->Connections.Find(TbSimpleSettings->ConnectionIdentifier);
+	FApiGearConnectionSetting* ConnectionSetting = ApiGearSettings->Connections.Find(TbSimpleSettings->TracerServiceIdentifier);
 
 	// Other protocols not supported. To support it edit templates:
 	// add protocol handler class for this interface like createTbSimpleEmptyInterfaceOLink and other necessary infrastructure
@@ -672,13 +672,13 @@ TScriptInterface<ITbSimpleEmptyInterfaceInterface> FTbSimpleModuleFactory::creat
 {
 	UTbSimpleSettings* TbSimpleSettings = GetMutableDefault<UTbSimpleSettings>();
 
-	if (TbSimpleSettings->ConnectionIdentifier == "Local")
+	if (TbSimpleSettings->TracerServiceIdentifier == "Local")
 	{
 		return createTbSimpleEmptyInterface(Collection);
 	}
 
 	UApiGearSettings* ApiGearSettings = GetMutableDefault<UApiGearSettings>();
-	FApiGearConnectionSetting* ConnectionSetting = ApiGearSettings->Connections.Find(TbSimpleSettings->ConnectionIdentifier);
+	FApiGearConnectionSetting* ConnectionSetting = ApiGearSettings->Connections.Find(TbSimpleSettings->TracerServiceIdentifier);
 
 	// Other protocols not supported. To support it edit templates:
 	// add protocol handler class for this interface like createTbSimpleEmptyInterfaceOLink and other necessary infrastructure

--- a/goldenmaster/Plugins/TbSimple/Source/TbSimple/Private/Generated/Monitor/TbSimpleFactory.cpp
+++ b/goldenmaster/Plugins/TbSimple/Source/TbSimple/Private/Generated/Monitor/TbSimpleFactory.cpp
@@ -17,6 +17,7 @@ limitations under the License.
 
 #include "TbSimpleFactory.h"
 #include "ApiGearSettings.h"
+#include "apigearolink.h"
 #include "TbSimpleSettings.h"
 #include "Implementation/TbSimpleSimpleInterface.h"
 #include "Generated/OLink/TbSimpleSimpleInterfaceOLinkClient.h"
@@ -96,7 +97,7 @@ TScriptInterface<ITbSimpleSimpleInterfaceInterface> FTbSimpleModuleFactory::crea
 	// Other protocols not supported. To support it edit templates:
 	// add protocol handler class for this interface like createTbSimpleSimpleInterfaceOLink and other necessary infrastructure
 	// extend this function in templates to handle protocol of your choice
-	if (ConnectionSetting && ConnectionSetting->ProtocolIdentifier == "olink")
+	if (ConnectionSetting && ConnectionSetting->ProtocolIdentifier == ApiGearOLinkProtocolIdentifier)
 	{
 		return createTbSimpleSimpleInterfaceOLink(GameInstance, Collection);
 	}
@@ -144,7 +145,7 @@ TScriptInterface<ITbSimpleSimpleInterfaceInterface> FTbSimpleModuleFactory::crea
 	// Other protocols not supported. To support it edit templates:
 	// add protocol handler class for this interface like createTbSimpleSimpleInterfaceOLink and other necessary infrastructure
 	// extend this function in templates to handle protocol of your choice
-	if (ConnectionSetting && ConnectionSetting->ProtocolIdentifier == "olink")
+	if (ConnectionSetting && ConnectionSetting->ProtocolIdentifier == ApiGearOLinkProtocolIdentifier)
 	{
 		return createTbSimpleSimpleInterfaceOLink(Collection);
 	}
@@ -204,7 +205,7 @@ TScriptInterface<ITbSimpleSimpleArrayInterfaceInterface> FTbSimpleModuleFactory:
 	// Other protocols not supported. To support it edit templates:
 	// add protocol handler class for this interface like createTbSimpleSimpleArrayInterfaceOLink and other necessary infrastructure
 	// extend this function in templates to handle protocol of your choice
-	if (ConnectionSetting && ConnectionSetting->ProtocolIdentifier == "olink")
+	if (ConnectionSetting && ConnectionSetting->ProtocolIdentifier == ApiGearOLinkProtocolIdentifier)
 	{
 		return createTbSimpleSimpleArrayInterfaceOLink(GameInstance, Collection);
 	}
@@ -252,7 +253,7 @@ TScriptInterface<ITbSimpleSimpleArrayInterfaceInterface> FTbSimpleModuleFactory:
 	// Other protocols not supported. To support it edit templates:
 	// add protocol handler class for this interface like createTbSimpleSimpleArrayInterfaceOLink and other necessary infrastructure
 	// extend this function in templates to handle protocol of your choice
-	if (ConnectionSetting && ConnectionSetting->ProtocolIdentifier == "olink")
+	if (ConnectionSetting && ConnectionSetting->ProtocolIdentifier == ApiGearOLinkProtocolIdentifier)
 	{
 		return createTbSimpleSimpleArrayInterfaceOLink(Collection);
 	}
@@ -312,7 +313,7 @@ TScriptInterface<ITbSimpleNoPropertiesInterfaceInterface> FTbSimpleModuleFactory
 	// Other protocols not supported. To support it edit templates:
 	// add protocol handler class for this interface like createTbSimpleNoPropertiesInterfaceOLink and other necessary infrastructure
 	// extend this function in templates to handle protocol of your choice
-	if (ConnectionSetting && ConnectionSetting->ProtocolIdentifier == "olink")
+	if (ConnectionSetting && ConnectionSetting->ProtocolIdentifier == ApiGearOLinkProtocolIdentifier)
 	{
 		return createTbSimpleNoPropertiesInterfaceOLink(GameInstance, Collection);
 	}
@@ -360,7 +361,7 @@ TScriptInterface<ITbSimpleNoPropertiesInterfaceInterface> FTbSimpleModuleFactory
 	// Other protocols not supported. To support it edit templates:
 	// add protocol handler class for this interface like createTbSimpleNoPropertiesInterfaceOLink and other necessary infrastructure
 	// extend this function in templates to handle protocol of your choice
-	if (ConnectionSetting && ConnectionSetting->ProtocolIdentifier == "olink")
+	if (ConnectionSetting && ConnectionSetting->ProtocolIdentifier == ApiGearOLinkProtocolIdentifier)
 	{
 		return createTbSimpleNoPropertiesInterfaceOLink(Collection);
 	}
@@ -420,7 +421,7 @@ TScriptInterface<ITbSimpleNoOperationsInterfaceInterface> FTbSimpleModuleFactory
 	// Other protocols not supported. To support it edit templates:
 	// add protocol handler class for this interface like createTbSimpleNoOperationsInterfaceOLink and other necessary infrastructure
 	// extend this function in templates to handle protocol of your choice
-	if (ConnectionSetting && ConnectionSetting->ProtocolIdentifier == "olink")
+	if (ConnectionSetting && ConnectionSetting->ProtocolIdentifier == ApiGearOLinkProtocolIdentifier)
 	{
 		return createTbSimpleNoOperationsInterfaceOLink(GameInstance, Collection);
 	}
@@ -468,7 +469,7 @@ TScriptInterface<ITbSimpleNoOperationsInterfaceInterface> FTbSimpleModuleFactory
 	// Other protocols not supported. To support it edit templates:
 	// add protocol handler class for this interface like createTbSimpleNoOperationsInterfaceOLink and other necessary infrastructure
 	// extend this function in templates to handle protocol of your choice
-	if (ConnectionSetting && ConnectionSetting->ProtocolIdentifier == "olink")
+	if (ConnectionSetting && ConnectionSetting->ProtocolIdentifier == ApiGearOLinkProtocolIdentifier)
 	{
 		return createTbSimpleNoOperationsInterfaceOLink(Collection);
 	}
@@ -528,7 +529,7 @@ TScriptInterface<ITbSimpleNoSignalsInterfaceInterface> FTbSimpleModuleFactory::c
 	// Other protocols not supported. To support it edit templates:
 	// add protocol handler class for this interface like createTbSimpleNoSignalsInterfaceOLink and other necessary infrastructure
 	// extend this function in templates to handle protocol of your choice
-	if (ConnectionSetting && ConnectionSetting->ProtocolIdentifier == "olink")
+	if (ConnectionSetting && ConnectionSetting->ProtocolIdentifier == ApiGearOLinkProtocolIdentifier)
 	{
 		return createTbSimpleNoSignalsInterfaceOLink(GameInstance, Collection);
 	}
@@ -576,7 +577,7 @@ TScriptInterface<ITbSimpleNoSignalsInterfaceInterface> FTbSimpleModuleFactory::c
 	// Other protocols not supported. To support it edit templates:
 	// add protocol handler class for this interface like createTbSimpleNoSignalsInterfaceOLink and other necessary infrastructure
 	// extend this function in templates to handle protocol of your choice
-	if (ConnectionSetting && ConnectionSetting->ProtocolIdentifier == "olink")
+	if (ConnectionSetting && ConnectionSetting->ProtocolIdentifier == ApiGearOLinkProtocolIdentifier)
 	{
 		return createTbSimpleNoSignalsInterfaceOLink(Collection);
 	}
@@ -636,7 +637,7 @@ TScriptInterface<ITbSimpleEmptyInterfaceInterface> FTbSimpleModuleFactory::creat
 	// Other protocols not supported. To support it edit templates:
 	// add protocol handler class for this interface like createTbSimpleEmptyInterfaceOLink and other necessary infrastructure
 	// extend this function in templates to handle protocol of your choice
-	if (ConnectionSetting && ConnectionSetting->ProtocolIdentifier == "olink")
+	if (ConnectionSetting && ConnectionSetting->ProtocolIdentifier == ApiGearOLinkProtocolIdentifier)
 	{
 		return createTbSimpleEmptyInterfaceOLink(GameInstance, Collection);
 	}
@@ -684,7 +685,7 @@ TScriptInterface<ITbSimpleEmptyInterfaceInterface> FTbSimpleModuleFactory::creat
 	// Other protocols not supported. To support it edit templates:
 	// add protocol handler class for this interface like createTbSimpleEmptyInterfaceOLink and other necessary infrastructure
 	// extend this function in templates to handle protocol of your choice
-	if (ConnectionSetting && ConnectionSetting->ProtocolIdentifier == "olink")
+	if (ConnectionSetting && ConnectionSetting->ProtocolIdentifier == ApiGearOLinkProtocolIdentifier)
 	{
 		return createTbSimpleEmptyInterfaceOLink(Collection);
 	}

--- a/goldenmaster/Plugins/TbSimple/Source/TbSimple/Private/Generated/Monitor/TbSimpleFactory.cpp
+++ b/goldenmaster/Plugins/TbSimple/Source/TbSimple/Private/Generated/Monitor/TbSimpleFactory.cpp
@@ -17,6 +17,7 @@ limitations under the License.
 
 #include "TbSimpleFactory.h"
 #include "ApiGearSettings.h"
+#include "TbSimpleSettings.h"
 #include "Implementation/TbSimpleSimpleInterface.h"
 #include "Generated/OLink/TbSimpleSimpleInterfaceOLinkClient.h"
 #include "Implementation/TbSimpleSimpleArrayInterface.h"
@@ -84,7 +85,7 @@ TScriptInterface<ITbSimpleSimpleInterfaceInterface> FTbSimpleModuleFactory::crea
 {
 	UTbSimpleSettings* TbSimpleSettings = GetMutableDefault<UTbSimpleSettings>();
 
-	if (TbSimpleSettings->TracerServiceIdentifier == "Local")
+	if (TbSimpleSettings->TracerServiceIdentifier == TbSimpleLocalBackendIdentifier)
 	{
 		return createTbSimpleSimpleInterface(GameInstance, Collection);
 	}
@@ -132,7 +133,7 @@ TScriptInterface<ITbSimpleSimpleInterfaceInterface> FTbSimpleModuleFactory::crea
 {
 	UTbSimpleSettings* TbSimpleSettings = GetMutableDefault<UTbSimpleSettings>();
 
-	if (TbSimpleSettings->TracerServiceIdentifier == "Local")
+	if (TbSimpleSettings->TracerServiceIdentifier == TbSimpleLocalBackendIdentifier)
 	{
 		return createTbSimpleSimpleInterface(Collection);
 	}
@@ -192,7 +193,7 @@ TScriptInterface<ITbSimpleSimpleArrayInterfaceInterface> FTbSimpleModuleFactory:
 {
 	UTbSimpleSettings* TbSimpleSettings = GetMutableDefault<UTbSimpleSettings>();
 
-	if (TbSimpleSettings->TracerServiceIdentifier == "Local")
+	if (TbSimpleSettings->TracerServiceIdentifier == TbSimpleLocalBackendIdentifier)
 	{
 		return createTbSimpleSimpleArrayInterface(GameInstance, Collection);
 	}
@@ -240,7 +241,7 @@ TScriptInterface<ITbSimpleSimpleArrayInterfaceInterface> FTbSimpleModuleFactory:
 {
 	UTbSimpleSettings* TbSimpleSettings = GetMutableDefault<UTbSimpleSettings>();
 
-	if (TbSimpleSettings->TracerServiceIdentifier == "Local")
+	if (TbSimpleSettings->TracerServiceIdentifier == TbSimpleLocalBackendIdentifier)
 	{
 		return createTbSimpleSimpleArrayInterface(Collection);
 	}
@@ -300,7 +301,7 @@ TScriptInterface<ITbSimpleNoPropertiesInterfaceInterface> FTbSimpleModuleFactory
 {
 	UTbSimpleSettings* TbSimpleSettings = GetMutableDefault<UTbSimpleSettings>();
 
-	if (TbSimpleSettings->TracerServiceIdentifier == "Local")
+	if (TbSimpleSettings->TracerServiceIdentifier == TbSimpleLocalBackendIdentifier)
 	{
 		return createTbSimpleNoPropertiesInterface(GameInstance, Collection);
 	}
@@ -348,7 +349,7 @@ TScriptInterface<ITbSimpleNoPropertiesInterfaceInterface> FTbSimpleModuleFactory
 {
 	UTbSimpleSettings* TbSimpleSettings = GetMutableDefault<UTbSimpleSettings>();
 
-	if (TbSimpleSettings->TracerServiceIdentifier == "Local")
+	if (TbSimpleSettings->TracerServiceIdentifier == TbSimpleLocalBackendIdentifier)
 	{
 		return createTbSimpleNoPropertiesInterface(Collection);
 	}
@@ -408,7 +409,7 @@ TScriptInterface<ITbSimpleNoOperationsInterfaceInterface> FTbSimpleModuleFactory
 {
 	UTbSimpleSettings* TbSimpleSettings = GetMutableDefault<UTbSimpleSettings>();
 
-	if (TbSimpleSettings->TracerServiceIdentifier == "Local")
+	if (TbSimpleSettings->TracerServiceIdentifier == TbSimpleLocalBackendIdentifier)
 	{
 		return createTbSimpleNoOperationsInterface(GameInstance, Collection);
 	}
@@ -456,7 +457,7 @@ TScriptInterface<ITbSimpleNoOperationsInterfaceInterface> FTbSimpleModuleFactory
 {
 	UTbSimpleSettings* TbSimpleSettings = GetMutableDefault<UTbSimpleSettings>();
 
-	if (TbSimpleSettings->TracerServiceIdentifier == "Local")
+	if (TbSimpleSettings->TracerServiceIdentifier == TbSimpleLocalBackendIdentifier)
 	{
 		return createTbSimpleNoOperationsInterface(Collection);
 	}
@@ -516,7 +517,7 @@ TScriptInterface<ITbSimpleNoSignalsInterfaceInterface> FTbSimpleModuleFactory::c
 {
 	UTbSimpleSettings* TbSimpleSettings = GetMutableDefault<UTbSimpleSettings>();
 
-	if (TbSimpleSettings->TracerServiceIdentifier == "Local")
+	if (TbSimpleSettings->TracerServiceIdentifier == TbSimpleLocalBackendIdentifier)
 	{
 		return createTbSimpleNoSignalsInterface(GameInstance, Collection);
 	}
@@ -564,7 +565,7 @@ TScriptInterface<ITbSimpleNoSignalsInterfaceInterface> FTbSimpleModuleFactory::c
 {
 	UTbSimpleSettings* TbSimpleSettings = GetMutableDefault<UTbSimpleSettings>();
 
-	if (TbSimpleSettings->TracerServiceIdentifier == "Local")
+	if (TbSimpleSettings->TracerServiceIdentifier == TbSimpleLocalBackendIdentifier)
 	{
 		return createTbSimpleNoSignalsInterface(Collection);
 	}
@@ -624,7 +625,7 @@ TScriptInterface<ITbSimpleEmptyInterfaceInterface> FTbSimpleModuleFactory::creat
 {
 	UTbSimpleSettings* TbSimpleSettings = GetMutableDefault<UTbSimpleSettings>();
 
-	if (TbSimpleSettings->TracerServiceIdentifier == "Local")
+	if (TbSimpleSettings->TracerServiceIdentifier == TbSimpleLocalBackendIdentifier)
 	{
 		return createTbSimpleEmptyInterface(GameInstance, Collection);
 	}
@@ -672,7 +673,7 @@ TScriptInterface<ITbSimpleEmptyInterfaceInterface> FTbSimpleModuleFactory::creat
 {
 	UTbSimpleSettings* TbSimpleSettings = GetMutableDefault<UTbSimpleSettings>();
 
-	if (TbSimpleSettings->TracerServiceIdentifier == "Local")
+	if (TbSimpleSettings->TracerServiceIdentifier == TbSimpleLocalBackendIdentifier)
 	{
 		return createTbSimpleEmptyInterface(Collection);
 	}

--- a/goldenmaster/Plugins/TbSimple/Source/TbSimple/Private/Generated/OLink/TbSimpleEmptyInterfaceOLinkClient.cpp
+++ b/goldenmaster/Plugins/TbSimple/Source/TbSimple/Private/Generated/OLink/TbSimpleEmptyInterfaceOLinkClient.cpp
@@ -22,6 +22,7 @@ limitations under the License.
 
 #include "Generated/OLink/TbSimpleEmptyInterfaceOLinkClient.h"
 #include "ApiGearSettings.h"
+#include "apigearolink.h"
 #include "Async/Async.h"
 #include "Generated/api/TbSimple.json.adapter.h"
 #include "unrealolink.h"
@@ -101,7 +102,7 @@ void UTbSimpleEmptyInterfaceOLinkClient::UseConnection(TScriptInterface<IApiGear
 	checkf(InConnection.GetInterface() != nullptr, TEXT("Cannot use connection - interface IApiGearConnection is not fully implemented"));
 
 	// only accept connections of type olink
-	checkf(InConnection->GetConnectionProtocolIdentifier() == "olink", TEXT("Cannot use connection - must be of type olink"));
+	checkf(InConnection->GetConnectionProtocolIdentifier() == ApiGearOLinkProtocolIdentifier, TEXT("Cannot use connection - must be of type olink"));
 
 	UUnrealOLink* UnrealOLinkConnection = nullptr;
 	// remove old connection

--- a/goldenmaster/Plugins/TbSimple/Source/TbSimple/Private/Generated/OLink/TbSimpleEmptyInterfaceOLinkClient.cpp
+++ b/goldenmaster/Plugins/TbSimple/Source/TbSimple/Private/Generated/OLink/TbSimpleEmptyInterfaceOLinkClient.cpp
@@ -69,8 +69,13 @@ void UTbSimpleEmptyInterfaceOLinkClient::Initialize(FSubsystemCollectionBase& Co
 
 	UApiGearConnectionsStore* AGCM = GEngine->GetEngineSubsystem<UApiGearConnectionsStore>();
 
-	TScriptInterface<IApiGearConnection> OLinkConnection = AGCM->GetConnection(settings->ConnectionIdentifier);
+	TScriptInterface<IApiGearConnection> OLinkConnection = AGCM->GetConnection(settings->OLinkConnectionIdentifier);
 
+	if (!OLinkConnection.GetInterface())
+	{
+		UE_LOG(LogTbSimpleEmptyInterfaceOLinkClient, Log, TEXT("No valid olink connection for %s, please set during run time"), UTF8_TO_TCHAR(m_sink->olinkObjectName().c_str()));
+		return;
+	}
 	UseConnection(OLinkConnection);
 	OLinkConnection->Connect();
 }

--- a/goldenmaster/Plugins/TbSimple/Source/TbSimple/Private/Generated/OLink/TbSimpleNoOperationsInterfaceOLinkClient.cpp
+++ b/goldenmaster/Plugins/TbSimple/Source/TbSimple/Private/Generated/OLink/TbSimpleNoOperationsInterfaceOLinkClient.cpp
@@ -22,6 +22,7 @@ limitations under the License.
 
 #include "Generated/OLink/TbSimpleNoOperationsInterfaceOLinkClient.h"
 #include "ApiGearSettings.h"
+#include "apigearolink.h"
 #include "Async/Async.h"
 #include "Generated/api/TbSimple.json.adapter.h"
 #include "unrealolink.h"
@@ -115,7 +116,7 @@ void UTbSimpleNoOperationsInterfaceOLinkClient::UseConnection(TScriptInterface<I
 	checkf(InConnection.GetInterface() != nullptr, TEXT("Cannot use connection - interface IApiGearConnection is not fully implemented"));
 
 	// only accept connections of type olink
-	checkf(InConnection->GetConnectionProtocolIdentifier() == "olink", TEXT("Cannot use connection - must be of type olink"));
+	checkf(InConnection->GetConnectionProtocolIdentifier() == ApiGearOLinkProtocolIdentifier, TEXT("Cannot use connection - must be of type olink"));
 
 	UUnrealOLink* UnrealOLinkConnection = nullptr;
 	// remove old connection

--- a/goldenmaster/Plugins/TbSimple/Source/TbSimple/Private/Generated/OLink/TbSimpleNoOperationsInterfaceOLinkClient.cpp
+++ b/goldenmaster/Plugins/TbSimple/Source/TbSimple/Private/Generated/OLink/TbSimpleNoOperationsInterfaceOLinkClient.cpp
@@ -83,8 +83,13 @@ void UTbSimpleNoOperationsInterfaceOLinkClient::Initialize(FSubsystemCollectionB
 
 	UApiGearConnectionsStore* AGCM = GEngine->GetEngineSubsystem<UApiGearConnectionsStore>();
 
-	TScriptInterface<IApiGearConnection> OLinkConnection = AGCM->GetConnection(settings->ConnectionIdentifier);
+	TScriptInterface<IApiGearConnection> OLinkConnection = AGCM->GetConnection(settings->OLinkConnectionIdentifier);
 
+	if (!OLinkConnection.GetInterface())
+	{
+		UE_LOG(LogTbSimpleNoOperationsInterfaceOLinkClient, Log, TEXT("No valid olink connection for %s, please set during run time"), UTF8_TO_TCHAR(m_sink->olinkObjectName().c_str()));
+		return;
+	}
 	UseConnection(OLinkConnection);
 	OLinkConnection->Connect();
 }

--- a/goldenmaster/Plugins/TbSimple/Source/TbSimple/Private/Generated/OLink/TbSimpleNoPropertiesInterfaceOLinkClient.cpp
+++ b/goldenmaster/Plugins/TbSimple/Source/TbSimple/Private/Generated/OLink/TbSimpleNoPropertiesInterfaceOLinkClient.cpp
@@ -22,6 +22,7 @@ limitations under the License.
 
 #include "Generated/OLink/TbSimpleNoPropertiesInterfaceOLinkClient.h"
 #include "ApiGearSettings.h"
+#include "apigearolink.h"
 #include "Async/Async.h"
 #include "Generated/api/TbSimple.json.adapter.h"
 #include "unrealolink.h"
@@ -101,7 +102,7 @@ void UTbSimpleNoPropertiesInterfaceOLinkClient::UseConnection(TScriptInterface<I
 	checkf(InConnection.GetInterface() != nullptr, TEXT("Cannot use connection - interface IApiGearConnection is not fully implemented"));
 
 	// only accept connections of type olink
-	checkf(InConnection->GetConnectionProtocolIdentifier() == "olink", TEXT("Cannot use connection - must be of type olink"));
+	checkf(InConnection->GetConnectionProtocolIdentifier() == ApiGearOLinkProtocolIdentifier, TEXT("Cannot use connection - must be of type olink"));
 
 	UUnrealOLink* UnrealOLinkConnection = nullptr;
 	// remove old connection

--- a/goldenmaster/Plugins/TbSimple/Source/TbSimple/Private/Generated/OLink/TbSimpleNoPropertiesInterfaceOLinkClient.cpp
+++ b/goldenmaster/Plugins/TbSimple/Source/TbSimple/Private/Generated/OLink/TbSimpleNoPropertiesInterfaceOLinkClient.cpp
@@ -69,8 +69,13 @@ void UTbSimpleNoPropertiesInterfaceOLinkClient::Initialize(FSubsystemCollectionB
 
 	UApiGearConnectionsStore* AGCM = GEngine->GetEngineSubsystem<UApiGearConnectionsStore>();
 
-	TScriptInterface<IApiGearConnection> OLinkConnection = AGCM->GetConnection(settings->ConnectionIdentifier);
+	TScriptInterface<IApiGearConnection> OLinkConnection = AGCM->GetConnection(settings->OLinkConnectionIdentifier);
 
+	if (!OLinkConnection.GetInterface())
+	{
+		UE_LOG(LogTbSimpleNoPropertiesInterfaceOLinkClient, Log, TEXT("No valid olink connection for %s, please set during run time"), UTF8_TO_TCHAR(m_sink->olinkObjectName().c_str()));
+		return;
+	}
 	UseConnection(OLinkConnection);
 	OLinkConnection->Connect();
 }

--- a/goldenmaster/Plugins/TbSimple/Source/TbSimple/Private/Generated/OLink/TbSimpleNoPropertiesInterfaceOLinkClient.cpp
+++ b/goldenmaster/Plugins/TbSimple/Source/TbSimple/Private/Generated/OLink/TbSimpleNoPropertiesInterfaceOLinkClient.cpp
@@ -142,7 +142,17 @@ bool UTbSimpleNoPropertiesInterfaceOLinkClient::FuncBool_Implementation(bool bPa
 		[bParamBool, &Promise, this]()
 		{
 			ApiGear::ObjectLink::InvokeReplyFunc GetNoPropertiesInterfaceStateFunc = [&Promise](ApiGear::ObjectLink::InvokeReplyArg arg)
-			{ Promise.SetValue(arg.value.get<bool>()); };
+			{
+				if (!arg.value.empty())
+				{
+					Promise.SetValue(arg.value.get<bool>());
+				}
+				else
+				{
+					UE_LOG(LogTbSimpleNoPropertiesInterfaceOLinkClient, Error, TEXT("FuncBool: OLink service returned empty value - should have returned type of bool"));
+					Promise.SetValue(bool());
+				}
+			};
 			static const auto memberId = ApiGear::ObjectLink::Name::createMemberId(m_sink->olinkObjectName(), "funcBool");
 			m_sink->GetNode()->invokeRemote(memberId, {bParamBool}, GetNoPropertiesInterfaceStateFunc);
 		});

--- a/goldenmaster/Plugins/TbSimple/Source/TbSimple/Private/Generated/OLink/TbSimpleNoSignalsInterfaceOLinkClient.cpp
+++ b/goldenmaster/Plugins/TbSimple/Source/TbSimple/Private/Generated/OLink/TbSimpleNoSignalsInterfaceOLinkClient.cpp
@@ -22,6 +22,7 @@ limitations under the License.
 
 #include "Generated/OLink/TbSimpleNoSignalsInterfaceOLinkClient.h"
 #include "ApiGearSettings.h"
+#include "apigearolink.h"
 #include "Async/Async.h"
 #include "Generated/api/TbSimple.json.adapter.h"
 #include "unrealolink.h"
@@ -115,7 +116,7 @@ void UTbSimpleNoSignalsInterfaceOLinkClient::UseConnection(TScriptInterface<IApi
 	checkf(InConnection.GetInterface() != nullptr, TEXT("Cannot use connection - interface IApiGearConnection is not fully implemented"));
 
 	// only accept connections of type olink
-	checkf(InConnection->GetConnectionProtocolIdentifier() == "olink", TEXT("Cannot use connection - must be of type olink"));
+	checkf(InConnection->GetConnectionProtocolIdentifier() == ApiGearOLinkProtocolIdentifier, TEXT("Cannot use connection - must be of type olink"));
 
 	UUnrealOLink* UnrealOLinkConnection = nullptr;
 	// remove old connection

--- a/goldenmaster/Plugins/TbSimple/Source/TbSimple/Private/Generated/OLink/TbSimpleNoSignalsInterfaceOLinkClient.cpp
+++ b/goldenmaster/Plugins/TbSimple/Source/TbSimple/Private/Generated/OLink/TbSimpleNoSignalsInterfaceOLinkClient.cpp
@@ -214,7 +214,17 @@ bool UTbSimpleNoSignalsInterfaceOLinkClient::FuncBool_Implementation(bool bParam
 		[bParamBool, &Promise, this]()
 		{
 			ApiGear::ObjectLink::InvokeReplyFunc GetNoSignalsInterfaceStateFunc = [&Promise](ApiGear::ObjectLink::InvokeReplyArg arg)
-			{ Promise.SetValue(arg.value.get<bool>()); };
+			{
+				if (!arg.value.empty())
+				{
+					Promise.SetValue(arg.value.get<bool>());
+				}
+				else
+				{
+					UE_LOG(LogTbSimpleNoSignalsInterfaceOLinkClient, Error, TEXT("FuncBool: OLink service returned empty value - should have returned type of bool"));
+					Promise.SetValue(bool());
+				}
+			};
 			static const auto memberId = ApiGear::ObjectLink::Name::createMemberId(m_sink->olinkObjectName(), "funcBool");
 			m_sink->GetNode()->invokeRemote(memberId, {bParamBool}, GetNoSignalsInterfaceStateFunc);
 		});

--- a/goldenmaster/Plugins/TbSimple/Source/TbSimple/Private/Generated/OLink/TbSimpleNoSignalsInterfaceOLinkClient.cpp
+++ b/goldenmaster/Plugins/TbSimple/Source/TbSimple/Private/Generated/OLink/TbSimpleNoSignalsInterfaceOLinkClient.cpp
@@ -83,8 +83,13 @@ void UTbSimpleNoSignalsInterfaceOLinkClient::Initialize(FSubsystemCollectionBase
 
 	UApiGearConnectionsStore* AGCM = GEngine->GetEngineSubsystem<UApiGearConnectionsStore>();
 
-	TScriptInterface<IApiGearConnection> OLinkConnection = AGCM->GetConnection(settings->ConnectionIdentifier);
+	TScriptInterface<IApiGearConnection> OLinkConnection = AGCM->GetConnection(settings->OLinkConnectionIdentifier);
 
+	if (!OLinkConnection.GetInterface())
+	{
+		UE_LOG(LogTbSimpleNoSignalsInterfaceOLinkClient, Log, TEXT("No valid olink connection for %s, please set during run time"), UTF8_TO_TCHAR(m_sink->olinkObjectName().c_str()));
+		return;
+	}
 	UseConnection(OLinkConnection);
 	OLinkConnection->Connect();
 }

--- a/goldenmaster/Plugins/TbSimple/Source/TbSimple/Private/Generated/OLink/TbSimpleSimpleArrayInterfaceOLinkClient.cpp
+++ b/goldenmaster/Plugins/TbSimple/Source/TbSimple/Private/Generated/OLink/TbSimpleSimpleArrayInterfaceOLinkClient.cpp
@@ -89,8 +89,13 @@ void UTbSimpleSimpleArrayInterfaceOLinkClient::Initialize(FSubsystemCollectionBa
 
 	UApiGearConnectionsStore* AGCM = GEngine->GetEngineSubsystem<UApiGearConnectionsStore>();
 
-	TScriptInterface<IApiGearConnection> OLinkConnection = AGCM->GetConnection(settings->ConnectionIdentifier);
+	TScriptInterface<IApiGearConnection> OLinkConnection = AGCM->GetConnection(settings->OLinkConnectionIdentifier);
 
+	if (!OLinkConnection.GetInterface())
+	{
+		UE_LOG(LogTbSimpleSimpleArrayInterfaceOLinkClient, Log, TEXT("No valid olink connection for %s, please set during run time"), UTF8_TO_TCHAR(m_sink->olinkObjectName().c_str()));
+		return;
+	}
 	UseConnection(OLinkConnection);
 	OLinkConnection->Connect();
 }

--- a/goldenmaster/Plugins/TbSimple/Source/TbSimple/Private/Generated/OLink/TbSimpleSimpleArrayInterfaceOLinkClient.cpp
+++ b/goldenmaster/Plugins/TbSimple/Source/TbSimple/Private/Generated/OLink/TbSimpleSimpleArrayInterfaceOLinkClient.cpp
@@ -381,7 +381,17 @@ TArray<bool> UTbSimpleSimpleArrayInterfaceOLinkClient::FuncBool_Implementation(c
 		[ParamBool, &Promise, this]()
 		{
 			ApiGear::ObjectLink::InvokeReplyFunc GetSimpleArrayInterfaceStateFunc = [&Promise](ApiGear::ObjectLink::InvokeReplyArg arg)
-			{ Promise.SetValue(arg.value.get<TArray<bool>>()); };
+			{
+				if (!arg.value.empty())
+				{
+					Promise.SetValue(arg.value.get<TArray<bool>>());
+				}
+				else
+				{
+					UE_LOG(LogTbSimpleSimpleArrayInterfaceOLinkClient, Error, TEXT("FuncBool: OLink service returned empty value - should have returned type of TArray<bool>"));
+					Promise.SetValue(TArray<bool>());
+				}
+			};
 			static const auto memberId = ApiGear::ObjectLink::Name::createMemberId(m_sink->olinkObjectName(), "funcBool");
 			m_sink->GetNode()->invokeRemote(memberId, {ParamBool}, GetSimpleArrayInterfaceStateFunc);
 		});
@@ -402,7 +412,17 @@ TArray<int32> UTbSimpleSimpleArrayInterfaceOLinkClient::FuncInt_Implementation(c
 		[ParamInt, &Promise, this]()
 		{
 			ApiGear::ObjectLink::InvokeReplyFunc GetSimpleArrayInterfaceStateFunc = [&Promise](ApiGear::ObjectLink::InvokeReplyArg arg)
-			{ Promise.SetValue(arg.value.get<TArray<int32>>()); };
+			{
+				if (!arg.value.empty())
+				{
+					Promise.SetValue(arg.value.get<TArray<int32>>());
+				}
+				else
+				{
+					UE_LOG(LogTbSimpleSimpleArrayInterfaceOLinkClient, Error, TEXT("FuncInt: OLink service returned empty value - should have returned type of TArray<int32>"));
+					Promise.SetValue(TArray<int32>());
+				}
+			};
 			static const auto memberId = ApiGear::ObjectLink::Name::createMemberId(m_sink->olinkObjectName(), "funcInt");
 			m_sink->GetNode()->invokeRemote(memberId, {ParamInt}, GetSimpleArrayInterfaceStateFunc);
 		});
@@ -423,7 +443,17 @@ TArray<int32> UTbSimpleSimpleArrayInterfaceOLinkClient::FuncInt32_Implementation
 		[ParamInt32, &Promise, this]()
 		{
 			ApiGear::ObjectLink::InvokeReplyFunc GetSimpleArrayInterfaceStateFunc = [&Promise](ApiGear::ObjectLink::InvokeReplyArg arg)
-			{ Promise.SetValue(arg.value.get<TArray<int32>>()); };
+			{
+				if (!arg.value.empty())
+				{
+					Promise.SetValue(arg.value.get<TArray<int32>>());
+				}
+				else
+				{
+					UE_LOG(LogTbSimpleSimpleArrayInterfaceOLinkClient, Error, TEXT("FuncInt32: OLink service returned empty value - should have returned type of TArray<int32>"));
+					Promise.SetValue(TArray<int32>());
+				}
+			};
 			static const auto memberId = ApiGear::ObjectLink::Name::createMemberId(m_sink->olinkObjectName(), "funcInt32");
 			m_sink->GetNode()->invokeRemote(memberId, {ParamInt32}, GetSimpleArrayInterfaceStateFunc);
 		});
@@ -444,7 +474,17 @@ TArray<int64> UTbSimpleSimpleArrayInterfaceOLinkClient::FuncInt64_Implementation
 		[ParamInt64, &Promise, this]()
 		{
 			ApiGear::ObjectLink::InvokeReplyFunc GetSimpleArrayInterfaceStateFunc = [&Promise](ApiGear::ObjectLink::InvokeReplyArg arg)
-			{ Promise.SetValue(arg.value.get<TArray<int64>>()); };
+			{
+				if (!arg.value.empty())
+				{
+					Promise.SetValue(arg.value.get<TArray<int64>>());
+				}
+				else
+				{
+					UE_LOG(LogTbSimpleSimpleArrayInterfaceOLinkClient, Error, TEXT("FuncInt64: OLink service returned empty value - should have returned type of TArray<int64>"));
+					Promise.SetValue(TArray<int64>());
+				}
+			};
 			static const auto memberId = ApiGear::ObjectLink::Name::createMemberId(m_sink->olinkObjectName(), "funcInt64");
 			m_sink->GetNode()->invokeRemote(memberId, {ParamInt64}, GetSimpleArrayInterfaceStateFunc);
 		});
@@ -465,7 +505,17 @@ TArray<float> UTbSimpleSimpleArrayInterfaceOLinkClient::FuncFloat_Implementation
 		[ParamFloat, &Promise, this]()
 		{
 			ApiGear::ObjectLink::InvokeReplyFunc GetSimpleArrayInterfaceStateFunc = [&Promise](ApiGear::ObjectLink::InvokeReplyArg arg)
-			{ Promise.SetValue(arg.value.get<TArray<float>>()); };
+			{
+				if (!arg.value.empty())
+				{
+					Promise.SetValue(arg.value.get<TArray<float>>());
+				}
+				else
+				{
+					UE_LOG(LogTbSimpleSimpleArrayInterfaceOLinkClient, Error, TEXT("FuncFloat: OLink service returned empty value - should have returned type of TArray<float>"));
+					Promise.SetValue(TArray<float>());
+				}
+			};
 			static const auto memberId = ApiGear::ObjectLink::Name::createMemberId(m_sink->olinkObjectName(), "funcFloat");
 			m_sink->GetNode()->invokeRemote(memberId, {ParamFloat}, GetSimpleArrayInterfaceStateFunc);
 		});
@@ -486,7 +536,17 @@ TArray<float> UTbSimpleSimpleArrayInterfaceOLinkClient::FuncFloat32_Implementati
 		[ParamFloat32, &Promise, this]()
 		{
 			ApiGear::ObjectLink::InvokeReplyFunc GetSimpleArrayInterfaceStateFunc = [&Promise](ApiGear::ObjectLink::InvokeReplyArg arg)
-			{ Promise.SetValue(arg.value.get<TArray<float>>()); };
+			{
+				if (!arg.value.empty())
+				{
+					Promise.SetValue(arg.value.get<TArray<float>>());
+				}
+				else
+				{
+					UE_LOG(LogTbSimpleSimpleArrayInterfaceOLinkClient, Error, TEXT("FuncFloat32: OLink service returned empty value - should have returned type of TArray<float>"));
+					Promise.SetValue(TArray<float>());
+				}
+			};
 			static const auto memberId = ApiGear::ObjectLink::Name::createMemberId(m_sink->olinkObjectName(), "funcFloat32");
 			m_sink->GetNode()->invokeRemote(memberId, {ParamFloat32}, GetSimpleArrayInterfaceStateFunc);
 		});
@@ -507,7 +567,17 @@ TArray<double> UTbSimpleSimpleArrayInterfaceOLinkClient::FuncFloat64_Implementat
 		[ParamFloat, &Promise, this]()
 		{
 			ApiGear::ObjectLink::InvokeReplyFunc GetSimpleArrayInterfaceStateFunc = [&Promise](ApiGear::ObjectLink::InvokeReplyArg arg)
-			{ Promise.SetValue(arg.value.get<TArray<double>>()); };
+			{
+				if (!arg.value.empty())
+				{
+					Promise.SetValue(arg.value.get<TArray<double>>());
+				}
+				else
+				{
+					UE_LOG(LogTbSimpleSimpleArrayInterfaceOLinkClient, Error, TEXT("FuncFloat64: OLink service returned empty value - should have returned type of TArray<double>"));
+					Promise.SetValue(TArray<double>());
+				}
+			};
 			static const auto memberId = ApiGear::ObjectLink::Name::createMemberId(m_sink->olinkObjectName(), "funcFloat64");
 			m_sink->GetNode()->invokeRemote(memberId, {ParamFloat}, GetSimpleArrayInterfaceStateFunc);
 		});
@@ -528,7 +598,17 @@ TArray<FString> UTbSimpleSimpleArrayInterfaceOLinkClient::FuncString_Implementat
 		[ParamString, &Promise, this]()
 		{
 			ApiGear::ObjectLink::InvokeReplyFunc GetSimpleArrayInterfaceStateFunc = [&Promise](ApiGear::ObjectLink::InvokeReplyArg arg)
-			{ Promise.SetValue(arg.value.get<TArray<FString>>()); };
+			{
+				if (!arg.value.empty())
+				{
+					Promise.SetValue(arg.value.get<TArray<FString>>());
+				}
+				else
+				{
+					UE_LOG(LogTbSimpleSimpleArrayInterfaceOLinkClient, Error, TEXT("FuncString: OLink service returned empty value - should have returned type of TArray<FString>"));
+					Promise.SetValue(TArray<FString>());
+				}
+			};
 			static const auto memberId = ApiGear::ObjectLink::Name::createMemberId(m_sink->olinkObjectName(), "funcString");
 			m_sink->GetNode()->invokeRemote(memberId, {ParamString}, GetSimpleArrayInterfaceStateFunc);
 		});

--- a/goldenmaster/Plugins/TbSimple/Source/TbSimple/Private/Generated/OLink/TbSimpleSimpleArrayInterfaceOLinkClient.cpp
+++ b/goldenmaster/Plugins/TbSimple/Source/TbSimple/Private/Generated/OLink/TbSimpleSimpleArrayInterfaceOLinkClient.cpp
@@ -22,6 +22,7 @@ limitations under the License.
 
 #include "Generated/OLink/TbSimpleSimpleArrayInterfaceOLinkClient.h"
 #include "ApiGearSettings.h"
+#include "apigearolink.h"
 #include "Async/Async.h"
 #include "Generated/api/TbSimple.json.adapter.h"
 #include "unrealolink.h"
@@ -121,7 +122,7 @@ void UTbSimpleSimpleArrayInterfaceOLinkClient::UseConnection(TScriptInterface<IA
 	checkf(InConnection.GetInterface() != nullptr, TEXT("Cannot use connection - interface IApiGearConnection is not fully implemented"));
 
 	// only accept connections of type olink
-	checkf(InConnection->GetConnectionProtocolIdentifier() == "olink", TEXT("Cannot use connection - must be of type olink"));
+	checkf(InConnection->GetConnectionProtocolIdentifier() == ApiGearOLinkProtocolIdentifier, TEXT("Cannot use connection - must be of type olink"));
 
 	UUnrealOLink* UnrealOLinkConnection = nullptr;
 	// remove old connection

--- a/goldenmaster/Plugins/TbSimple/Source/TbSimple/Private/Generated/OLink/TbSimpleSimpleInterfaceOLinkClient.cpp
+++ b/goldenmaster/Plugins/TbSimple/Source/TbSimple/Private/Generated/OLink/TbSimpleSimpleInterfaceOLinkClient.cpp
@@ -400,7 +400,17 @@ bool UTbSimpleSimpleInterfaceOLinkClient::FuncBool_Implementation(bool bParamBoo
 		[bParamBool, &Promise, this]()
 		{
 			ApiGear::ObjectLink::InvokeReplyFunc GetSimpleInterfaceStateFunc = [&Promise](ApiGear::ObjectLink::InvokeReplyArg arg)
-			{ Promise.SetValue(arg.value.get<bool>()); };
+			{
+				if (!arg.value.empty())
+				{
+					Promise.SetValue(arg.value.get<bool>());
+				}
+				else
+				{
+					UE_LOG(LogTbSimpleSimpleInterfaceOLinkClient, Error, TEXT("FuncBool: OLink service returned empty value - should have returned type of bool"));
+					Promise.SetValue(bool());
+				}
+			};
 			static const auto memberId = ApiGear::ObjectLink::Name::createMemberId(m_sink->olinkObjectName(), "funcBool");
 			m_sink->GetNode()->invokeRemote(memberId, {bParamBool}, GetSimpleInterfaceStateFunc);
 		});
@@ -421,7 +431,17 @@ int32 UTbSimpleSimpleInterfaceOLinkClient::FuncInt_Implementation(int32 ParamInt
 		[ParamInt, &Promise, this]()
 		{
 			ApiGear::ObjectLink::InvokeReplyFunc GetSimpleInterfaceStateFunc = [&Promise](ApiGear::ObjectLink::InvokeReplyArg arg)
-			{ Promise.SetValue(arg.value.get<int32>()); };
+			{
+				if (!arg.value.empty())
+				{
+					Promise.SetValue(arg.value.get<int32>());
+				}
+				else
+				{
+					UE_LOG(LogTbSimpleSimpleInterfaceOLinkClient, Error, TEXT("FuncInt: OLink service returned empty value - should have returned type of int32"));
+					Promise.SetValue(int32());
+				}
+			};
 			static const auto memberId = ApiGear::ObjectLink::Name::createMemberId(m_sink->olinkObjectName(), "funcInt");
 			m_sink->GetNode()->invokeRemote(memberId, {ParamInt}, GetSimpleInterfaceStateFunc);
 		});
@@ -442,7 +462,17 @@ int32 UTbSimpleSimpleInterfaceOLinkClient::FuncInt32_Implementation(int32 ParamI
 		[ParamInt32, &Promise, this]()
 		{
 			ApiGear::ObjectLink::InvokeReplyFunc GetSimpleInterfaceStateFunc = [&Promise](ApiGear::ObjectLink::InvokeReplyArg arg)
-			{ Promise.SetValue(arg.value.get<int32>()); };
+			{
+				if (!arg.value.empty())
+				{
+					Promise.SetValue(arg.value.get<int32>());
+				}
+				else
+				{
+					UE_LOG(LogTbSimpleSimpleInterfaceOLinkClient, Error, TEXT("FuncInt32: OLink service returned empty value - should have returned type of int32"));
+					Promise.SetValue(int32());
+				}
+			};
 			static const auto memberId = ApiGear::ObjectLink::Name::createMemberId(m_sink->olinkObjectName(), "funcInt32");
 			m_sink->GetNode()->invokeRemote(memberId, {ParamInt32}, GetSimpleInterfaceStateFunc);
 		});
@@ -463,7 +493,17 @@ int64 UTbSimpleSimpleInterfaceOLinkClient::FuncInt64_Implementation(int64 ParamI
 		[ParamInt64, &Promise, this]()
 		{
 			ApiGear::ObjectLink::InvokeReplyFunc GetSimpleInterfaceStateFunc = [&Promise](ApiGear::ObjectLink::InvokeReplyArg arg)
-			{ Promise.SetValue(arg.value.get<int64>()); };
+			{
+				if (!arg.value.empty())
+				{
+					Promise.SetValue(arg.value.get<int64>());
+				}
+				else
+				{
+					UE_LOG(LogTbSimpleSimpleInterfaceOLinkClient, Error, TEXT("FuncInt64: OLink service returned empty value - should have returned type of int64"));
+					Promise.SetValue(int64());
+				}
+			};
 			static const auto memberId = ApiGear::ObjectLink::Name::createMemberId(m_sink->olinkObjectName(), "funcInt64");
 			m_sink->GetNode()->invokeRemote(memberId, {ParamInt64}, GetSimpleInterfaceStateFunc);
 		});
@@ -484,7 +524,17 @@ float UTbSimpleSimpleInterfaceOLinkClient::FuncFloat_Implementation(float ParamF
 		[ParamFloat, &Promise, this]()
 		{
 			ApiGear::ObjectLink::InvokeReplyFunc GetSimpleInterfaceStateFunc = [&Promise](ApiGear::ObjectLink::InvokeReplyArg arg)
-			{ Promise.SetValue(arg.value.get<float>()); };
+			{
+				if (!arg.value.empty())
+				{
+					Promise.SetValue(arg.value.get<float>());
+				}
+				else
+				{
+					UE_LOG(LogTbSimpleSimpleInterfaceOLinkClient, Error, TEXT("FuncFloat: OLink service returned empty value - should have returned type of float"));
+					Promise.SetValue(float());
+				}
+			};
 			static const auto memberId = ApiGear::ObjectLink::Name::createMemberId(m_sink->olinkObjectName(), "funcFloat");
 			m_sink->GetNode()->invokeRemote(memberId, {ParamFloat}, GetSimpleInterfaceStateFunc);
 		});
@@ -505,7 +555,17 @@ float UTbSimpleSimpleInterfaceOLinkClient::FuncFloat32_Implementation(float Para
 		[ParamFloat32, &Promise, this]()
 		{
 			ApiGear::ObjectLink::InvokeReplyFunc GetSimpleInterfaceStateFunc = [&Promise](ApiGear::ObjectLink::InvokeReplyArg arg)
-			{ Promise.SetValue(arg.value.get<float>()); };
+			{
+				if (!arg.value.empty())
+				{
+					Promise.SetValue(arg.value.get<float>());
+				}
+				else
+				{
+					UE_LOG(LogTbSimpleSimpleInterfaceOLinkClient, Error, TEXT("FuncFloat32: OLink service returned empty value - should have returned type of float"));
+					Promise.SetValue(float());
+				}
+			};
 			static const auto memberId = ApiGear::ObjectLink::Name::createMemberId(m_sink->olinkObjectName(), "funcFloat32");
 			m_sink->GetNode()->invokeRemote(memberId, {ParamFloat32}, GetSimpleInterfaceStateFunc);
 		});
@@ -526,7 +586,17 @@ double UTbSimpleSimpleInterfaceOLinkClient::FuncFloat64_Implementation(double Pa
 		[ParamFloat, &Promise, this]()
 		{
 			ApiGear::ObjectLink::InvokeReplyFunc GetSimpleInterfaceStateFunc = [&Promise](ApiGear::ObjectLink::InvokeReplyArg arg)
-			{ Promise.SetValue(arg.value.get<double>()); };
+			{
+				if (!arg.value.empty())
+				{
+					Promise.SetValue(arg.value.get<double>());
+				}
+				else
+				{
+					UE_LOG(LogTbSimpleSimpleInterfaceOLinkClient, Error, TEXT("FuncFloat64: OLink service returned empty value - should have returned type of double"));
+					Promise.SetValue(double());
+				}
+			};
 			static const auto memberId = ApiGear::ObjectLink::Name::createMemberId(m_sink->olinkObjectName(), "funcFloat64");
 			m_sink->GetNode()->invokeRemote(memberId, {ParamFloat}, GetSimpleInterfaceStateFunc);
 		});
@@ -547,7 +617,17 @@ FString UTbSimpleSimpleInterfaceOLinkClient::FuncString_Implementation(const FSt
 		[ParamString, &Promise, this]()
 		{
 			ApiGear::ObjectLink::InvokeReplyFunc GetSimpleInterfaceStateFunc = [&Promise](ApiGear::ObjectLink::InvokeReplyArg arg)
-			{ Promise.SetValue(arg.value.get<FString>()); };
+			{
+				if (!arg.value.empty())
+				{
+					Promise.SetValue(arg.value.get<FString>());
+				}
+				else
+				{
+					UE_LOG(LogTbSimpleSimpleInterfaceOLinkClient, Error, TEXT("FuncString: OLink service returned empty value - should have returned type of FString"));
+					Promise.SetValue(FString());
+				}
+			};
 			static const auto memberId = ApiGear::ObjectLink::Name::createMemberId(m_sink->olinkObjectName(), "funcString");
 			m_sink->GetNode()->invokeRemote(memberId, {ParamString}, GetSimpleInterfaceStateFunc);
 		});

--- a/goldenmaster/Plugins/TbSimple/Source/TbSimple/Private/Generated/OLink/TbSimpleSimpleInterfaceOLinkClient.cpp
+++ b/goldenmaster/Plugins/TbSimple/Source/TbSimple/Private/Generated/OLink/TbSimpleSimpleInterfaceOLinkClient.cpp
@@ -22,6 +22,7 @@ limitations under the License.
 
 #include "Generated/OLink/TbSimpleSimpleInterfaceOLinkClient.h"
 #include "ApiGearSettings.h"
+#include "apigearolink.h"
 #include "Async/Async.h"
 #include "Generated/api/TbSimple.json.adapter.h"
 #include "unrealolink.h"
@@ -122,7 +123,7 @@ void UTbSimpleSimpleInterfaceOLinkClient::UseConnection(TScriptInterface<IApiGea
 	checkf(InConnection.GetInterface() != nullptr, TEXT("Cannot use connection - interface IApiGearConnection is not fully implemented"));
 
 	// only accept connections of type olink
-	checkf(InConnection->GetConnectionProtocolIdentifier() == "olink", TEXT("Cannot use connection - must be of type olink"));
+	checkf(InConnection->GetConnectionProtocolIdentifier() == ApiGearOLinkProtocolIdentifier, TEXT("Cannot use connection - must be of type olink"));
 
 	UUnrealOLink* UnrealOLinkConnection = nullptr;
 	// remove old connection

--- a/goldenmaster/Plugins/TbSimple/Source/TbSimple/Private/Generated/OLink/TbSimpleSimpleInterfaceOLinkClient.cpp
+++ b/goldenmaster/Plugins/TbSimple/Source/TbSimple/Private/Generated/OLink/TbSimpleSimpleInterfaceOLinkClient.cpp
@@ -90,8 +90,13 @@ void UTbSimpleSimpleInterfaceOLinkClient::Initialize(FSubsystemCollectionBase& C
 
 	UApiGearConnectionsStore* AGCM = GEngine->GetEngineSubsystem<UApiGearConnectionsStore>();
 
-	TScriptInterface<IApiGearConnection> OLinkConnection = AGCM->GetConnection(settings->ConnectionIdentifier);
+	TScriptInterface<IApiGearConnection> OLinkConnection = AGCM->GetConnection(settings->OLinkConnectionIdentifier);
 
+	if (!OLinkConnection.GetInterface())
+	{
+		UE_LOG(LogTbSimpleSimpleInterfaceOLinkClient, Log, TEXT("No valid olink connection for %s, please set during run time"), UTF8_TO_TCHAR(m_sink->olinkObjectName().c_str()));
+		return;
+	}
 	UseConnection(OLinkConnection);
 	OLinkConnection->Connect();
 }

--- a/goldenmaster/Plugins/TbSimple/Source/TbSimple/Private/TbSimpleSettings.cpp
+++ b/goldenmaster/Plugins/TbSimple/Source/TbSimple/Private/TbSimpleSettings.cpp
@@ -27,18 +27,24 @@ void UTbSimpleSettings::PostInitProperties()
 {
 	Super::PostInitProperties();
 
+	check(GEngine);
+	UApiGearConnectionsStore* AGCM = GEngine->GetEngineSubsystem<UApiGearConnectionsStore>();
+
+	if (!AGCM->DoesConnectionExist(OLinkConnectionIdentifier))
+	{
+		UE_LOG(LogTemp, Warning, TEXT("UTbSimpleSettings could not find connection %s."), *OLinkConnectionIdentifier);
+		OLinkConnectionIdentifier = "";
+	}
+
 	// the local backend does not require configuration
-	if (ConnectionIdentifier == "Local")
+	if (TracerServiceIdentifier == "Local")
 	{
 		return;
 	}
 
-	check(GEngine);
-	UApiGearConnectionsStore* AGCM = GEngine->GetEngineSubsystem<UApiGearConnectionsStore>();
-
-	if (!AGCM->DoesConnectionExist(ConnectionIdentifier))
+	if (!AGCM->DoesConnectionExist(TracerServiceIdentifier))
 	{
-		UE_LOG(LogTemp, Warning, TEXT("UTbSimpleSettings could not find connection %s, falling back to local backend."), *ConnectionIdentifier);
-		ConnectionIdentifier = "Local";
+		UE_LOG(LogTemp, Warning, TEXT("UTbSimpleSettings could not find connection %s, falling back to local backend."), *TracerServiceIdentifier);
+		TracerServiceIdentifier = "Local";
 	}
 }

--- a/goldenmaster/Plugins/TbSimple/Source/TbSimple/Private/TbSimpleSettings.cpp
+++ b/goldenmaster/Plugins/TbSimple/Source/TbSimple/Private/TbSimpleSettings.cpp
@@ -37,7 +37,7 @@ void UTbSimpleSettings::PostInitProperties()
 	}
 
 	// the local backend does not require configuration
-	if (TracerServiceIdentifier == "Local")
+	if (TracerServiceIdentifier == TbSimpleLocalBackendIdentifier)
 	{
 		return;
 	}
@@ -45,6 +45,6 @@ void UTbSimpleSettings::PostInitProperties()
 	if (!AGCM->DoesConnectionExist(TracerServiceIdentifier))
 	{
 		UE_LOG(LogTemp, Warning, TEXT("UTbSimpleSettings could not find connection %s, falling back to local backend."), *TracerServiceIdentifier);
-		TracerServiceIdentifier = "Local";
+		TracerServiceIdentifier = TbSimpleLocalBackendIdentifier;
 	}
 }

--- a/goldenmaster/Plugins/TbSimple/Source/TbSimple/Public/TbSimpleSettings.h
+++ b/goldenmaster/Plugins/TbSimple/Source/TbSimple/Public/TbSimpleSettings.h
@@ -22,6 +22,8 @@ limitations under the License.
 #include "Engine/EngineTypes.h"
 #include "TbSimpleSettings.generated.h"
 
+const FString TbSimpleLocalBackendIdentifier = "Local";
+
 /**
  * Implements the settings for the TbSimple plugin.
  */

--- a/goldenmaster/Plugins/TbSimple/Source/TbSimple/Public/TbSimpleSettings.h
+++ b/goldenmaster/Plugins/TbSimple/Source/TbSimple/Public/TbSimpleSettings.h
@@ -33,6 +33,10 @@ class TBSIMPLE_API UTbSimpleSettings : public UObject
 	virtual void PostInitProperties() override;
 
 	// Choose the backend service for the logging decorator to use
-	UPROPERTY(EditAnywhere, config, Category = ServiceSetup)
-	FString ConnectionIdentifier;
+	UPROPERTY(EditAnywhere, config, Category = TracerServiceSetup)
+	FString TracerServiceIdentifier;
+
+	// Choose the olink connection to use
+	UPROPERTY(EditAnywhere, config, Category = OLinkConnectionSetup)
+	FString OLinkConnectionIdentifier;
 };

--- a/goldenmaster/Plugins/TbSimple/Source/TbSimpleEditor/Private/TbSimpleConnectionSettings.cpp
+++ b/goldenmaster/Plugins/TbSimple/Source/TbSimpleEditor/Private/TbSimpleConnectionSettings.cpp
@@ -2,6 +2,7 @@
 #include "TbSimpleConnectionSettings.h"
 
 #include "ApiGearSettings.h"
+#include "apigearolink.h"
 #include "TbSimpleSettings.h"
 #include "Templates/SharedPointer.h"
 #include "IDetailCustomization.h"
@@ -106,7 +107,7 @@ TSharedRef<SWidget> FTbSimpleConnectionSettingsDetails::MakeDefaultOLinkConnecti
 
 	for (auto ConnectionSetting : settings->Connections)
 	{
-		if (ConnectionSetting.Value.ProtocolIdentifier == "olink")
+		if (ConnectionSetting.Value.ProtocolIdentifier == ApiGearOLinkProtocolIdentifier)
 		{
 			TSharedPtr<FText> ConnectionName = MakeShared<FText>(FText::FromString(*ConnectionSetting.Key));
 			AvailableOLinkConnectionNames->Add(ConnectionName);

--- a/goldenmaster/Plugins/TbSimple/Source/TbSimpleEditor/Private/TbSimpleConnectionSettings.cpp
+++ b/goldenmaster/Plugins/TbSimple/Source/TbSimpleEditor/Private/TbSimpleConnectionSettings.cpp
@@ -2,6 +2,7 @@
 #include "TbSimpleConnectionSettings.h"
 
 #include "ApiGearSettings.h"
+#include "TbSimpleSettings.h"
 #include "Templates/SharedPointer.h"
 #include "IDetailCustomization.h"
 #include "PropertyHandle.h"
@@ -32,7 +33,7 @@ TSharedRef<SWidget> FTbSimpleConnectionSettingsDetails::MakeDefaultBackendServic
 	TArray<TSharedPtr<FText>>* AvailableServicesNames = &AvailableServices;
 	FText TooltipText = FText::FromString(TEXT("Choose which service should be used as default."));
 
-	TSharedPtr<FText> LocalServiceName = TSharedPtr<FText>(new FText(FText::FromString(TEXT("Local"))));
+	TSharedPtr<FText> LocalServiceName = TSharedPtr<FText>(new FText(FText::FromString(TbSimpleLocalBackendIdentifier)));
 	AvailableServicesNames->Add(LocalServiceName);
 	SelectedDefaultBackendService = LocalServiceName;
 

--- a/goldenmaster/Plugins/TbSimple/Source/TbSimpleEditor/Public/TbSimpleConnectionSettings.h
+++ b/goldenmaster/Plugins/TbSimple/Source/TbSimpleEditor/Public/TbSimpleConnectionSettings.h
@@ -21,8 +21,13 @@ public:
 	virtual void CustomizeDetails(IDetailLayoutBuilder& DetailBuilder) override;
 
 private:
-	TSharedRef<SWidget> MakeDefaultConnectionSelectorWidget(const TSharedPtr<IPropertyHandle>& PropertyHandle);
+	void CustomizeTracerDetails(IDetailLayoutBuilder& DetailBuilder);
+	TSharedRef<SWidget> MakeDefaultBackendServiceSelectorWidget(const TSharedPtr<IPropertyHandle>& PropertyHandle);
+	TSharedPtr<FText> SelectedDefaultBackendService;
+	TArray<TSharedPtr<FText>> AvailableServices;
 
-	TSharedPtr<FText> SelectedDefaultConnection;
-	TArray<TSharedPtr<FText>> AvailableConnections;
+	void CustomizeOLinkDetails(IDetailLayoutBuilder& DetailBuilder);
+	TSharedRef<SWidget> MakeDefaultOLinkConnectionSelectorWidget(const TSharedPtr<IPropertyHandle>& PropertyHandle);
+	TSharedPtr<FText> SelectedDefaultOLinkConnection;
+	TArray<TSharedPtr<FText>> AvailableOLinkConnections;
 };

--- a/goldenmaster/Plugins/TbSimple/Source/TbSimpleEditor/TbSimpleEditor.Build.cs
+++ b/goldenmaster/Plugins/TbSimple/Source/TbSimpleEditor/TbSimpleEditor.Build.cs
@@ -14,6 +14,7 @@ namespace UnrealBuildTool.Rules
 					"UnrealEd",
 					// modules below are needed for connection settings
 					"ApiGear",
+					"ApiGearOLink",
 					"InputCore",
 					"PropertyEditor",
 					"Slate",

--- a/goldenmaster/Plugins/Testbed1/Source/Testbed1/Private/Generated/Monitor/Testbed1Factory.cpp
+++ b/goldenmaster/Plugins/Testbed1/Source/Testbed1/Private/Generated/Monitor/Testbed1Factory.cpp
@@ -17,6 +17,7 @@ limitations under the License.
 
 #include "Testbed1Factory.h"
 #include "ApiGearSettings.h"
+#include "Testbed1Settings.h"
 #include "Implementation/Testbed1StructInterface.h"
 #include "Generated/OLink/Testbed1StructInterfaceOLinkClient.h"
 #include "Implementation/Testbed1StructArrayInterface.h"
@@ -76,7 +77,7 @@ TScriptInterface<ITestbed1StructInterfaceInterface> FTestbed1ModuleFactory::crea
 {
 	UTestbed1Settings* Testbed1Settings = GetMutableDefault<UTestbed1Settings>();
 
-	if (Testbed1Settings->TracerServiceIdentifier == "Local")
+	if (Testbed1Settings->TracerServiceIdentifier == Testbed1LocalBackendIdentifier)
 	{
 		return createTestbed1StructInterface(GameInstance, Collection);
 	}
@@ -124,7 +125,7 @@ TScriptInterface<ITestbed1StructInterfaceInterface> FTestbed1ModuleFactory::crea
 {
 	UTestbed1Settings* Testbed1Settings = GetMutableDefault<UTestbed1Settings>();
 
-	if (Testbed1Settings->TracerServiceIdentifier == "Local")
+	if (Testbed1Settings->TracerServiceIdentifier == Testbed1LocalBackendIdentifier)
 	{
 		return createTestbed1StructInterface(Collection);
 	}
@@ -184,7 +185,7 @@ TScriptInterface<ITestbed1StructArrayInterfaceInterface> FTestbed1ModuleFactory:
 {
 	UTestbed1Settings* Testbed1Settings = GetMutableDefault<UTestbed1Settings>();
 
-	if (Testbed1Settings->TracerServiceIdentifier == "Local")
+	if (Testbed1Settings->TracerServiceIdentifier == Testbed1LocalBackendIdentifier)
 	{
 		return createTestbed1StructArrayInterface(GameInstance, Collection);
 	}
@@ -232,7 +233,7 @@ TScriptInterface<ITestbed1StructArrayInterfaceInterface> FTestbed1ModuleFactory:
 {
 	UTestbed1Settings* Testbed1Settings = GetMutableDefault<UTestbed1Settings>();
 
-	if (Testbed1Settings->TracerServiceIdentifier == "Local")
+	if (Testbed1Settings->TracerServiceIdentifier == Testbed1LocalBackendIdentifier)
 	{
 		return createTestbed1StructArrayInterface(Collection);
 	}

--- a/goldenmaster/Plugins/Testbed1/Source/Testbed1/Private/Generated/Monitor/Testbed1Factory.cpp
+++ b/goldenmaster/Plugins/Testbed1/Source/Testbed1/Private/Generated/Monitor/Testbed1Factory.cpp
@@ -17,6 +17,7 @@ limitations under the License.
 
 #include "Testbed1Factory.h"
 #include "ApiGearSettings.h"
+#include "apigearolink.h"
 #include "Testbed1Settings.h"
 #include "Implementation/Testbed1StructInterface.h"
 #include "Generated/OLink/Testbed1StructInterfaceOLinkClient.h"
@@ -88,7 +89,7 @@ TScriptInterface<ITestbed1StructInterfaceInterface> FTestbed1ModuleFactory::crea
 	// Other protocols not supported. To support it edit templates:
 	// add protocol handler class for this interface like createTestbed1StructInterfaceOLink and other necessary infrastructure
 	// extend this function in templates to handle protocol of your choice
-	if (ConnectionSetting && ConnectionSetting->ProtocolIdentifier == "olink")
+	if (ConnectionSetting && ConnectionSetting->ProtocolIdentifier == ApiGearOLinkProtocolIdentifier)
 	{
 		return createTestbed1StructInterfaceOLink(GameInstance, Collection);
 	}
@@ -136,7 +137,7 @@ TScriptInterface<ITestbed1StructInterfaceInterface> FTestbed1ModuleFactory::crea
 	// Other protocols not supported. To support it edit templates:
 	// add protocol handler class for this interface like createTestbed1StructInterfaceOLink and other necessary infrastructure
 	// extend this function in templates to handle protocol of your choice
-	if (ConnectionSetting && ConnectionSetting->ProtocolIdentifier == "olink")
+	if (ConnectionSetting && ConnectionSetting->ProtocolIdentifier == ApiGearOLinkProtocolIdentifier)
 	{
 		return createTestbed1StructInterfaceOLink(Collection);
 	}
@@ -196,7 +197,7 @@ TScriptInterface<ITestbed1StructArrayInterfaceInterface> FTestbed1ModuleFactory:
 	// Other protocols not supported. To support it edit templates:
 	// add protocol handler class for this interface like createTestbed1StructArrayInterfaceOLink and other necessary infrastructure
 	// extend this function in templates to handle protocol of your choice
-	if (ConnectionSetting && ConnectionSetting->ProtocolIdentifier == "olink")
+	if (ConnectionSetting && ConnectionSetting->ProtocolIdentifier == ApiGearOLinkProtocolIdentifier)
 	{
 		return createTestbed1StructArrayInterfaceOLink(GameInstance, Collection);
 	}
@@ -244,7 +245,7 @@ TScriptInterface<ITestbed1StructArrayInterfaceInterface> FTestbed1ModuleFactory:
 	// Other protocols not supported. To support it edit templates:
 	// add protocol handler class for this interface like createTestbed1StructArrayInterfaceOLink and other necessary infrastructure
 	// extend this function in templates to handle protocol of your choice
-	if (ConnectionSetting && ConnectionSetting->ProtocolIdentifier == "olink")
+	if (ConnectionSetting && ConnectionSetting->ProtocolIdentifier == ApiGearOLinkProtocolIdentifier)
 	{
 		return createTestbed1StructArrayInterfaceOLink(Collection);
 	}

--- a/goldenmaster/Plugins/Testbed1/Source/Testbed1/Private/Generated/Monitor/Testbed1Factory.cpp
+++ b/goldenmaster/Plugins/Testbed1/Source/Testbed1/Private/Generated/Monitor/Testbed1Factory.cpp
@@ -76,13 +76,13 @@ TScriptInterface<ITestbed1StructInterfaceInterface> FTestbed1ModuleFactory::crea
 {
 	UTestbed1Settings* Testbed1Settings = GetMutableDefault<UTestbed1Settings>();
 
-	if (Testbed1Settings->ConnectionIdentifier == "Local")
+	if (Testbed1Settings->TracerServiceIdentifier == "Local")
 	{
 		return createTestbed1StructInterface(GameInstance, Collection);
 	}
 
 	UApiGearSettings* ApiGearSettings = GetMutableDefault<UApiGearSettings>();
-	FApiGearConnectionSetting* ConnectionSetting = ApiGearSettings->Connections.Find(Testbed1Settings->ConnectionIdentifier);
+	FApiGearConnectionSetting* ConnectionSetting = ApiGearSettings->Connections.Find(Testbed1Settings->TracerServiceIdentifier);
 
 	// Other protocols not supported. To support it edit templates:
 	// add protocol handler class for this interface like createTestbed1StructInterfaceOLink and other necessary infrastructure
@@ -124,13 +124,13 @@ TScriptInterface<ITestbed1StructInterfaceInterface> FTestbed1ModuleFactory::crea
 {
 	UTestbed1Settings* Testbed1Settings = GetMutableDefault<UTestbed1Settings>();
 
-	if (Testbed1Settings->ConnectionIdentifier == "Local")
+	if (Testbed1Settings->TracerServiceIdentifier == "Local")
 	{
 		return createTestbed1StructInterface(Collection);
 	}
 
 	UApiGearSettings* ApiGearSettings = GetMutableDefault<UApiGearSettings>();
-	FApiGearConnectionSetting* ConnectionSetting = ApiGearSettings->Connections.Find(Testbed1Settings->ConnectionIdentifier);
+	FApiGearConnectionSetting* ConnectionSetting = ApiGearSettings->Connections.Find(Testbed1Settings->TracerServiceIdentifier);
 
 	// Other protocols not supported. To support it edit templates:
 	// add protocol handler class for this interface like createTestbed1StructInterfaceOLink and other necessary infrastructure
@@ -184,13 +184,13 @@ TScriptInterface<ITestbed1StructArrayInterfaceInterface> FTestbed1ModuleFactory:
 {
 	UTestbed1Settings* Testbed1Settings = GetMutableDefault<UTestbed1Settings>();
 
-	if (Testbed1Settings->ConnectionIdentifier == "Local")
+	if (Testbed1Settings->TracerServiceIdentifier == "Local")
 	{
 		return createTestbed1StructArrayInterface(GameInstance, Collection);
 	}
 
 	UApiGearSettings* ApiGearSettings = GetMutableDefault<UApiGearSettings>();
-	FApiGearConnectionSetting* ConnectionSetting = ApiGearSettings->Connections.Find(Testbed1Settings->ConnectionIdentifier);
+	FApiGearConnectionSetting* ConnectionSetting = ApiGearSettings->Connections.Find(Testbed1Settings->TracerServiceIdentifier);
 
 	// Other protocols not supported. To support it edit templates:
 	// add protocol handler class for this interface like createTestbed1StructArrayInterfaceOLink and other necessary infrastructure
@@ -232,13 +232,13 @@ TScriptInterface<ITestbed1StructArrayInterfaceInterface> FTestbed1ModuleFactory:
 {
 	UTestbed1Settings* Testbed1Settings = GetMutableDefault<UTestbed1Settings>();
 
-	if (Testbed1Settings->ConnectionIdentifier == "Local")
+	if (Testbed1Settings->TracerServiceIdentifier == "Local")
 	{
 		return createTestbed1StructArrayInterface(Collection);
 	}
 
 	UApiGearSettings* ApiGearSettings = GetMutableDefault<UApiGearSettings>();
-	FApiGearConnectionSetting* ConnectionSetting = ApiGearSettings->Connections.Find(Testbed1Settings->ConnectionIdentifier);
+	FApiGearConnectionSetting* ConnectionSetting = ApiGearSettings->Connections.Find(Testbed1Settings->TracerServiceIdentifier);
 
 	// Other protocols not supported. To support it edit templates:
 	// add protocol handler class for this interface like createTestbed1StructArrayInterfaceOLink and other necessary infrastructure

--- a/goldenmaster/Plugins/Testbed1/Source/Testbed1/Private/Generated/OLink/Testbed1StructArrayInterfaceOLinkClient.cpp
+++ b/goldenmaster/Plugins/Testbed1/Source/Testbed1/Private/Generated/OLink/Testbed1StructArrayInterfaceOLinkClient.cpp
@@ -261,7 +261,17 @@ FTestbed1StructBool UTestbed1StructArrayInterfaceOLinkClient::FuncBool_Implement
 		[ParamBool, &Promise, this]()
 		{
 			ApiGear::ObjectLink::InvokeReplyFunc GetStructArrayInterfaceStateFunc = [&Promise](ApiGear::ObjectLink::InvokeReplyArg arg)
-			{ Promise.SetValue(arg.value.get<FTestbed1StructBool>()); };
+			{
+				if (!arg.value.empty())
+				{
+					Promise.SetValue(arg.value.get<FTestbed1StructBool>());
+				}
+				else
+				{
+					UE_LOG(LogTestbed1StructArrayInterfaceOLinkClient, Error, TEXT("FuncBool: OLink service returned empty value - should have returned type of FTestbed1StructBool"));
+					Promise.SetValue(FTestbed1StructBool());
+				}
+			};
 			static const auto memberId = ApiGear::ObjectLink::Name::createMemberId(m_sink->olinkObjectName(), "funcBool");
 			m_sink->GetNode()->invokeRemote(memberId, {ParamBool}, GetStructArrayInterfaceStateFunc);
 		});
@@ -282,7 +292,17 @@ FTestbed1StructBool UTestbed1StructArrayInterfaceOLinkClient::FuncInt_Implementa
 		[ParamInt, &Promise, this]()
 		{
 			ApiGear::ObjectLink::InvokeReplyFunc GetStructArrayInterfaceStateFunc = [&Promise](ApiGear::ObjectLink::InvokeReplyArg arg)
-			{ Promise.SetValue(arg.value.get<FTestbed1StructBool>()); };
+			{
+				if (!arg.value.empty())
+				{
+					Promise.SetValue(arg.value.get<FTestbed1StructBool>());
+				}
+				else
+				{
+					UE_LOG(LogTestbed1StructArrayInterfaceOLinkClient, Error, TEXT("FuncInt: OLink service returned empty value - should have returned type of FTestbed1StructBool"));
+					Promise.SetValue(FTestbed1StructBool());
+				}
+			};
 			static const auto memberId = ApiGear::ObjectLink::Name::createMemberId(m_sink->olinkObjectName(), "funcInt");
 			m_sink->GetNode()->invokeRemote(memberId, {ParamInt}, GetStructArrayInterfaceStateFunc);
 		});
@@ -303,7 +323,17 @@ FTestbed1StructBool UTestbed1StructArrayInterfaceOLinkClient::FuncFloat_Implemen
 		[ParamFloat, &Promise, this]()
 		{
 			ApiGear::ObjectLink::InvokeReplyFunc GetStructArrayInterfaceStateFunc = [&Promise](ApiGear::ObjectLink::InvokeReplyArg arg)
-			{ Promise.SetValue(arg.value.get<FTestbed1StructBool>()); };
+			{
+				if (!arg.value.empty())
+				{
+					Promise.SetValue(arg.value.get<FTestbed1StructBool>());
+				}
+				else
+				{
+					UE_LOG(LogTestbed1StructArrayInterfaceOLinkClient, Error, TEXT("FuncFloat: OLink service returned empty value - should have returned type of FTestbed1StructBool"));
+					Promise.SetValue(FTestbed1StructBool());
+				}
+			};
 			static const auto memberId = ApiGear::ObjectLink::Name::createMemberId(m_sink->olinkObjectName(), "funcFloat");
 			m_sink->GetNode()->invokeRemote(memberId, {ParamFloat}, GetStructArrayInterfaceStateFunc);
 		});
@@ -324,7 +354,17 @@ FTestbed1StructBool UTestbed1StructArrayInterfaceOLinkClient::FuncString_Impleme
 		[ParamString, &Promise, this]()
 		{
 			ApiGear::ObjectLink::InvokeReplyFunc GetStructArrayInterfaceStateFunc = [&Promise](ApiGear::ObjectLink::InvokeReplyArg arg)
-			{ Promise.SetValue(arg.value.get<FTestbed1StructBool>()); };
+			{
+				if (!arg.value.empty())
+				{
+					Promise.SetValue(arg.value.get<FTestbed1StructBool>());
+				}
+				else
+				{
+					UE_LOG(LogTestbed1StructArrayInterfaceOLinkClient, Error, TEXT("FuncString: OLink service returned empty value - should have returned type of FTestbed1StructBool"));
+					Promise.SetValue(FTestbed1StructBool());
+				}
+			};
 			static const auto memberId = ApiGear::ObjectLink::Name::createMemberId(m_sink->olinkObjectName(), "funcString");
 			m_sink->GetNode()->invokeRemote(memberId, {ParamString}, GetStructArrayInterfaceStateFunc);
 		});

--- a/goldenmaster/Plugins/Testbed1/Source/Testbed1/Private/Generated/OLink/Testbed1StructArrayInterfaceOLinkClient.cpp
+++ b/goldenmaster/Plugins/Testbed1/Source/Testbed1/Private/Generated/OLink/Testbed1StructArrayInterfaceOLinkClient.cpp
@@ -22,6 +22,7 @@ limitations under the License.
 
 #include "Generated/OLink/Testbed1StructArrayInterfaceOLinkClient.h"
 #include "ApiGearSettings.h"
+#include "apigearolink.h"
 #include "Async/Async.h"
 #include "Generated/api/Testbed1.json.adapter.h"
 #include "unrealolink.h"
@@ -117,7 +118,7 @@ void UTestbed1StructArrayInterfaceOLinkClient::UseConnection(TScriptInterface<IA
 	checkf(InConnection.GetInterface() != nullptr, TEXT("Cannot use connection - interface IApiGearConnection is not fully implemented"));
 
 	// only accept connections of type olink
-	checkf(InConnection->GetConnectionProtocolIdentifier() == "olink", TEXT("Cannot use connection - must be of type olink"));
+	checkf(InConnection->GetConnectionProtocolIdentifier() == ApiGearOLinkProtocolIdentifier, TEXT("Cannot use connection - must be of type olink"));
 
 	UUnrealOLink* UnrealOLinkConnection = nullptr;
 	// remove old connection

--- a/goldenmaster/Plugins/Testbed1/Source/Testbed1/Private/Generated/OLink/Testbed1StructArrayInterfaceOLinkClient.cpp
+++ b/goldenmaster/Plugins/Testbed1/Source/Testbed1/Private/Generated/OLink/Testbed1StructArrayInterfaceOLinkClient.cpp
@@ -85,8 +85,13 @@ void UTestbed1StructArrayInterfaceOLinkClient::Initialize(FSubsystemCollectionBa
 
 	UApiGearConnectionsStore* AGCM = GEngine->GetEngineSubsystem<UApiGearConnectionsStore>();
 
-	TScriptInterface<IApiGearConnection> OLinkConnection = AGCM->GetConnection(settings->ConnectionIdentifier);
+	TScriptInterface<IApiGearConnection> OLinkConnection = AGCM->GetConnection(settings->OLinkConnectionIdentifier);
 
+	if (!OLinkConnection.GetInterface())
+	{
+		UE_LOG(LogTestbed1StructArrayInterfaceOLinkClient, Log, TEXT("No valid olink connection for %s, please set during run time"), UTF8_TO_TCHAR(m_sink->olinkObjectName().c_str()));
+		return;
+	}
 	UseConnection(OLinkConnection);
 	OLinkConnection->Connect();
 }

--- a/goldenmaster/Plugins/Testbed1/Source/Testbed1/Private/Generated/OLink/Testbed1StructInterfaceOLinkClient.cpp
+++ b/goldenmaster/Plugins/Testbed1/Source/Testbed1/Private/Generated/OLink/Testbed1StructInterfaceOLinkClient.cpp
@@ -261,7 +261,17 @@ FTestbed1StructBool UTestbed1StructInterfaceOLinkClient::FuncBool_Implementation
 		[ParamBool, &Promise, this]()
 		{
 			ApiGear::ObjectLink::InvokeReplyFunc GetStructInterfaceStateFunc = [&Promise](ApiGear::ObjectLink::InvokeReplyArg arg)
-			{ Promise.SetValue(arg.value.get<FTestbed1StructBool>()); };
+			{
+				if (!arg.value.empty())
+				{
+					Promise.SetValue(arg.value.get<FTestbed1StructBool>());
+				}
+				else
+				{
+					UE_LOG(LogTestbed1StructInterfaceOLinkClient, Error, TEXT("FuncBool: OLink service returned empty value - should have returned type of FTestbed1StructBool"));
+					Promise.SetValue(FTestbed1StructBool());
+				}
+			};
 			static const auto memberId = ApiGear::ObjectLink::Name::createMemberId(m_sink->olinkObjectName(), "funcBool");
 			m_sink->GetNode()->invokeRemote(memberId, {ParamBool}, GetStructInterfaceStateFunc);
 		});
@@ -282,7 +292,17 @@ FTestbed1StructBool UTestbed1StructInterfaceOLinkClient::FuncInt_Implementation(
 		[ParamInt, &Promise, this]()
 		{
 			ApiGear::ObjectLink::InvokeReplyFunc GetStructInterfaceStateFunc = [&Promise](ApiGear::ObjectLink::InvokeReplyArg arg)
-			{ Promise.SetValue(arg.value.get<FTestbed1StructBool>()); };
+			{
+				if (!arg.value.empty())
+				{
+					Promise.SetValue(arg.value.get<FTestbed1StructBool>());
+				}
+				else
+				{
+					UE_LOG(LogTestbed1StructInterfaceOLinkClient, Error, TEXT("FuncInt: OLink service returned empty value - should have returned type of FTestbed1StructBool"));
+					Promise.SetValue(FTestbed1StructBool());
+				}
+			};
 			static const auto memberId = ApiGear::ObjectLink::Name::createMemberId(m_sink->olinkObjectName(), "funcInt");
 			m_sink->GetNode()->invokeRemote(memberId, {ParamInt}, GetStructInterfaceStateFunc);
 		});
@@ -303,7 +323,17 @@ FTestbed1StructFloat UTestbed1StructInterfaceOLinkClient::FuncFloat_Implementati
 		[ParamFloat, &Promise, this]()
 		{
 			ApiGear::ObjectLink::InvokeReplyFunc GetStructInterfaceStateFunc = [&Promise](ApiGear::ObjectLink::InvokeReplyArg arg)
-			{ Promise.SetValue(arg.value.get<FTestbed1StructFloat>()); };
+			{
+				if (!arg.value.empty())
+				{
+					Promise.SetValue(arg.value.get<FTestbed1StructFloat>());
+				}
+				else
+				{
+					UE_LOG(LogTestbed1StructInterfaceOLinkClient, Error, TEXT("FuncFloat: OLink service returned empty value - should have returned type of FTestbed1StructFloat"));
+					Promise.SetValue(FTestbed1StructFloat());
+				}
+			};
 			static const auto memberId = ApiGear::ObjectLink::Name::createMemberId(m_sink->olinkObjectName(), "funcFloat");
 			m_sink->GetNode()->invokeRemote(memberId, {ParamFloat}, GetStructInterfaceStateFunc);
 		});
@@ -324,7 +354,17 @@ FTestbed1StructString UTestbed1StructInterfaceOLinkClient::FuncString_Implementa
 		[ParamString, &Promise, this]()
 		{
 			ApiGear::ObjectLink::InvokeReplyFunc GetStructInterfaceStateFunc = [&Promise](ApiGear::ObjectLink::InvokeReplyArg arg)
-			{ Promise.SetValue(arg.value.get<FTestbed1StructString>()); };
+			{
+				if (!arg.value.empty())
+				{
+					Promise.SetValue(arg.value.get<FTestbed1StructString>());
+				}
+				else
+				{
+					UE_LOG(LogTestbed1StructInterfaceOLinkClient, Error, TEXT("FuncString: OLink service returned empty value - should have returned type of FTestbed1StructString"));
+					Promise.SetValue(FTestbed1StructString());
+				}
+			};
 			static const auto memberId = ApiGear::ObjectLink::Name::createMemberId(m_sink->olinkObjectName(), "funcString");
 			m_sink->GetNode()->invokeRemote(memberId, {ParamString}, GetStructInterfaceStateFunc);
 		});

--- a/goldenmaster/Plugins/Testbed1/Source/Testbed1/Private/Generated/OLink/Testbed1StructInterfaceOLinkClient.cpp
+++ b/goldenmaster/Plugins/Testbed1/Source/Testbed1/Private/Generated/OLink/Testbed1StructInterfaceOLinkClient.cpp
@@ -85,8 +85,13 @@ void UTestbed1StructInterfaceOLinkClient::Initialize(FSubsystemCollectionBase& C
 
 	UApiGearConnectionsStore* AGCM = GEngine->GetEngineSubsystem<UApiGearConnectionsStore>();
 
-	TScriptInterface<IApiGearConnection> OLinkConnection = AGCM->GetConnection(settings->ConnectionIdentifier);
+	TScriptInterface<IApiGearConnection> OLinkConnection = AGCM->GetConnection(settings->OLinkConnectionIdentifier);
 
+	if (!OLinkConnection.GetInterface())
+	{
+		UE_LOG(LogTestbed1StructInterfaceOLinkClient, Log, TEXT("No valid olink connection for %s, please set during run time"), UTF8_TO_TCHAR(m_sink->olinkObjectName().c_str()));
+		return;
+	}
 	UseConnection(OLinkConnection);
 	OLinkConnection->Connect();
 }

--- a/goldenmaster/Plugins/Testbed1/Source/Testbed1/Private/Generated/OLink/Testbed1StructInterfaceOLinkClient.cpp
+++ b/goldenmaster/Plugins/Testbed1/Source/Testbed1/Private/Generated/OLink/Testbed1StructInterfaceOLinkClient.cpp
@@ -22,6 +22,7 @@ limitations under the License.
 
 #include "Generated/OLink/Testbed1StructInterfaceOLinkClient.h"
 #include "ApiGearSettings.h"
+#include "apigearolink.h"
 #include "Async/Async.h"
 #include "Generated/api/Testbed1.json.adapter.h"
 #include "unrealolink.h"
@@ -117,7 +118,7 @@ void UTestbed1StructInterfaceOLinkClient::UseConnection(TScriptInterface<IApiGea
 	checkf(InConnection.GetInterface() != nullptr, TEXT("Cannot use connection - interface IApiGearConnection is not fully implemented"));
 
 	// only accept connections of type olink
-	checkf(InConnection->GetConnectionProtocolIdentifier() == "olink", TEXT("Cannot use connection - must be of type olink"));
+	checkf(InConnection->GetConnectionProtocolIdentifier() == ApiGearOLinkProtocolIdentifier, TEXT("Cannot use connection - must be of type olink"));
 
 	UUnrealOLink* UnrealOLinkConnection = nullptr;
 	// remove old connection

--- a/goldenmaster/Plugins/Testbed1/Source/Testbed1/Private/Testbed1Settings.cpp
+++ b/goldenmaster/Plugins/Testbed1/Source/Testbed1/Private/Testbed1Settings.cpp
@@ -37,7 +37,7 @@ void UTestbed1Settings::PostInitProperties()
 	}
 
 	// the local backend does not require configuration
-	if (TracerServiceIdentifier == "Local")
+	if (TracerServiceIdentifier == Testbed1LocalBackendIdentifier)
 	{
 		return;
 	}
@@ -45,6 +45,6 @@ void UTestbed1Settings::PostInitProperties()
 	if (!AGCM->DoesConnectionExist(TracerServiceIdentifier))
 	{
 		UE_LOG(LogTemp, Warning, TEXT("UTestbed1Settings could not find connection %s, falling back to local backend."), *TracerServiceIdentifier);
-		TracerServiceIdentifier = "Local";
+		TracerServiceIdentifier = Testbed1LocalBackendIdentifier;
 	}
 }

--- a/goldenmaster/Plugins/Testbed1/Source/Testbed1/Private/Testbed1Settings.cpp
+++ b/goldenmaster/Plugins/Testbed1/Source/Testbed1/Private/Testbed1Settings.cpp
@@ -27,18 +27,24 @@ void UTestbed1Settings::PostInitProperties()
 {
 	Super::PostInitProperties();
 
+	check(GEngine);
+	UApiGearConnectionsStore* AGCM = GEngine->GetEngineSubsystem<UApiGearConnectionsStore>();
+
+	if (!AGCM->DoesConnectionExist(OLinkConnectionIdentifier))
+	{
+		UE_LOG(LogTemp, Warning, TEXT("UTestbed1Settings could not find connection %s."), *OLinkConnectionIdentifier);
+		OLinkConnectionIdentifier = "";
+	}
+
 	// the local backend does not require configuration
-	if (ConnectionIdentifier == "Local")
+	if (TracerServiceIdentifier == "Local")
 	{
 		return;
 	}
 
-	check(GEngine);
-	UApiGearConnectionsStore* AGCM = GEngine->GetEngineSubsystem<UApiGearConnectionsStore>();
-
-	if (!AGCM->DoesConnectionExist(ConnectionIdentifier))
+	if (!AGCM->DoesConnectionExist(TracerServiceIdentifier))
 	{
-		UE_LOG(LogTemp, Warning, TEXT("UTestbed1Settings could not find connection %s, falling back to local backend."), *ConnectionIdentifier);
-		ConnectionIdentifier = "Local";
+		UE_LOG(LogTemp, Warning, TEXT("UTestbed1Settings could not find connection %s, falling back to local backend."), *TracerServiceIdentifier);
+		TracerServiceIdentifier = "Local";
 	}
 }

--- a/goldenmaster/Plugins/Testbed1/Source/Testbed1/Public/Testbed1Settings.h
+++ b/goldenmaster/Plugins/Testbed1/Source/Testbed1/Public/Testbed1Settings.h
@@ -22,6 +22,8 @@ limitations under the License.
 #include "Engine/EngineTypes.h"
 #include "Testbed1Settings.generated.h"
 
+const FString Testbed1LocalBackendIdentifier = "Local";
+
 /**
  * Implements the settings for the Testbed1 plugin.
  */

--- a/goldenmaster/Plugins/Testbed1/Source/Testbed1/Public/Testbed1Settings.h
+++ b/goldenmaster/Plugins/Testbed1/Source/Testbed1/Public/Testbed1Settings.h
@@ -33,6 +33,10 @@ class TESTBED1_API UTestbed1Settings : public UObject
 	virtual void PostInitProperties() override;
 
 	// Choose the backend service for the logging decorator to use
-	UPROPERTY(EditAnywhere, config, Category = ServiceSetup)
-	FString ConnectionIdentifier;
+	UPROPERTY(EditAnywhere, config, Category = TracerServiceSetup)
+	FString TracerServiceIdentifier;
+
+	// Choose the olink connection to use
+	UPROPERTY(EditAnywhere, config, Category = OLinkConnectionSetup)
+	FString OLinkConnectionIdentifier;
 };

--- a/goldenmaster/Plugins/Testbed1/Source/Testbed1Editor/Private/Testbed1ConnectionSettings.cpp
+++ b/goldenmaster/Plugins/Testbed1/Source/Testbed1Editor/Private/Testbed1ConnectionSettings.cpp
@@ -2,6 +2,7 @@
 #include "Testbed1ConnectionSettings.h"
 
 #include "ApiGearSettings.h"
+#include "Testbed1Settings.h"
 #include "Templates/SharedPointer.h"
 #include "IDetailCustomization.h"
 #include "PropertyHandle.h"
@@ -32,7 +33,7 @@ TSharedRef<SWidget> FTestbed1ConnectionSettingsDetails::MakeDefaultBackendServic
 	TArray<TSharedPtr<FText>>* AvailableServicesNames = &AvailableServices;
 	FText TooltipText = FText::FromString(TEXT("Choose which service should be used as default."));
 
-	TSharedPtr<FText> LocalServiceName = TSharedPtr<FText>(new FText(FText::FromString(TEXT("Local"))));
+	TSharedPtr<FText> LocalServiceName = TSharedPtr<FText>(new FText(FText::FromString(Testbed1LocalBackendIdentifier)));
 	AvailableServicesNames->Add(LocalServiceName);
 	SelectedDefaultBackendService = LocalServiceName;
 

--- a/goldenmaster/Plugins/Testbed1/Source/Testbed1Editor/Private/Testbed1ConnectionSettings.cpp
+++ b/goldenmaster/Plugins/Testbed1/Source/Testbed1Editor/Private/Testbed1ConnectionSettings.cpp
@@ -2,6 +2,7 @@
 #include "Testbed1ConnectionSettings.h"
 
 #include "ApiGearSettings.h"
+#include "apigearolink.h"
 #include "Testbed1Settings.h"
 #include "Templates/SharedPointer.h"
 #include "IDetailCustomization.h"
@@ -106,7 +107,7 @@ TSharedRef<SWidget> FTestbed1ConnectionSettingsDetails::MakeDefaultOLinkConnecti
 
 	for (auto ConnectionSetting : settings->Connections)
 	{
-		if (ConnectionSetting.Value.ProtocolIdentifier == "olink")
+		if (ConnectionSetting.Value.ProtocolIdentifier == ApiGearOLinkProtocolIdentifier)
 		{
 			TSharedPtr<FText> ConnectionName = MakeShared<FText>(FText::FromString(*ConnectionSetting.Key));
 			AvailableOLinkConnectionNames->Add(ConnectionName);

--- a/goldenmaster/Plugins/Testbed1/Source/Testbed1Editor/Private/Testbed1ConnectionSettings.cpp
+++ b/goldenmaster/Plugins/Testbed1/Source/Testbed1Editor/Private/Testbed1ConnectionSettings.cpp
@@ -24,33 +24,38 @@ TSharedRef<IDetailCustomization> FTestbed1ConnectionSettingsDetails::MakeInstanc
 	return MakeShareable(new FTestbed1ConnectionSettingsDetails);
 }
 
-TSharedRef<SWidget> FTestbed1ConnectionSettingsDetails::MakeDefaultConnectionSelectorWidget(const TSharedPtr<IPropertyHandle>& PropertyHandle)
+TSharedRef<SWidget> FTestbed1ConnectionSettingsDetails::MakeDefaultBackendServiceSelectorWidget(const TSharedPtr<IPropertyHandle>& PropertyHandle)
 {
 	UApiGearSettings* settings = GetMutableDefault<UApiGearSettings>();
 	check(settings);
 
-	TArray<TSharedPtr<FText>>* AvailableConnectionNames = &AvailableConnections;
-	FText TooltipText = FText::FromString(TEXT("Choose which connection should be used as default. Please make sure to have at least one connection defined."));
+	TArray<TSharedPtr<FText>>* AvailableServicesNames = &AvailableServices;
+	FText TooltipText = FText::FromString(TEXT("Choose which service should be used as default."));
 
-	TSharedPtr<FText> DefaultEffectName = TSharedPtr<FText>(new FText(FText::FromString(TEXT("Local"))));
-	SelectedDefaultConnection = TSharedPtr<FText>(new FText(*DefaultEffectName));
-	PropertyHandle->GetValueAsDisplayText(*SelectedDefaultConnection);
+	TSharedPtr<FText> LocalServiceName = TSharedPtr<FText>(new FText(FText::FromString(TEXT("Local"))));
+	AvailableServicesNames->Add(LocalServiceName);
+	SelectedDefaultBackendService = LocalServiceName;
 
-	AvailableConnectionNames->Add(DefaultEffectName);
+	TSharedPtr<FText> CurrentServiceName = TSharedPtr<FText>(new FText(FText::GetEmpty()));
+	PropertyHandle->GetValueAsDisplayText(*CurrentServiceName);
+	if (!CurrentServiceName->EqualTo(FText::GetEmpty()))
+	{
+		SelectedDefaultBackendService = CurrentServiceName;
+	}
 
 	for (auto ConnectionSetting : settings->Connections)
 	{
-		AvailableConnectionNames->Add(MakeShared<FText>(FText::FromString(*ConnectionSetting.Key)));
+		AvailableServicesNames->Add(MakeShared<FText>(FText::FromString(*ConnectionSetting.Key)));
 	}
 
 	// clang-format off
 	// Text box component:
 	TSharedRef<STextBlock > EditableTextBox = SNew(STextBlock )
-		.Text_Lambda([this]() { return *SelectedDefaultConnection; });
+		.Text_Lambda([this]() { return *SelectedDefaultBackendService; });
 
 	// Combo box component:
 	TSharedRef<SWidget> ComboBox = SNew(SListView<TSharedPtr<FText>>)
-		.ListItemsSource(AvailableConnectionNames)
+		.ListItemsSource(AvailableServicesNames)
 		.OnGenerateRow_Lambda([](TSharedPtr<FText> InItem, const TSharedRef< class STableViewBase >& Owner)
 		{
 			return SNew(STableRow<TSharedPtr<FText>>, Owner)
@@ -61,7 +66,7 @@ TSharedRef<SWidget> FTestbed1ConnectionSettingsDetails::MakeDefaultConnectionSel
 		})
 		.OnSelectionChanged_Lambda([this, PropertyHandle](TSharedPtr<FText> InText, ESelectInfo::Type)
 		{
-			SelectedDefaultConnection = InText;
+			SelectedDefaultBackendService = InText;
 			PropertyHandle->SetValue(InText->ToString());
 		});
 
@@ -90,24 +95,133 @@ TSharedRef<SWidget> FTestbed1ConnectionSettingsDetails::MakeDefaultConnectionSel
 	return NewWidget;
 }
 
-void FTestbed1ConnectionSettingsDetails::CustomizeDetails(IDetailLayoutBuilder& DetailBuilder)
+TSharedRef<SWidget> FTestbed1ConnectionSettingsDetails::MakeDefaultOLinkConnectionSelectorWidget(const TSharedPtr<IPropertyHandle>& PropertyHandle)
 {
-	IDetailCategoryBuilder& ConnectionsCategory = DetailBuilder.EditCategory(TEXT("ServiceSetup"));
+	UApiGearSettings* settings = GetMutableDefault<UApiGearSettings>();
+	check(settings);
 
-	TSharedPtr<IPropertyHandle> ConnectionIdentifierPropertyHandle = DetailBuilder.GetProperty("ConnectionIdentifier", nullptr);
-	IDetailPropertyRow& DefaultConnectionIdentifierPropertyRow = ConnectionsCategory.AddProperty(ConnectionIdentifierPropertyHandle);
+	TArray<TSharedPtr<FText>>* AvailableOLinkConnectionNames = &AvailableOLinkConnections;
+	FText TooltipText = FText::FromString(TEXT("Choose which connection should be used as default. Please make sure to have at least one connection defined."));
+
+	for (auto ConnectionSetting : settings->Connections)
+	{
+		if (ConnectionSetting.Value.ProtocolIdentifier == "olink")
+		{
+			TSharedPtr<FText> ConnectionName = MakeShared<FText>(FText::FromString(*ConnectionSetting.Key));
+			AvailableOLinkConnectionNames->Add(ConnectionName);
+
+			if (!SelectedDefaultOLinkConnection)
+			{
+				SelectedDefaultOLinkConnection = ConnectionName;
+			}
+		}
+	}
+
+	TSharedPtr<FText> CurrentConnectionName = TSharedPtr<FText>(new FText(FText::GetEmpty()));
+	PropertyHandle->GetValueAsDisplayText(*CurrentConnectionName);
+	if (!CurrentConnectionName->EqualTo(FText::GetEmpty()))
+	{
+		SelectedDefaultOLinkConnection = CurrentConnectionName;
+	}
+
+	if (!SelectedDefaultOLinkConnection)
+	{
+		SelectedDefaultOLinkConnection = TSharedPtr<FText>(new FText(FText::FromString(TEXT("Please define a connection in the settings first!"))));
+	}
 
 	// clang-format off
-	DefaultConnectionIdentifierPropertyRow.CustomWidget()
+	// Text box component:
+	TSharedRef<STextBlock > EditableTextBox = SNew(STextBlock )
+		.Text_Lambda([this]() { return *SelectedDefaultOLinkConnection; });
+
+	// Combo box component:
+	TSharedRef<SWidget> ComboBox = SNew(SListView<TSharedPtr<FText>>)
+		.ListItemsSource(AvailableOLinkConnectionNames)
+		.OnGenerateRow_Lambda([](TSharedPtr<FText> InItem, const TSharedRef< class STableViewBase >& Owner)
+		{
+			return SNew(STableRow<TSharedPtr<FText>>, Owner)
+					.Padding(FMargin(16, 4, 16, 4))
+					[
+						SNew(STextBlock).Text(*InItem)
+					];
+		})
+		.OnSelectionChanged_Lambda([this, PropertyHandle](TSharedPtr<FText> InText, ESelectInfo::Type)
+		{
+			SelectedDefaultOLinkConnection = InText;
+			PropertyHandle->SetValue(InText->ToString());
+		});
+
+
+	//Generate widget:
+	const TSharedRef<SWidget> NewWidget = SNew(SComboButton)
+		.ContentPadding(FMargin(0, 0, 5, 0))
+		.ToolTipText(TooltipText)
+		.ButtonContent()
+		[
+			SNew(SBorder)
+#if (ENGINE_MAJOR_VERSION >= 5)
+			.BorderImage(FAppStyle::GetBrush("NoBorder"))
+#endif
+			.Padding(FMargin(0, 0, 5, 0))
+			[
+				EditableTextBox
+			]
+		]
+		.MenuContent()
+		[
+			ComboBox
+		];
+	// clang-format on
+
+	return NewWidget;
+}
+
+void FTestbed1ConnectionSettingsDetails::CustomizeTracerDetails(IDetailLayoutBuilder& DetailBuilder)
+{
+	IDetailCategoryBuilder& TracerServiceCategory = DetailBuilder.EditCategory(TEXT("TracerServiceSetup"));
+
+	TSharedPtr<IPropertyHandle> BackendServiceIdentifierPropertyHandle = DetailBuilder.GetProperty("TracerServiceIdentifier", nullptr);
+	IDetailPropertyRow& DefaultBackendServiceIdentifierPropertyRow = TracerServiceCategory.AddProperty(BackendServiceIdentifierPropertyHandle);
+
+	// clang-format off
+	DefaultBackendServiceIdentifierPropertyRow.CustomWidget()
 		.NameContent()
 		[
-			ConnectionIdentifierPropertyHandle->CreatePropertyNameWidget()
+			BackendServiceIdentifierPropertyHandle->CreatePropertyNameWidget()
 		]
 		.ValueContent()
 		.MaxDesiredWidth(500.0f)
 		.MinDesiredWidth(100.0f)
 		[
-			MakeDefaultConnectionSelectorWidget(ConnectionIdentifierPropertyHandle)
+			MakeDefaultBackendServiceSelectorWidget(BackendServiceIdentifierPropertyHandle)
 		];
 	// clang-format on
+}
+
+void FTestbed1ConnectionSettingsDetails::CustomizeOLinkDetails(IDetailLayoutBuilder& DetailBuilder)
+{
+	IDetailCategoryBuilder& OLinkConnectionsCategory = DetailBuilder.EditCategory(TEXT("OLinkConnectionSetup"));
+
+	TSharedPtr<IPropertyHandle> OLinkConnectionIdentifierPropertyHandle = DetailBuilder.GetProperty("OLinkConnectionIdentifier", nullptr);
+	IDetailPropertyRow& DefaultOLinkConnectionIdentifierPropertyRow = OLinkConnectionsCategory.AddProperty(OLinkConnectionIdentifierPropertyHandle);
+
+	// clang-format off
+	DefaultOLinkConnectionIdentifierPropertyRow.CustomWidget()
+		.NameContent()
+		[
+			OLinkConnectionIdentifierPropertyHandle->CreatePropertyNameWidget()
+		]
+		.ValueContent()
+		.MaxDesiredWidth(500.0f)
+		.MinDesiredWidth(100.0f)
+		[
+			MakeDefaultOLinkConnectionSelectorWidget(OLinkConnectionIdentifierPropertyHandle)
+		];
+	// clang-format on
+}
+
+void FTestbed1ConnectionSettingsDetails::CustomizeDetails(IDetailLayoutBuilder& DetailBuilder)
+{
+	CustomizeTracerDetails(DetailBuilder);
+	CustomizeOLinkDetails(DetailBuilder);
 }

--- a/goldenmaster/Plugins/Testbed1/Source/Testbed1Editor/Public/Testbed1ConnectionSettings.h
+++ b/goldenmaster/Plugins/Testbed1/Source/Testbed1Editor/Public/Testbed1ConnectionSettings.h
@@ -21,8 +21,13 @@ public:
 	virtual void CustomizeDetails(IDetailLayoutBuilder& DetailBuilder) override;
 
 private:
-	TSharedRef<SWidget> MakeDefaultConnectionSelectorWidget(const TSharedPtr<IPropertyHandle>& PropertyHandle);
+	void CustomizeTracerDetails(IDetailLayoutBuilder& DetailBuilder);
+	TSharedRef<SWidget> MakeDefaultBackendServiceSelectorWidget(const TSharedPtr<IPropertyHandle>& PropertyHandle);
+	TSharedPtr<FText> SelectedDefaultBackendService;
+	TArray<TSharedPtr<FText>> AvailableServices;
 
-	TSharedPtr<FText> SelectedDefaultConnection;
-	TArray<TSharedPtr<FText>> AvailableConnections;
+	void CustomizeOLinkDetails(IDetailLayoutBuilder& DetailBuilder);
+	TSharedRef<SWidget> MakeDefaultOLinkConnectionSelectorWidget(const TSharedPtr<IPropertyHandle>& PropertyHandle);
+	TSharedPtr<FText> SelectedDefaultOLinkConnection;
+	TArray<TSharedPtr<FText>> AvailableOLinkConnections;
 };

--- a/goldenmaster/Plugins/Testbed1/Source/Testbed1Editor/Testbed1Editor.Build.cs
+++ b/goldenmaster/Plugins/Testbed1/Source/Testbed1Editor/Testbed1Editor.Build.cs
@@ -14,6 +14,7 @@ namespace UnrealBuildTool.Rules
 					"UnrealEd",
 					// modules below are needed for connection settings
 					"ApiGear",
+					"ApiGearOLink",
 					"InputCore",
 					"PropertyEditor",
 					"Slate",

--- a/goldenmaster/Plugins/Testbed2/Source/Testbed2/Private/Generated/Monitor/Testbed2Factory.cpp
+++ b/goldenmaster/Plugins/Testbed2/Source/Testbed2/Private/Generated/Monitor/Testbed2Factory.cpp
@@ -17,6 +17,7 @@ limitations under the License.
 
 #include "Testbed2Factory.h"
 #include "ApiGearSettings.h"
+#include "Testbed2Settings.h"
 #include "Implementation/Testbed2ManyParamInterface.h"
 #include "Generated/OLink/Testbed2ManyParamInterfaceOLinkClient.h"
 #include "Implementation/Testbed2NestedStruct1Interface.h"
@@ -80,7 +81,7 @@ TScriptInterface<ITestbed2ManyParamInterfaceInterface> FTestbed2ModuleFactory::c
 {
 	UTestbed2Settings* Testbed2Settings = GetMutableDefault<UTestbed2Settings>();
 
-	if (Testbed2Settings->TracerServiceIdentifier == "Local")
+	if (Testbed2Settings->TracerServiceIdentifier == Testbed2LocalBackendIdentifier)
 	{
 		return createTestbed2ManyParamInterface(GameInstance, Collection);
 	}
@@ -128,7 +129,7 @@ TScriptInterface<ITestbed2ManyParamInterfaceInterface> FTestbed2ModuleFactory::c
 {
 	UTestbed2Settings* Testbed2Settings = GetMutableDefault<UTestbed2Settings>();
 
-	if (Testbed2Settings->TracerServiceIdentifier == "Local")
+	if (Testbed2Settings->TracerServiceIdentifier == Testbed2LocalBackendIdentifier)
 	{
 		return createTestbed2ManyParamInterface(Collection);
 	}
@@ -188,7 +189,7 @@ TScriptInterface<ITestbed2NestedStruct1InterfaceInterface> FTestbed2ModuleFactor
 {
 	UTestbed2Settings* Testbed2Settings = GetMutableDefault<UTestbed2Settings>();
 
-	if (Testbed2Settings->TracerServiceIdentifier == "Local")
+	if (Testbed2Settings->TracerServiceIdentifier == Testbed2LocalBackendIdentifier)
 	{
 		return createTestbed2NestedStruct1Interface(GameInstance, Collection);
 	}
@@ -236,7 +237,7 @@ TScriptInterface<ITestbed2NestedStruct1InterfaceInterface> FTestbed2ModuleFactor
 {
 	UTestbed2Settings* Testbed2Settings = GetMutableDefault<UTestbed2Settings>();
 
-	if (Testbed2Settings->TracerServiceIdentifier == "Local")
+	if (Testbed2Settings->TracerServiceIdentifier == Testbed2LocalBackendIdentifier)
 	{
 		return createTestbed2NestedStruct1Interface(Collection);
 	}
@@ -296,7 +297,7 @@ TScriptInterface<ITestbed2NestedStruct2InterfaceInterface> FTestbed2ModuleFactor
 {
 	UTestbed2Settings* Testbed2Settings = GetMutableDefault<UTestbed2Settings>();
 
-	if (Testbed2Settings->TracerServiceIdentifier == "Local")
+	if (Testbed2Settings->TracerServiceIdentifier == Testbed2LocalBackendIdentifier)
 	{
 		return createTestbed2NestedStruct2Interface(GameInstance, Collection);
 	}
@@ -344,7 +345,7 @@ TScriptInterface<ITestbed2NestedStruct2InterfaceInterface> FTestbed2ModuleFactor
 {
 	UTestbed2Settings* Testbed2Settings = GetMutableDefault<UTestbed2Settings>();
 
-	if (Testbed2Settings->TracerServiceIdentifier == "Local")
+	if (Testbed2Settings->TracerServiceIdentifier == Testbed2LocalBackendIdentifier)
 	{
 		return createTestbed2NestedStruct2Interface(Collection);
 	}
@@ -404,7 +405,7 @@ TScriptInterface<ITestbed2NestedStruct3InterfaceInterface> FTestbed2ModuleFactor
 {
 	UTestbed2Settings* Testbed2Settings = GetMutableDefault<UTestbed2Settings>();
 
-	if (Testbed2Settings->TracerServiceIdentifier == "Local")
+	if (Testbed2Settings->TracerServiceIdentifier == Testbed2LocalBackendIdentifier)
 	{
 		return createTestbed2NestedStruct3Interface(GameInstance, Collection);
 	}
@@ -452,7 +453,7 @@ TScriptInterface<ITestbed2NestedStruct3InterfaceInterface> FTestbed2ModuleFactor
 {
 	UTestbed2Settings* Testbed2Settings = GetMutableDefault<UTestbed2Settings>();
 
-	if (Testbed2Settings->TracerServiceIdentifier == "Local")
+	if (Testbed2Settings->TracerServiceIdentifier == Testbed2LocalBackendIdentifier)
 	{
 		return createTestbed2NestedStruct3Interface(Collection);
 	}

--- a/goldenmaster/Plugins/Testbed2/Source/Testbed2/Private/Generated/Monitor/Testbed2Factory.cpp
+++ b/goldenmaster/Plugins/Testbed2/Source/Testbed2/Private/Generated/Monitor/Testbed2Factory.cpp
@@ -17,6 +17,7 @@ limitations under the License.
 
 #include "Testbed2Factory.h"
 #include "ApiGearSettings.h"
+#include "apigearolink.h"
 #include "Testbed2Settings.h"
 #include "Implementation/Testbed2ManyParamInterface.h"
 #include "Generated/OLink/Testbed2ManyParamInterfaceOLinkClient.h"
@@ -92,7 +93,7 @@ TScriptInterface<ITestbed2ManyParamInterfaceInterface> FTestbed2ModuleFactory::c
 	// Other protocols not supported. To support it edit templates:
 	// add protocol handler class for this interface like createTestbed2ManyParamInterfaceOLink and other necessary infrastructure
 	// extend this function in templates to handle protocol of your choice
-	if (ConnectionSetting && ConnectionSetting->ProtocolIdentifier == "olink")
+	if (ConnectionSetting && ConnectionSetting->ProtocolIdentifier == ApiGearOLinkProtocolIdentifier)
 	{
 		return createTestbed2ManyParamInterfaceOLink(GameInstance, Collection);
 	}
@@ -140,7 +141,7 @@ TScriptInterface<ITestbed2ManyParamInterfaceInterface> FTestbed2ModuleFactory::c
 	// Other protocols not supported. To support it edit templates:
 	// add protocol handler class for this interface like createTestbed2ManyParamInterfaceOLink and other necessary infrastructure
 	// extend this function in templates to handle protocol of your choice
-	if (ConnectionSetting && ConnectionSetting->ProtocolIdentifier == "olink")
+	if (ConnectionSetting && ConnectionSetting->ProtocolIdentifier == ApiGearOLinkProtocolIdentifier)
 	{
 		return createTestbed2ManyParamInterfaceOLink(Collection);
 	}
@@ -200,7 +201,7 @@ TScriptInterface<ITestbed2NestedStruct1InterfaceInterface> FTestbed2ModuleFactor
 	// Other protocols not supported. To support it edit templates:
 	// add protocol handler class for this interface like createTestbed2NestedStruct1InterfaceOLink and other necessary infrastructure
 	// extend this function in templates to handle protocol of your choice
-	if (ConnectionSetting && ConnectionSetting->ProtocolIdentifier == "olink")
+	if (ConnectionSetting && ConnectionSetting->ProtocolIdentifier == ApiGearOLinkProtocolIdentifier)
 	{
 		return createTestbed2NestedStruct1InterfaceOLink(GameInstance, Collection);
 	}
@@ -248,7 +249,7 @@ TScriptInterface<ITestbed2NestedStruct1InterfaceInterface> FTestbed2ModuleFactor
 	// Other protocols not supported. To support it edit templates:
 	// add protocol handler class for this interface like createTestbed2NestedStruct1InterfaceOLink and other necessary infrastructure
 	// extend this function in templates to handle protocol of your choice
-	if (ConnectionSetting && ConnectionSetting->ProtocolIdentifier == "olink")
+	if (ConnectionSetting && ConnectionSetting->ProtocolIdentifier == ApiGearOLinkProtocolIdentifier)
 	{
 		return createTestbed2NestedStruct1InterfaceOLink(Collection);
 	}
@@ -308,7 +309,7 @@ TScriptInterface<ITestbed2NestedStruct2InterfaceInterface> FTestbed2ModuleFactor
 	// Other protocols not supported. To support it edit templates:
 	// add protocol handler class for this interface like createTestbed2NestedStruct2InterfaceOLink and other necessary infrastructure
 	// extend this function in templates to handle protocol of your choice
-	if (ConnectionSetting && ConnectionSetting->ProtocolIdentifier == "olink")
+	if (ConnectionSetting && ConnectionSetting->ProtocolIdentifier == ApiGearOLinkProtocolIdentifier)
 	{
 		return createTestbed2NestedStruct2InterfaceOLink(GameInstance, Collection);
 	}
@@ -356,7 +357,7 @@ TScriptInterface<ITestbed2NestedStruct2InterfaceInterface> FTestbed2ModuleFactor
 	// Other protocols not supported. To support it edit templates:
 	// add protocol handler class for this interface like createTestbed2NestedStruct2InterfaceOLink and other necessary infrastructure
 	// extend this function in templates to handle protocol of your choice
-	if (ConnectionSetting && ConnectionSetting->ProtocolIdentifier == "olink")
+	if (ConnectionSetting && ConnectionSetting->ProtocolIdentifier == ApiGearOLinkProtocolIdentifier)
 	{
 		return createTestbed2NestedStruct2InterfaceOLink(Collection);
 	}
@@ -416,7 +417,7 @@ TScriptInterface<ITestbed2NestedStruct3InterfaceInterface> FTestbed2ModuleFactor
 	// Other protocols not supported. To support it edit templates:
 	// add protocol handler class for this interface like createTestbed2NestedStruct3InterfaceOLink and other necessary infrastructure
 	// extend this function in templates to handle protocol of your choice
-	if (ConnectionSetting && ConnectionSetting->ProtocolIdentifier == "olink")
+	if (ConnectionSetting && ConnectionSetting->ProtocolIdentifier == ApiGearOLinkProtocolIdentifier)
 	{
 		return createTestbed2NestedStruct3InterfaceOLink(GameInstance, Collection);
 	}
@@ -464,7 +465,7 @@ TScriptInterface<ITestbed2NestedStruct3InterfaceInterface> FTestbed2ModuleFactor
 	// Other protocols not supported. To support it edit templates:
 	// add protocol handler class for this interface like createTestbed2NestedStruct3InterfaceOLink and other necessary infrastructure
 	// extend this function in templates to handle protocol of your choice
-	if (ConnectionSetting && ConnectionSetting->ProtocolIdentifier == "olink")
+	if (ConnectionSetting && ConnectionSetting->ProtocolIdentifier == ApiGearOLinkProtocolIdentifier)
 	{
 		return createTestbed2NestedStruct3InterfaceOLink(Collection);
 	}

--- a/goldenmaster/Plugins/Testbed2/Source/Testbed2/Private/Generated/Monitor/Testbed2Factory.cpp
+++ b/goldenmaster/Plugins/Testbed2/Source/Testbed2/Private/Generated/Monitor/Testbed2Factory.cpp
@@ -80,13 +80,13 @@ TScriptInterface<ITestbed2ManyParamInterfaceInterface> FTestbed2ModuleFactory::c
 {
 	UTestbed2Settings* Testbed2Settings = GetMutableDefault<UTestbed2Settings>();
 
-	if (Testbed2Settings->ConnectionIdentifier == "Local")
+	if (Testbed2Settings->TracerServiceIdentifier == "Local")
 	{
 		return createTestbed2ManyParamInterface(GameInstance, Collection);
 	}
 
 	UApiGearSettings* ApiGearSettings = GetMutableDefault<UApiGearSettings>();
-	FApiGearConnectionSetting* ConnectionSetting = ApiGearSettings->Connections.Find(Testbed2Settings->ConnectionIdentifier);
+	FApiGearConnectionSetting* ConnectionSetting = ApiGearSettings->Connections.Find(Testbed2Settings->TracerServiceIdentifier);
 
 	// Other protocols not supported. To support it edit templates:
 	// add protocol handler class for this interface like createTestbed2ManyParamInterfaceOLink and other necessary infrastructure
@@ -128,13 +128,13 @@ TScriptInterface<ITestbed2ManyParamInterfaceInterface> FTestbed2ModuleFactory::c
 {
 	UTestbed2Settings* Testbed2Settings = GetMutableDefault<UTestbed2Settings>();
 
-	if (Testbed2Settings->ConnectionIdentifier == "Local")
+	if (Testbed2Settings->TracerServiceIdentifier == "Local")
 	{
 		return createTestbed2ManyParamInterface(Collection);
 	}
 
 	UApiGearSettings* ApiGearSettings = GetMutableDefault<UApiGearSettings>();
-	FApiGearConnectionSetting* ConnectionSetting = ApiGearSettings->Connections.Find(Testbed2Settings->ConnectionIdentifier);
+	FApiGearConnectionSetting* ConnectionSetting = ApiGearSettings->Connections.Find(Testbed2Settings->TracerServiceIdentifier);
 
 	// Other protocols not supported. To support it edit templates:
 	// add protocol handler class for this interface like createTestbed2ManyParamInterfaceOLink and other necessary infrastructure
@@ -188,13 +188,13 @@ TScriptInterface<ITestbed2NestedStruct1InterfaceInterface> FTestbed2ModuleFactor
 {
 	UTestbed2Settings* Testbed2Settings = GetMutableDefault<UTestbed2Settings>();
 
-	if (Testbed2Settings->ConnectionIdentifier == "Local")
+	if (Testbed2Settings->TracerServiceIdentifier == "Local")
 	{
 		return createTestbed2NestedStruct1Interface(GameInstance, Collection);
 	}
 
 	UApiGearSettings* ApiGearSettings = GetMutableDefault<UApiGearSettings>();
-	FApiGearConnectionSetting* ConnectionSetting = ApiGearSettings->Connections.Find(Testbed2Settings->ConnectionIdentifier);
+	FApiGearConnectionSetting* ConnectionSetting = ApiGearSettings->Connections.Find(Testbed2Settings->TracerServiceIdentifier);
 
 	// Other protocols not supported. To support it edit templates:
 	// add protocol handler class for this interface like createTestbed2NestedStruct1InterfaceOLink and other necessary infrastructure
@@ -236,13 +236,13 @@ TScriptInterface<ITestbed2NestedStruct1InterfaceInterface> FTestbed2ModuleFactor
 {
 	UTestbed2Settings* Testbed2Settings = GetMutableDefault<UTestbed2Settings>();
 
-	if (Testbed2Settings->ConnectionIdentifier == "Local")
+	if (Testbed2Settings->TracerServiceIdentifier == "Local")
 	{
 		return createTestbed2NestedStruct1Interface(Collection);
 	}
 
 	UApiGearSettings* ApiGearSettings = GetMutableDefault<UApiGearSettings>();
-	FApiGearConnectionSetting* ConnectionSetting = ApiGearSettings->Connections.Find(Testbed2Settings->ConnectionIdentifier);
+	FApiGearConnectionSetting* ConnectionSetting = ApiGearSettings->Connections.Find(Testbed2Settings->TracerServiceIdentifier);
 
 	// Other protocols not supported. To support it edit templates:
 	// add protocol handler class for this interface like createTestbed2NestedStruct1InterfaceOLink and other necessary infrastructure
@@ -296,13 +296,13 @@ TScriptInterface<ITestbed2NestedStruct2InterfaceInterface> FTestbed2ModuleFactor
 {
 	UTestbed2Settings* Testbed2Settings = GetMutableDefault<UTestbed2Settings>();
 
-	if (Testbed2Settings->ConnectionIdentifier == "Local")
+	if (Testbed2Settings->TracerServiceIdentifier == "Local")
 	{
 		return createTestbed2NestedStruct2Interface(GameInstance, Collection);
 	}
 
 	UApiGearSettings* ApiGearSettings = GetMutableDefault<UApiGearSettings>();
-	FApiGearConnectionSetting* ConnectionSetting = ApiGearSettings->Connections.Find(Testbed2Settings->ConnectionIdentifier);
+	FApiGearConnectionSetting* ConnectionSetting = ApiGearSettings->Connections.Find(Testbed2Settings->TracerServiceIdentifier);
 
 	// Other protocols not supported. To support it edit templates:
 	// add protocol handler class for this interface like createTestbed2NestedStruct2InterfaceOLink and other necessary infrastructure
@@ -344,13 +344,13 @@ TScriptInterface<ITestbed2NestedStruct2InterfaceInterface> FTestbed2ModuleFactor
 {
 	UTestbed2Settings* Testbed2Settings = GetMutableDefault<UTestbed2Settings>();
 
-	if (Testbed2Settings->ConnectionIdentifier == "Local")
+	if (Testbed2Settings->TracerServiceIdentifier == "Local")
 	{
 		return createTestbed2NestedStruct2Interface(Collection);
 	}
 
 	UApiGearSettings* ApiGearSettings = GetMutableDefault<UApiGearSettings>();
-	FApiGearConnectionSetting* ConnectionSetting = ApiGearSettings->Connections.Find(Testbed2Settings->ConnectionIdentifier);
+	FApiGearConnectionSetting* ConnectionSetting = ApiGearSettings->Connections.Find(Testbed2Settings->TracerServiceIdentifier);
 
 	// Other protocols not supported. To support it edit templates:
 	// add protocol handler class for this interface like createTestbed2NestedStruct2InterfaceOLink and other necessary infrastructure
@@ -404,13 +404,13 @@ TScriptInterface<ITestbed2NestedStruct3InterfaceInterface> FTestbed2ModuleFactor
 {
 	UTestbed2Settings* Testbed2Settings = GetMutableDefault<UTestbed2Settings>();
 
-	if (Testbed2Settings->ConnectionIdentifier == "Local")
+	if (Testbed2Settings->TracerServiceIdentifier == "Local")
 	{
 		return createTestbed2NestedStruct3Interface(GameInstance, Collection);
 	}
 
 	UApiGearSettings* ApiGearSettings = GetMutableDefault<UApiGearSettings>();
-	FApiGearConnectionSetting* ConnectionSetting = ApiGearSettings->Connections.Find(Testbed2Settings->ConnectionIdentifier);
+	FApiGearConnectionSetting* ConnectionSetting = ApiGearSettings->Connections.Find(Testbed2Settings->TracerServiceIdentifier);
 
 	// Other protocols not supported. To support it edit templates:
 	// add protocol handler class for this interface like createTestbed2NestedStruct3InterfaceOLink and other necessary infrastructure
@@ -452,13 +452,13 @@ TScriptInterface<ITestbed2NestedStruct3InterfaceInterface> FTestbed2ModuleFactor
 {
 	UTestbed2Settings* Testbed2Settings = GetMutableDefault<UTestbed2Settings>();
 
-	if (Testbed2Settings->ConnectionIdentifier == "Local")
+	if (Testbed2Settings->TracerServiceIdentifier == "Local")
 	{
 		return createTestbed2NestedStruct3Interface(Collection);
 	}
 
 	UApiGearSettings* ApiGearSettings = GetMutableDefault<UApiGearSettings>();
-	FApiGearConnectionSetting* ConnectionSetting = ApiGearSettings->Connections.Find(Testbed2Settings->ConnectionIdentifier);
+	FApiGearConnectionSetting* ConnectionSetting = ApiGearSettings->Connections.Find(Testbed2Settings->TracerServiceIdentifier);
 
 	// Other protocols not supported. To support it edit templates:
 	// add protocol handler class for this interface like createTestbed2NestedStruct3InterfaceOLink and other necessary infrastructure

--- a/goldenmaster/Plugins/Testbed2/Source/Testbed2/Private/Generated/OLink/Testbed2ManyParamInterfaceOLinkClient.cpp
+++ b/goldenmaster/Plugins/Testbed2/Source/Testbed2/Private/Generated/OLink/Testbed2ManyParamInterfaceOLinkClient.cpp
@@ -261,7 +261,17 @@ int32 UTestbed2ManyParamInterfaceOLinkClient::Func1_Implementation(int32 Param1)
 		[Param1, &Promise, this]()
 		{
 			ApiGear::ObjectLink::InvokeReplyFunc GetManyParamInterfaceStateFunc = [&Promise](ApiGear::ObjectLink::InvokeReplyArg arg)
-			{ Promise.SetValue(arg.value.get<int32>()); };
+			{
+				if (!arg.value.empty())
+				{
+					Promise.SetValue(arg.value.get<int32>());
+				}
+				else
+				{
+					UE_LOG(LogTestbed2ManyParamInterfaceOLinkClient, Error, TEXT("Func1: OLink service returned empty value - should have returned type of int32"));
+					Promise.SetValue(int32());
+				}
+			};
 			static const auto memberId = ApiGear::ObjectLink::Name::createMemberId(m_sink->olinkObjectName(), "func1");
 			m_sink->GetNode()->invokeRemote(memberId, {Param1}, GetManyParamInterfaceStateFunc);
 		});
@@ -282,7 +292,17 @@ int32 UTestbed2ManyParamInterfaceOLinkClient::Func2_Implementation(int32 Param1,
 		[Param1, Param2, &Promise, this]()
 		{
 			ApiGear::ObjectLink::InvokeReplyFunc GetManyParamInterfaceStateFunc = [&Promise](ApiGear::ObjectLink::InvokeReplyArg arg)
-			{ Promise.SetValue(arg.value.get<int32>()); };
+			{
+				if (!arg.value.empty())
+				{
+					Promise.SetValue(arg.value.get<int32>());
+				}
+				else
+				{
+					UE_LOG(LogTestbed2ManyParamInterfaceOLinkClient, Error, TEXT("Func2: OLink service returned empty value - should have returned type of int32"));
+					Promise.SetValue(int32());
+				}
+			};
 			static const auto memberId = ApiGear::ObjectLink::Name::createMemberId(m_sink->olinkObjectName(), "func2");
 			m_sink->GetNode()->invokeRemote(memberId, {Param1, Param2}, GetManyParamInterfaceStateFunc);
 		});
@@ -303,7 +323,17 @@ int32 UTestbed2ManyParamInterfaceOLinkClient::Func3_Implementation(int32 Param1,
 		[Param1, Param2, Param3, &Promise, this]()
 		{
 			ApiGear::ObjectLink::InvokeReplyFunc GetManyParamInterfaceStateFunc = [&Promise](ApiGear::ObjectLink::InvokeReplyArg arg)
-			{ Promise.SetValue(arg.value.get<int32>()); };
+			{
+				if (!arg.value.empty())
+				{
+					Promise.SetValue(arg.value.get<int32>());
+				}
+				else
+				{
+					UE_LOG(LogTestbed2ManyParamInterfaceOLinkClient, Error, TEXT("Func3: OLink service returned empty value - should have returned type of int32"));
+					Promise.SetValue(int32());
+				}
+			};
 			static const auto memberId = ApiGear::ObjectLink::Name::createMemberId(m_sink->olinkObjectName(), "func3");
 			m_sink->GetNode()->invokeRemote(memberId, {Param1, Param2, Param3}, GetManyParamInterfaceStateFunc);
 		});
@@ -324,7 +354,17 @@ int32 UTestbed2ManyParamInterfaceOLinkClient::Func4_Implementation(int32 Param1,
 		[Param1, Param2, Param3, Param4, &Promise, this]()
 		{
 			ApiGear::ObjectLink::InvokeReplyFunc GetManyParamInterfaceStateFunc = [&Promise](ApiGear::ObjectLink::InvokeReplyArg arg)
-			{ Promise.SetValue(arg.value.get<int32>()); };
+			{
+				if (!arg.value.empty())
+				{
+					Promise.SetValue(arg.value.get<int32>());
+				}
+				else
+				{
+					UE_LOG(LogTestbed2ManyParamInterfaceOLinkClient, Error, TEXT("Func4: OLink service returned empty value - should have returned type of int32"));
+					Promise.SetValue(int32());
+				}
+			};
 			static const auto memberId = ApiGear::ObjectLink::Name::createMemberId(m_sink->olinkObjectName(), "func4");
 			m_sink->GetNode()->invokeRemote(memberId, {Param1, Param2, Param3, Param4}, GetManyParamInterfaceStateFunc);
 		});

--- a/goldenmaster/Plugins/Testbed2/Source/Testbed2/Private/Generated/OLink/Testbed2ManyParamInterfaceOLinkClient.cpp
+++ b/goldenmaster/Plugins/Testbed2/Source/Testbed2/Private/Generated/OLink/Testbed2ManyParamInterfaceOLinkClient.cpp
@@ -85,8 +85,13 @@ void UTestbed2ManyParamInterfaceOLinkClient::Initialize(FSubsystemCollectionBase
 
 	UApiGearConnectionsStore* AGCM = GEngine->GetEngineSubsystem<UApiGearConnectionsStore>();
 
-	TScriptInterface<IApiGearConnection> OLinkConnection = AGCM->GetConnection(settings->ConnectionIdentifier);
+	TScriptInterface<IApiGearConnection> OLinkConnection = AGCM->GetConnection(settings->OLinkConnectionIdentifier);
 
+	if (!OLinkConnection.GetInterface())
+	{
+		UE_LOG(LogTestbed2ManyParamInterfaceOLinkClient, Log, TEXT("No valid olink connection for %s, please set during run time"), UTF8_TO_TCHAR(m_sink->olinkObjectName().c_str()));
+		return;
+	}
 	UseConnection(OLinkConnection);
 	OLinkConnection->Connect();
 }

--- a/goldenmaster/Plugins/Testbed2/Source/Testbed2/Private/Generated/OLink/Testbed2ManyParamInterfaceOLinkClient.cpp
+++ b/goldenmaster/Plugins/Testbed2/Source/Testbed2/Private/Generated/OLink/Testbed2ManyParamInterfaceOLinkClient.cpp
@@ -22,6 +22,7 @@ limitations under the License.
 
 #include "Generated/OLink/Testbed2ManyParamInterfaceOLinkClient.h"
 #include "ApiGearSettings.h"
+#include "apigearolink.h"
 #include "Async/Async.h"
 #include "Generated/api/Testbed2.json.adapter.h"
 #include "unrealolink.h"
@@ -117,7 +118,7 @@ void UTestbed2ManyParamInterfaceOLinkClient::UseConnection(TScriptInterface<IApi
 	checkf(InConnection.GetInterface() != nullptr, TEXT("Cannot use connection - interface IApiGearConnection is not fully implemented"));
 
 	// only accept connections of type olink
-	checkf(InConnection->GetConnectionProtocolIdentifier() == "olink", TEXT("Cannot use connection - must be of type olink"));
+	checkf(InConnection->GetConnectionProtocolIdentifier() == ApiGearOLinkProtocolIdentifier, TEXT("Cannot use connection - must be of type olink"));
 
 	UUnrealOLink* UnrealOLinkConnection = nullptr;
 	// remove old connection

--- a/goldenmaster/Plugins/Testbed2/Source/Testbed2/Private/Generated/OLink/Testbed2NestedStruct1InterfaceOLinkClient.cpp
+++ b/goldenmaster/Plugins/Testbed2/Source/Testbed2/Private/Generated/OLink/Testbed2NestedStruct1InterfaceOLinkClient.cpp
@@ -171,7 +171,17 @@ FTestbed2NestedStruct1 UTestbed2NestedStruct1InterfaceOLinkClient::Func1_Impleme
 		[Param1, &Promise, this]()
 		{
 			ApiGear::ObjectLink::InvokeReplyFunc GetNestedStruct1InterfaceStateFunc = [&Promise](ApiGear::ObjectLink::InvokeReplyArg arg)
-			{ Promise.SetValue(arg.value.get<FTestbed2NestedStruct1>()); };
+			{
+				if (!arg.value.empty())
+				{
+					Promise.SetValue(arg.value.get<FTestbed2NestedStruct1>());
+				}
+				else
+				{
+					UE_LOG(LogTestbed2NestedStruct1InterfaceOLinkClient, Error, TEXT("Func1: OLink service returned empty value - should have returned type of FTestbed2NestedStruct1"));
+					Promise.SetValue(FTestbed2NestedStruct1());
+				}
+			};
 			static const auto memberId = ApiGear::ObjectLink::Name::createMemberId(m_sink->olinkObjectName(), "func1");
 			m_sink->GetNode()->invokeRemote(memberId, {Param1}, GetNestedStruct1InterfaceStateFunc);
 		});

--- a/goldenmaster/Plugins/Testbed2/Source/Testbed2/Private/Generated/OLink/Testbed2NestedStruct1InterfaceOLinkClient.cpp
+++ b/goldenmaster/Plugins/Testbed2/Source/Testbed2/Private/Generated/OLink/Testbed2NestedStruct1InterfaceOLinkClient.cpp
@@ -22,6 +22,7 @@ limitations under the License.
 
 #include "Generated/OLink/Testbed2NestedStruct1InterfaceOLinkClient.h"
 #include "ApiGearSettings.h"
+#include "apigearolink.h"
 #include "Async/Async.h"
 #include "Generated/api/Testbed2.json.adapter.h"
 #include "unrealolink.h"
@@ -114,7 +115,7 @@ void UTestbed2NestedStruct1InterfaceOLinkClient::UseConnection(TScriptInterface<
 	checkf(InConnection.GetInterface() != nullptr, TEXT("Cannot use connection - interface IApiGearConnection is not fully implemented"));
 
 	// only accept connections of type olink
-	checkf(InConnection->GetConnectionProtocolIdentifier() == "olink", TEXT("Cannot use connection - must be of type olink"));
+	checkf(InConnection->GetConnectionProtocolIdentifier() == ApiGearOLinkProtocolIdentifier, TEXT("Cannot use connection - must be of type olink"));
 
 	UUnrealOLink* UnrealOLinkConnection = nullptr;
 	// remove old connection

--- a/goldenmaster/Plugins/Testbed2/Source/Testbed2/Private/Generated/OLink/Testbed2NestedStruct1InterfaceOLinkClient.cpp
+++ b/goldenmaster/Plugins/Testbed2/Source/Testbed2/Private/Generated/OLink/Testbed2NestedStruct1InterfaceOLinkClient.cpp
@@ -82,8 +82,13 @@ void UTestbed2NestedStruct1InterfaceOLinkClient::Initialize(FSubsystemCollection
 
 	UApiGearConnectionsStore* AGCM = GEngine->GetEngineSubsystem<UApiGearConnectionsStore>();
 
-	TScriptInterface<IApiGearConnection> OLinkConnection = AGCM->GetConnection(settings->ConnectionIdentifier);
+	TScriptInterface<IApiGearConnection> OLinkConnection = AGCM->GetConnection(settings->OLinkConnectionIdentifier);
 
+	if (!OLinkConnection.GetInterface())
+	{
+		UE_LOG(LogTestbed2NestedStruct1InterfaceOLinkClient, Log, TEXT("No valid olink connection for %s, please set during run time"), UTF8_TO_TCHAR(m_sink->olinkObjectName().c_str()));
+		return;
+	}
 	UseConnection(OLinkConnection);
 	OLinkConnection->Connect();
 }

--- a/goldenmaster/Plugins/Testbed2/Source/Testbed2/Private/Generated/OLink/Testbed2NestedStruct2InterfaceOLinkClient.cpp
+++ b/goldenmaster/Plugins/Testbed2/Source/Testbed2/Private/Generated/OLink/Testbed2NestedStruct2InterfaceOLinkClient.cpp
@@ -201,7 +201,17 @@ FTestbed2NestedStruct1 UTestbed2NestedStruct2InterfaceOLinkClient::Func1_Impleme
 		[Param1, &Promise, this]()
 		{
 			ApiGear::ObjectLink::InvokeReplyFunc GetNestedStruct2InterfaceStateFunc = [&Promise](ApiGear::ObjectLink::InvokeReplyArg arg)
-			{ Promise.SetValue(arg.value.get<FTestbed2NestedStruct1>()); };
+			{
+				if (!arg.value.empty())
+				{
+					Promise.SetValue(arg.value.get<FTestbed2NestedStruct1>());
+				}
+				else
+				{
+					UE_LOG(LogTestbed2NestedStruct2InterfaceOLinkClient, Error, TEXT("Func1: OLink service returned empty value - should have returned type of FTestbed2NestedStruct1"));
+					Promise.SetValue(FTestbed2NestedStruct1());
+				}
+			};
 			static const auto memberId = ApiGear::ObjectLink::Name::createMemberId(m_sink->olinkObjectName(), "func1");
 			m_sink->GetNode()->invokeRemote(memberId, {Param1}, GetNestedStruct2InterfaceStateFunc);
 		});
@@ -222,7 +232,17 @@ FTestbed2NestedStruct1 UTestbed2NestedStruct2InterfaceOLinkClient::Func2_Impleme
 		[Param1, Param2, &Promise, this]()
 		{
 			ApiGear::ObjectLink::InvokeReplyFunc GetNestedStruct2InterfaceStateFunc = [&Promise](ApiGear::ObjectLink::InvokeReplyArg arg)
-			{ Promise.SetValue(arg.value.get<FTestbed2NestedStruct1>()); };
+			{
+				if (!arg.value.empty())
+				{
+					Promise.SetValue(arg.value.get<FTestbed2NestedStruct1>());
+				}
+				else
+				{
+					UE_LOG(LogTestbed2NestedStruct2InterfaceOLinkClient, Error, TEXT("Func2: OLink service returned empty value - should have returned type of FTestbed2NestedStruct1"));
+					Promise.SetValue(FTestbed2NestedStruct1());
+				}
+			};
 			static const auto memberId = ApiGear::ObjectLink::Name::createMemberId(m_sink->olinkObjectName(), "func2");
 			m_sink->GetNode()->invokeRemote(memberId, {Param1, Param2}, GetNestedStruct2InterfaceStateFunc);
 		});

--- a/goldenmaster/Plugins/Testbed2/Source/Testbed2/Private/Generated/OLink/Testbed2NestedStruct2InterfaceOLinkClient.cpp
+++ b/goldenmaster/Plugins/Testbed2/Source/Testbed2/Private/Generated/OLink/Testbed2NestedStruct2InterfaceOLinkClient.cpp
@@ -22,6 +22,7 @@ limitations under the License.
 
 #include "Generated/OLink/Testbed2NestedStruct2InterfaceOLinkClient.h"
 #include "ApiGearSettings.h"
+#include "apigearolink.h"
 #include "Async/Async.h"
 #include "Generated/api/Testbed2.json.adapter.h"
 #include "unrealolink.h"
@@ -115,7 +116,7 @@ void UTestbed2NestedStruct2InterfaceOLinkClient::UseConnection(TScriptInterface<
 	checkf(InConnection.GetInterface() != nullptr, TEXT("Cannot use connection - interface IApiGearConnection is not fully implemented"));
 
 	// only accept connections of type olink
-	checkf(InConnection->GetConnectionProtocolIdentifier() == "olink", TEXT("Cannot use connection - must be of type olink"));
+	checkf(InConnection->GetConnectionProtocolIdentifier() == ApiGearOLinkProtocolIdentifier, TEXT("Cannot use connection - must be of type olink"));
 
 	UUnrealOLink* UnrealOLinkConnection = nullptr;
 	// remove old connection

--- a/goldenmaster/Plugins/Testbed2/Source/Testbed2/Private/Generated/OLink/Testbed2NestedStruct2InterfaceOLinkClient.cpp
+++ b/goldenmaster/Plugins/Testbed2/Source/Testbed2/Private/Generated/OLink/Testbed2NestedStruct2InterfaceOLinkClient.cpp
@@ -83,8 +83,13 @@ void UTestbed2NestedStruct2InterfaceOLinkClient::Initialize(FSubsystemCollection
 
 	UApiGearConnectionsStore* AGCM = GEngine->GetEngineSubsystem<UApiGearConnectionsStore>();
 
-	TScriptInterface<IApiGearConnection> OLinkConnection = AGCM->GetConnection(settings->ConnectionIdentifier);
+	TScriptInterface<IApiGearConnection> OLinkConnection = AGCM->GetConnection(settings->OLinkConnectionIdentifier);
 
+	if (!OLinkConnection.GetInterface())
+	{
+		UE_LOG(LogTestbed2NestedStruct2InterfaceOLinkClient, Log, TEXT("No valid olink connection for %s, please set during run time"), UTF8_TO_TCHAR(m_sink->olinkObjectName().c_str()));
+		return;
+	}
 	UseConnection(OLinkConnection);
 	OLinkConnection->Connect();
 }

--- a/goldenmaster/Plugins/Testbed2/Source/Testbed2/Private/Generated/OLink/Testbed2NestedStruct3InterfaceOLinkClient.cpp
+++ b/goldenmaster/Plugins/Testbed2/Source/Testbed2/Private/Generated/OLink/Testbed2NestedStruct3InterfaceOLinkClient.cpp
@@ -22,6 +22,7 @@ limitations under the License.
 
 #include "Generated/OLink/Testbed2NestedStruct3InterfaceOLinkClient.h"
 #include "ApiGearSettings.h"
+#include "apigearolink.h"
 #include "Async/Async.h"
 #include "Generated/api/Testbed2.json.adapter.h"
 #include "unrealolink.h"
@@ -116,7 +117,7 @@ void UTestbed2NestedStruct3InterfaceOLinkClient::UseConnection(TScriptInterface<
 	checkf(InConnection.GetInterface() != nullptr, TEXT("Cannot use connection - interface IApiGearConnection is not fully implemented"));
 
 	// only accept connections of type olink
-	checkf(InConnection->GetConnectionProtocolIdentifier() == "olink", TEXT("Cannot use connection - must be of type olink"));
+	checkf(InConnection->GetConnectionProtocolIdentifier() == ApiGearOLinkProtocolIdentifier, TEXT("Cannot use connection - must be of type olink"));
 
 	UUnrealOLink* UnrealOLinkConnection = nullptr;
 	// remove old connection

--- a/goldenmaster/Plugins/Testbed2/Source/Testbed2/Private/Generated/OLink/Testbed2NestedStruct3InterfaceOLinkClient.cpp
+++ b/goldenmaster/Plugins/Testbed2/Source/Testbed2/Private/Generated/OLink/Testbed2NestedStruct3InterfaceOLinkClient.cpp
@@ -84,8 +84,13 @@ void UTestbed2NestedStruct3InterfaceOLinkClient::Initialize(FSubsystemCollection
 
 	UApiGearConnectionsStore* AGCM = GEngine->GetEngineSubsystem<UApiGearConnectionsStore>();
 
-	TScriptInterface<IApiGearConnection> OLinkConnection = AGCM->GetConnection(settings->ConnectionIdentifier);
+	TScriptInterface<IApiGearConnection> OLinkConnection = AGCM->GetConnection(settings->OLinkConnectionIdentifier);
 
+	if (!OLinkConnection.GetInterface())
+	{
+		UE_LOG(LogTestbed2NestedStruct3InterfaceOLinkClient, Log, TEXT("No valid olink connection for %s, please set during run time"), UTF8_TO_TCHAR(m_sink->olinkObjectName().c_str()));
+		return;
+	}
 	UseConnection(OLinkConnection);
 	OLinkConnection->Connect();
 }

--- a/goldenmaster/Plugins/Testbed2/Source/Testbed2/Private/Generated/OLink/Testbed2NestedStruct3InterfaceOLinkClient.cpp
+++ b/goldenmaster/Plugins/Testbed2/Source/Testbed2/Private/Generated/OLink/Testbed2NestedStruct3InterfaceOLinkClient.cpp
@@ -231,7 +231,17 @@ FTestbed2NestedStruct1 UTestbed2NestedStruct3InterfaceOLinkClient::Func1_Impleme
 		[Param1, &Promise, this]()
 		{
 			ApiGear::ObjectLink::InvokeReplyFunc GetNestedStruct3InterfaceStateFunc = [&Promise](ApiGear::ObjectLink::InvokeReplyArg arg)
-			{ Promise.SetValue(arg.value.get<FTestbed2NestedStruct1>()); };
+			{
+				if (!arg.value.empty())
+				{
+					Promise.SetValue(arg.value.get<FTestbed2NestedStruct1>());
+				}
+				else
+				{
+					UE_LOG(LogTestbed2NestedStruct3InterfaceOLinkClient, Error, TEXT("Func1: OLink service returned empty value - should have returned type of FTestbed2NestedStruct1"));
+					Promise.SetValue(FTestbed2NestedStruct1());
+				}
+			};
 			static const auto memberId = ApiGear::ObjectLink::Name::createMemberId(m_sink->olinkObjectName(), "func1");
 			m_sink->GetNode()->invokeRemote(memberId, {Param1}, GetNestedStruct3InterfaceStateFunc);
 		});
@@ -252,7 +262,17 @@ FTestbed2NestedStruct1 UTestbed2NestedStruct3InterfaceOLinkClient::Func2_Impleme
 		[Param1, Param2, &Promise, this]()
 		{
 			ApiGear::ObjectLink::InvokeReplyFunc GetNestedStruct3InterfaceStateFunc = [&Promise](ApiGear::ObjectLink::InvokeReplyArg arg)
-			{ Promise.SetValue(arg.value.get<FTestbed2NestedStruct1>()); };
+			{
+				if (!arg.value.empty())
+				{
+					Promise.SetValue(arg.value.get<FTestbed2NestedStruct1>());
+				}
+				else
+				{
+					UE_LOG(LogTestbed2NestedStruct3InterfaceOLinkClient, Error, TEXT("Func2: OLink service returned empty value - should have returned type of FTestbed2NestedStruct1"));
+					Promise.SetValue(FTestbed2NestedStruct1());
+				}
+			};
 			static const auto memberId = ApiGear::ObjectLink::Name::createMemberId(m_sink->olinkObjectName(), "func2");
 			m_sink->GetNode()->invokeRemote(memberId, {Param1, Param2}, GetNestedStruct3InterfaceStateFunc);
 		});
@@ -273,7 +293,17 @@ FTestbed2NestedStruct1 UTestbed2NestedStruct3InterfaceOLinkClient::Func3_Impleme
 		[Param1, Param2, Param3, &Promise, this]()
 		{
 			ApiGear::ObjectLink::InvokeReplyFunc GetNestedStruct3InterfaceStateFunc = [&Promise](ApiGear::ObjectLink::InvokeReplyArg arg)
-			{ Promise.SetValue(arg.value.get<FTestbed2NestedStruct1>()); };
+			{
+				if (!arg.value.empty())
+				{
+					Promise.SetValue(arg.value.get<FTestbed2NestedStruct1>());
+				}
+				else
+				{
+					UE_LOG(LogTestbed2NestedStruct3InterfaceOLinkClient, Error, TEXT("Func3: OLink service returned empty value - should have returned type of FTestbed2NestedStruct1"));
+					Promise.SetValue(FTestbed2NestedStruct1());
+				}
+			};
 			static const auto memberId = ApiGear::ObjectLink::Name::createMemberId(m_sink->olinkObjectName(), "func3");
 			m_sink->GetNode()->invokeRemote(memberId, {Param1, Param2, Param3}, GetNestedStruct3InterfaceStateFunc);
 		});

--- a/goldenmaster/Plugins/Testbed2/Source/Testbed2/Private/Testbed2Settings.cpp
+++ b/goldenmaster/Plugins/Testbed2/Source/Testbed2/Private/Testbed2Settings.cpp
@@ -27,18 +27,24 @@ void UTestbed2Settings::PostInitProperties()
 {
 	Super::PostInitProperties();
 
+	check(GEngine);
+	UApiGearConnectionsStore* AGCM = GEngine->GetEngineSubsystem<UApiGearConnectionsStore>();
+
+	if (!AGCM->DoesConnectionExist(OLinkConnectionIdentifier))
+	{
+		UE_LOG(LogTemp, Warning, TEXT("UTestbed2Settings could not find connection %s."), *OLinkConnectionIdentifier);
+		OLinkConnectionIdentifier = "";
+	}
+
 	// the local backend does not require configuration
-	if (ConnectionIdentifier == "Local")
+	if (TracerServiceIdentifier == "Local")
 	{
 		return;
 	}
 
-	check(GEngine);
-	UApiGearConnectionsStore* AGCM = GEngine->GetEngineSubsystem<UApiGearConnectionsStore>();
-
-	if (!AGCM->DoesConnectionExist(ConnectionIdentifier))
+	if (!AGCM->DoesConnectionExist(TracerServiceIdentifier))
 	{
-		UE_LOG(LogTemp, Warning, TEXT("UTestbed2Settings could not find connection %s, falling back to local backend."), *ConnectionIdentifier);
-		ConnectionIdentifier = "Local";
+		UE_LOG(LogTemp, Warning, TEXT("UTestbed2Settings could not find connection %s, falling back to local backend."), *TracerServiceIdentifier);
+		TracerServiceIdentifier = "Local";
 	}
 }

--- a/goldenmaster/Plugins/Testbed2/Source/Testbed2/Private/Testbed2Settings.cpp
+++ b/goldenmaster/Plugins/Testbed2/Source/Testbed2/Private/Testbed2Settings.cpp
@@ -37,7 +37,7 @@ void UTestbed2Settings::PostInitProperties()
 	}
 
 	// the local backend does not require configuration
-	if (TracerServiceIdentifier == "Local")
+	if (TracerServiceIdentifier == Testbed2LocalBackendIdentifier)
 	{
 		return;
 	}
@@ -45,6 +45,6 @@ void UTestbed2Settings::PostInitProperties()
 	if (!AGCM->DoesConnectionExist(TracerServiceIdentifier))
 	{
 		UE_LOG(LogTemp, Warning, TEXT("UTestbed2Settings could not find connection %s, falling back to local backend."), *TracerServiceIdentifier);
-		TracerServiceIdentifier = "Local";
+		TracerServiceIdentifier = Testbed2LocalBackendIdentifier;
 	}
 }

--- a/goldenmaster/Plugins/Testbed2/Source/Testbed2/Public/Testbed2Settings.h
+++ b/goldenmaster/Plugins/Testbed2/Source/Testbed2/Public/Testbed2Settings.h
@@ -22,6 +22,8 @@ limitations under the License.
 #include "Engine/EngineTypes.h"
 #include "Testbed2Settings.generated.h"
 
+const FString Testbed2LocalBackendIdentifier = "Local";
+
 /**
  * Implements the settings for the Testbed2 plugin.
  */

--- a/goldenmaster/Plugins/Testbed2/Source/Testbed2/Public/Testbed2Settings.h
+++ b/goldenmaster/Plugins/Testbed2/Source/Testbed2/Public/Testbed2Settings.h
@@ -33,6 +33,10 @@ class TESTBED2_API UTestbed2Settings : public UObject
 	virtual void PostInitProperties() override;
 
 	// Choose the backend service for the logging decorator to use
-	UPROPERTY(EditAnywhere, config, Category = ServiceSetup)
-	FString ConnectionIdentifier;
+	UPROPERTY(EditAnywhere, config, Category = TracerServiceSetup)
+	FString TracerServiceIdentifier;
+
+	// Choose the olink connection to use
+	UPROPERTY(EditAnywhere, config, Category = OLinkConnectionSetup)
+	FString OLinkConnectionIdentifier;
 };

--- a/goldenmaster/Plugins/Testbed2/Source/Testbed2Editor/Private/Testbed2ConnectionSettings.cpp
+++ b/goldenmaster/Plugins/Testbed2/Source/Testbed2Editor/Private/Testbed2ConnectionSettings.cpp
@@ -2,6 +2,7 @@
 #include "Testbed2ConnectionSettings.h"
 
 #include "ApiGearSettings.h"
+#include "Testbed2Settings.h"
 #include "Templates/SharedPointer.h"
 #include "IDetailCustomization.h"
 #include "PropertyHandle.h"
@@ -32,7 +33,7 @@ TSharedRef<SWidget> FTestbed2ConnectionSettingsDetails::MakeDefaultBackendServic
 	TArray<TSharedPtr<FText>>* AvailableServicesNames = &AvailableServices;
 	FText TooltipText = FText::FromString(TEXT("Choose which service should be used as default."));
 
-	TSharedPtr<FText> LocalServiceName = TSharedPtr<FText>(new FText(FText::FromString(TEXT("Local"))));
+	TSharedPtr<FText> LocalServiceName = TSharedPtr<FText>(new FText(FText::FromString(Testbed2LocalBackendIdentifier)));
 	AvailableServicesNames->Add(LocalServiceName);
 	SelectedDefaultBackendService = LocalServiceName;
 

--- a/goldenmaster/Plugins/Testbed2/Source/Testbed2Editor/Private/Testbed2ConnectionSettings.cpp
+++ b/goldenmaster/Plugins/Testbed2/Source/Testbed2Editor/Private/Testbed2ConnectionSettings.cpp
@@ -24,33 +24,38 @@ TSharedRef<IDetailCustomization> FTestbed2ConnectionSettingsDetails::MakeInstanc
 	return MakeShareable(new FTestbed2ConnectionSettingsDetails);
 }
 
-TSharedRef<SWidget> FTestbed2ConnectionSettingsDetails::MakeDefaultConnectionSelectorWidget(const TSharedPtr<IPropertyHandle>& PropertyHandle)
+TSharedRef<SWidget> FTestbed2ConnectionSettingsDetails::MakeDefaultBackendServiceSelectorWidget(const TSharedPtr<IPropertyHandle>& PropertyHandle)
 {
 	UApiGearSettings* settings = GetMutableDefault<UApiGearSettings>();
 	check(settings);
 
-	TArray<TSharedPtr<FText>>* AvailableConnectionNames = &AvailableConnections;
-	FText TooltipText = FText::FromString(TEXT("Choose which connection should be used as default. Please make sure to have at least one connection defined."));
+	TArray<TSharedPtr<FText>>* AvailableServicesNames = &AvailableServices;
+	FText TooltipText = FText::FromString(TEXT("Choose which service should be used as default."));
 
-	TSharedPtr<FText> DefaultEffectName = TSharedPtr<FText>(new FText(FText::FromString(TEXT("Local"))));
-	SelectedDefaultConnection = TSharedPtr<FText>(new FText(*DefaultEffectName));
-	PropertyHandle->GetValueAsDisplayText(*SelectedDefaultConnection);
+	TSharedPtr<FText> LocalServiceName = TSharedPtr<FText>(new FText(FText::FromString(TEXT("Local"))));
+	AvailableServicesNames->Add(LocalServiceName);
+	SelectedDefaultBackendService = LocalServiceName;
 
-	AvailableConnectionNames->Add(DefaultEffectName);
+	TSharedPtr<FText> CurrentServiceName = TSharedPtr<FText>(new FText(FText::GetEmpty()));
+	PropertyHandle->GetValueAsDisplayText(*CurrentServiceName);
+	if (!CurrentServiceName->EqualTo(FText::GetEmpty()))
+	{
+		SelectedDefaultBackendService = CurrentServiceName;
+	}
 
 	for (auto ConnectionSetting : settings->Connections)
 	{
-		AvailableConnectionNames->Add(MakeShared<FText>(FText::FromString(*ConnectionSetting.Key)));
+		AvailableServicesNames->Add(MakeShared<FText>(FText::FromString(*ConnectionSetting.Key)));
 	}
 
 	// clang-format off
 	// Text box component:
 	TSharedRef<STextBlock > EditableTextBox = SNew(STextBlock )
-		.Text_Lambda([this]() { return *SelectedDefaultConnection; });
+		.Text_Lambda([this]() { return *SelectedDefaultBackendService; });
 
 	// Combo box component:
 	TSharedRef<SWidget> ComboBox = SNew(SListView<TSharedPtr<FText>>)
-		.ListItemsSource(AvailableConnectionNames)
+		.ListItemsSource(AvailableServicesNames)
 		.OnGenerateRow_Lambda([](TSharedPtr<FText> InItem, const TSharedRef< class STableViewBase >& Owner)
 		{
 			return SNew(STableRow<TSharedPtr<FText>>, Owner)
@@ -61,7 +66,7 @@ TSharedRef<SWidget> FTestbed2ConnectionSettingsDetails::MakeDefaultConnectionSel
 		})
 		.OnSelectionChanged_Lambda([this, PropertyHandle](TSharedPtr<FText> InText, ESelectInfo::Type)
 		{
-			SelectedDefaultConnection = InText;
+			SelectedDefaultBackendService = InText;
 			PropertyHandle->SetValue(InText->ToString());
 		});
 
@@ -90,24 +95,133 @@ TSharedRef<SWidget> FTestbed2ConnectionSettingsDetails::MakeDefaultConnectionSel
 	return NewWidget;
 }
 
-void FTestbed2ConnectionSettingsDetails::CustomizeDetails(IDetailLayoutBuilder& DetailBuilder)
+TSharedRef<SWidget> FTestbed2ConnectionSettingsDetails::MakeDefaultOLinkConnectionSelectorWidget(const TSharedPtr<IPropertyHandle>& PropertyHandle)
 {
-	IDetailCategoryBuilder& ConnectionsCategory = DetailBuilder.EditCategory(TEXT("ServiceSetup"));
+	UApiGearSettings* settings = GetMutableDefault<UApiGearSettings>();
+	check(settings);
 
-	TSharedPtr<IPropertyHandle> ConnectionIdentifierPropertyHandle = DetailBuilder.GetProperty("ConnectionIdentifier", nullptr);
-	IDetailPropertyRow& DefaultConnectionIdentifierPropertyRow = ConnectionsCategory.AddProperty(ConnectionIdentifierPropertyHandle);
+	TArray<TSharedPtr<FText>>* AvailableOLinkConnectionNames = &AvailableOLinkConnections;
+	FText TooltipText = FText::FromString(TEXT("Choose which connection should be used as default. Please make sure to have at least one connection defined."));
+
+	for (auto ConnectionSetting : settings->Connections)
+	{
+		if (ConnectionSetting.Value.ProtocolIdentifier == "olink")
+		{
+			TSharedPtr<FText> ConnectionName = MakeShared<FText>(FText::FromString(*ConnectionSetting.Key));
+			AvailableOLinkConnectionNames->Add(ConnectionName);
+
+			if (!SelectedDefaultOLinkConnection)
+			{
+				SelectedDefaultOLinkConnection = ConnectionName;
+			}
+		}
+	}
+
+	TSharedPtr<FText> CurrentConnectionName = TSharedPtr<FText>(new FText(FText::GetEmpty()));
+	PropertyHandle->GetValueAsDisplayText(*CurrentConnectionName);
+	if (!CurrentConnectionName->EqualTo(FText::GetEmpty()))
+	{
+		SelectedDefaultOLinkConnection = CurrentConnectionName;
+	}
+
+	if (!SelectedDefaultOLinkConnection)
+	{
+		SelectedDefaultOLinkConnection = TSharedPtr<FText>(new FText(FText::FromString(TEXT("Please define a connection in the settings first!"))));
+	}
 
 	// clang-format off
-	DefaultConnectionIdentifierPropertyRow.CustomWidget()
+	// Text box component:
+	TSharedRef<STextBlock > EditableTextBox = SNew(STextBlock )
+		.Text_Lambda([this]() { return *SelectedDefaultOLinkConnection; });
+
+	// Combo box component:
+	TSharedRef<SWidget> ComboBox = SNew(SListView<TSharedPtr<FText>>)
+		.ListItemsSource(AvailableOLinkConnectionNames)
+		.OnGenerateRow_Lambda([](TSharedPtr<FText> InItem, const TSharedRef< class STableViewBase >& Owner)
+		{
+			return SNew(STableRow<TSharedPtr<FText>>, Owner)
+					.Padding(FMargin(16, 4, 16, 4))
+					[
+						SNew(STextBlock).Text(*InItem)
+					];
+		})
+		.OnSelectionChanged_Lambda([this, PropertyHandle](TSharedPtr<FText> InText, ESelectInfo::Type)
+		{
+			SelectedDefaultOLinkConnection = InText;
+			PropertyHandle->SetValue(InText->ToString());
+		});
+
+
+	//Generate widget:
+	const TSharedRef<SWidget> NewWidget = SNew(SComboButton)
+		.ContentPadding(FMargin(0, 0, 5, 0))
+		.ToolTipText(TooltipText)
+		.ButtonContent()
+		[
+			SNew(SBorder)
+#if (ENGINE_MAJOR_VERSION >= 5)
+			.BorderImage(FAppStyle::GetBrush("NoBorder"))
+#endif
+			.Padding(FMargin(0, 0, 5, 0))
+			[
+				EditableTextBox
+			]
+		]
+		.MenuContent()
+		[
+			ComboBox
+		];
+	// clang-format on
+
+	return NewWidget;
+}
+
+void FTestbed2ConnectionSettingsDetails::CustomizeTracerDetails(IDetailLayoutBuilder& DetailBuilder)
+{
+	IDetailCategoryBuilder& TracerServiceCategory = DetailBuilder.EditCategory(TEXT("TracerServiceSetup"));
+
+	TSharedPtr<IPropertyHandle> BackendServiceIdentifierPropertyHandle = DetailBuilder.GetProperty("TracerServiceIdentifier", nullptr);
+	IDetailPropertyRow& DefaultBackendServiceIdentifierPropertyRow = TracerServiceCategory.AddProperty(BackendServiceIdentifierPropertyHandle);
+
+	// clang-format off
+	DefaultBackendServiceIdentifierPropertyRow.CustomWidget()
 		.NameContent()
 		[
-			ConnectionIdentifierPropertyHandle->CreatePropertyNameWidget()
+			BackendServiceIdentifierPropertyHandle->CreatePropertyNameWidget()
 		]
 		.ValueContent()
 		.MaxDesiredWidth(500.0f)
 		.MinDesiredWidth(100.0f)
 		[
-			MakeDefaultConnectionSelectorWidget(ConnectionIdentifierPropertyHandle)
+			MakeDefaultBackendServiceSelectorWidget(BackendServiceIdentifierPropertyHandle)
 		];
 	// clang-format on
+}
+
+void FTestbed2ConnectionSettingsDetails::CustomizeOLinkDetails(IDetailLayoutBuilder& DetailBuilder)
+{
+	IDetailCategoryBuilder& OLinkConnectionsCategory = DetailBuilder.EditCategory(TEXT("OLinkConnectionSetup"));
+
+	TSharedPtr<IPropertyHandle> OLinkConnectionIdentifierPropertyHandle = DetailBuilder.GetProperty("OLinkConnectionIdentifier", nullptr);
+	IDetailPropertyRow& DefaultOLinkConnectionIdentifierPropertyRow = OLinkConnectionsCategory.AddProperty(OLinkConnectionIdentifierPropertyHandle);
+
+	// clang-format off
+	DefaultOLinkConnectionIdentifierPropertyRow.CustomWidget()
+		.NameContent()
+		[
+			OLinkConnectionIdentifierPropertyHandle->CreatePropertyNameWidget()
+		]
+		.ValueContent()
+		.MaxDesiredWidth(500.0f)
+		.MinDesiredWidth(100.0f)
+		[
+			MakeDefaultOLinkConnectionSelectorWidget(OLinkConnectionIdentifierPropertyHandle)
+		];
+	// clang-format on
+}
+
+void FTestbed2ConnectionSettingsDetails::CustomizeDetails(IDetailLayoutBuilder& DetailBuilder)
+{
+	CustomizeTracerDetails(DetailBuilder);
+	CustomizeOLinkDetails(DetailBuilder);
 }

--- a/goldenmaster/Plugins/Testbed2/Source/Testbed2Editor/Private/Testbed2ConnectionSettings.cpp
+++ b/goldenmaster/Plugins/Testbed2/Source/Testbed2Editor/Private/Testbed2ConnectionSettings.cpp
@@ -2,6 +2,7 @@
 #include "Testbed2ConnectionSettings.h"
 
 #include "ApiGearSettings.h"
+#include "apigearolink.h"
 #include "Testbed2Settings.h"
 #include "Templates/SharedPointer.h"
 #include "IDetailCustomization.h"
@@ -106,7 +107,7 @@ TSharedRef<SWidget> FTestbed2ConnectionSettingsDetails::MakeDefaultOLinkConnecti
 
 	for (auto ConnectionSetting : settings->Connections)
 	{
-		if (ConnectionSetting.Value.ProtocolIdentifier == "olink")
+		if (ConnectionSetting.Value.ProtocolIdentifier == ApiGearOLinkProtocolIdentifier)
 		{
 			TSharedPtr<FText> ConnectionName = MakeShared<FText>(FText::FromString(*ConnectionSetting.Key));
 			AvailableOLinkConnectionNames->Add(ConnectionName);

--- a/goldenmaster/Plugins/Testbed2/Source/Testbed2Editor/Public/Testbed2ConnectionSettings.h
+++ b/goldenmaster/Plugins/Testbed2/Source/Testbed2Editor/Public/Testbed2ConnectionSettings.h
@@ -21,8 +21,13 @@ public:
 	virtual void CustomizeDetails(IDetailLayoutBuilder& DetailBuilder) override;
 
 private:
-	TSharedRef<SWidget> MakeDefaultConnectionSelectorWidget(const TSharedPtr<IPropertyHandle>& PropertyHandle);
+	void CustomizeTracerDetails(IDetailLayoutBuilder& DetailBuilder);
+	TSharedRef<SWidget> MakeDefaultBackendServiceSelectorWidget(const TSharedPtr<IPropertyHandle>& PropertyHandle);
+	TSharedPtr<FText> SelectedDefaultBackendService;
+	TArray<TSharedPtr<FText>> AvailableServices;
 
-	TSharedPtr<FText> SelectedDefaultConnection;
-	TArray<TSharedPtr<FText>> AvailableConnections;
+	void CustomizeOLinkDetails(IDetailLayoutBuilder& DetailBuilder);
+	TSharedRef<SWidget> MakeDefaultOLinkConnectionSelectorWidget(const TSharedPtr<IPropertyHandle>& PropertyHandle);
+	TSharedPtr<FText> SelectedDefaultOLinkConnection;
+	TArray<TSharedPtr<FText>> AvailableOLinkConnections;
 };

--- a/goldenmaster/Plugins/Testbed2/Source/Testbed2Editor/Testbed2Editor.Build.cs
+++ b/goldenmaster/Plugins/Testbed2/Source/Testbed2Editor/Testbed2Editor.Build.cs
@@ -14,6 +14,7 @@ namespace UnrealBuildTool.Rules
 					"UnrealEd",
 					// modules below are needed for connection settings
 					"ApiGear",
+					"ApiGearOLink",
 					"InputCore",
 					"PropertyEditor",
 					"Slate",

--- a/templates/ApiGear/Source/ApiGear/Public/ApiGearSettings.h
+++ b/templates/ApiGear/Source/ApiGear/Public/ApiGearSettings.h
@@ -17,7 +17,7 @@ struct FApiGearConnectionSetting
 	 * Unique protocol identifier, based on which connection type can be recognized and created.
 	 * You can have more than one connection of the same protocol type with different urls
 	 */
-	FString ProtocolIdentifier{TEXT("olink")};
+	FString ProtocolIdentifier{"olink"};
 
 	/** Choose the server to connect to */
 	UPROPERTY(EditAnywhere, config, Category = ApiGearConnectionSetting)

--- a/templates/ApiGear/Source/ApiGearOLink/Private/apigearolink.cpp
+++ b/templates/ApiGear/Source/ApiGearOLink/Private/apigearolink.cpp
@@ -13,7 +13,7 @@ void FApiGearModuleOLink::StartupModule()
 	FWebSocketsModule& WebSocketsModule = FModuleManager::LoadModuleChecked<FWebSocketsModule>(TEXT("WebSockets"));
 
 	// register olink factory function
-	UApiGearConnectionsStore::RegisterConnectionFactory("olink", &OLinkFactory::Create);
+	UApiGearConnectionsStore::RegisterConnectionFactory(ApiGearOLinkProtocolIdentifier, &OLinkFactory::Create);
 }
 
 void FApiGearModuleOLink::ShutdownModule()

--- a/templates/ApiGear/Source/ApiGearOLink/Public/apigearolink.h
+++ b/templates/ApiGear/Source/ApiGearOLink/Public/apigearolink.h
@@ -2,6 +2,9 @@
 #pragma once
 
 #include "Modules/ModuleManager.h"
+#include "Containers/UnrealString.h"
+
+const FString ApiGearOLinkProtocolIdentifier = "olink";
 
 class FApiGearModuleOLink : public IModuleInterface
 {

--- a/templates/ApiGear/Source/ApiGearOLink/Public/unrealolink.h
+++ b/templates/ApiGear/Source/ApiGearOLink/Public/unrealolink.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include "AbstractApiGearConnection.h"
+#include "apigearolink.h"
 THIRD_PARTY_INCLUDES_START
 #include "olink/clientnode.h"
 #include "olink/clientregistry.h"
@@ -45,7 +46,7 @@ public:
 	FString GetUniqueEndpointIdentifier() const override;
 	FString GetConnectionProtocolIdentifier() const override
 	{
-		return "olink";
+		return ApiGearOLinkProtocolIdentifier;
 	};
 
 	std::shared_ptr<ApiGear::ObjectLink::ClientNode> node()

--- a/templates/ApiGear/Source/ApiGearOLink/Public/unrealolink.h
+++ b/templates/ApiGear/Source/ApiGearOLink/Public/unrealolink.h
@@ -67,7 +67,6 @@ private:
 
 	TSharedPtr<IWebSocket> m_socket;
 	FString m_serverURL;
-	FString ConnectionIdentifier;
 	ApiGear::ObjectLink::ClientRegistry m_registry;
 	std::shared_ptr<ApiGear::ObjectLink::ClientNode> m_node;
 	TQueue<std::string, EQueueMode::Mpsc> m_queue;

--- a/templates/module/Source/module/Private/Generated/Monitor/pluginfactory.cpp.tpl
+++ b/templates/module/Source/module/Private/Generated/Monitor/pluginfactory.cpp.tpl
@@ -22,6 +22,7 @@ limitations under the License.
 
 #include "{{$ModuleName}}Factory.h"
 #include "ApiGearSettings.h"
+#include "{{$ModuleName}}Settings.h"
 {{- range .Module.Interfaces }}
 {{- $iclass := printf "%s%s" $ModuleName (Camel .Name)}}
 {{- if $.Features.stubs }}
@@ -95,7 +96,7 @@ TScriptInterface<I{{$class}}Interface> {{$mclass}}::create{{$iclass}}(UGameInsta
 {
 	U{{$ModuleName}}Settings* {{$ModuleName}}Settings = GetMutableDefault<U{{$ModuleName}}Settings>();
 
-	if ({{$ModuleName}}Settings->TracerServiceIdentifier == "Local")
+	if ({{$ModuleName}}Settings->TracerServiceIdentifier == {{$ModuleName}}LocalBackendIdentifier)
 	{
 		return create{{$class}}(GameInstance, Collection);
 	}
@@ -150,7 +151,7 @@ TScriptInterface<I{{$class}}Interface> {{$mclass}}::create{{$iclass}}(FSubsystem
 {
 	U{{$ModuleName}}Settings* {{$ModuleName}}Settings = GetMutableDefault<U{{$ModuleName}}Settings>();
 
-	if ({{$ModuleName}}Settings->TracerServiceIdentifier == "Local")
+	if ({{$ModuleName}}Settings->TracerServiceIdentifier == {{$ModuleName}}LocalBackendIdentifier)
 	{
 		return create{{$class}}(Collection);
 	}

--- a/templates/module/Source/module/Private/Generated/Monitor/pluginfactory.cpp.tpl
+++ b/templates/module/Source/module/Private/Generated/Monitor/pluginfactory.cpp.tpl
@@ -22,6 +22,7 @@ limitations under the License.
 
 #include "{{$ModuleName}}Factory.h"
 #include "ApiGearSettings.h"
+#include "apigearolink.h"
 #include "{{$ModuleName}}Settings.h"
 {{- range .Module.Interfaces }}
 {{- $iclass := printf "%s%s" $ModuleName (Camel .Name)}}
@@ -109,7 +110,7 @@ TScriptInterface<I{{$class}}Interface> {{$mclass}}::create{{$iclass}}(UGameInsta
 	// Other protocols not supported. To support it edit templates:
 	// add protocol handler class for this interface like create{{$class}}OLink and other necessary infrastructure
 	// extend this function in templates to handle protocol of your choice
-	if (ConnectionSetting && ConnectionSetting->ProtocolIdentifier == "olink")
+	if (ConnectionSetting && ConnectionSetting->ProtocolIdentifier == ApiGearOLinkProtocolIdentifier)
 	{
 		return create{{$class}}OLink(GameInstance, Collection);
 	}
@@ -164,7 +165,7 @@ TScriptInterface<I{{$class}}Interface> {{$mclass}}::create{{$iclass}}(FSubsystem
 	// Other protocols not supported. To support it edit templates:
 	// add protocol handler class for this interface like create{{$class}}OLink and other necessary infrastructure
 	// extend this function in templates to handle protocol of your choice
-	if (ConnectionSetting && ConnectionSetting->ProtocolIdentifier == "olink")
+	if (ConnectionSetting && ConnectionSetting->ProtocolIdentifier == ApiGearOLinkProtocolIdentifier)
 	{
 		return create{{$class}}OLink(Collection);
 	}

--- a/templates/module/Source/module/Private/Generated/Monitor/pluginfactory.cpp.tpl
+++ b/templates/module/Source/module/Private/Generated/Monitor/pluginfactory.cpp.tpl
@@ -95,13 +95,13 @@ TScriptInterface<I{{$class}}Interface> {{$mclass}}::create{{$iclass}}(UGameInsta
 {
 	U{{$ModuleName}}Settings* {{$ModuleName}}Settings = GetMutableDefault<U{{$ModuleName}}Settings>();
 
-	if ({{$ModuleName}}Settings->ConnectionIdentifier == "Local")
+	if ({{$ModuleName}}Settings->TracerServiceIdentifier == "Local")
 	{
 		return create{{$class}}(GameInstance, Collection);
 	}
 
 	UApiGearSettings* ApiGearSettings = GetMutableDefault<UApiGearSettings>();
-	FApiGearConnectionSetting* ConnectionSetting = ApiGearSettings->Connections.Find({{$ModuleName}}Settings->ConnectionIdentifier);
+	FApiGearConnectionSetting* ConnectionSetting = ApiGearSettings->Connections.Find({{$ModuleName}}Settings->TracerServiceIdentifier);
 
 {{- if $.Features.olink }}
 
@@ -150,13 +150,13 @@ TScriptInterface<I{{$class}}Interface> {{$mclass}}::create{{$iclass}}(FSubsystem
 {
 	U{{$ModuleName}}Settings* {{$ModuleName}}Settings = GetMutableDefault<U{{$ModuleName}}Settings>();
 
-	if ({{$ModuleName}}Settings->ConnectionIdentifier == "Local")
+	if ({{$ModuleName}}Settings->TracerServiceIdentifier == "Local")
 	{
 		return create{{$class}}(Collection);
 	}
 
 	UApiGearSettings* ApiGearSettings = GetMutableDefault<UApiGearSettings>();
-	FApiGearConnectionSetting* ConnectionSetting = ApiGearSettings->Connections.Find({{$ModuleName}}Settings->ConnectionIdentifier);
+	FApiGearConnectionSetting* ConnectionSetting = ApiGearSettings->Connections.Find({{$ModuleName}}Settings->TracerServiceIdentifier);
 
 {{- if $.Features.olink }}
 

--- a/templates/module/Source/module/Private/Generated/OLink/olinkclient.cpp.tpl
+++ b/templates/module/Source/module/Private/Generated/OLink/olinkclient.cpp.tpl
@@ -16,6 +16,7 @@
 
 #include "Generated/OLink/{{$Iface}}OLinkClient.h"
 #include "ApiGearSettings.h"
+#include "apigearolink.h"
 #include "Async/Async.h"
 #include "Generated/api/{{$ModuleName}}.json.adapter.h"
 #include "unrealolink.h"
@@ -119,7 +120,7 @@ void {{$Class}}::UseConnection(TScriptInterface<IApiGearConnection> InConnection
 	checkf(InConnection.GetInterface() != nullptr, TEXT("Cannot use connection - interface IApiGearConnection is not fully implemented"));
 
 	// only accept connections of type olink
-	checkf(InConnection->GetConnectionProtocolIdentifier() == "olink", TEXT("Cannot use connection - must be of type olink"));
+	checkf(InConnection->GetConnectionProtocolIdentifier() == ApiGearOLinkProtocolIdentifier, TEXT("Cannot use connection - must be of type olink"));
 
 	UUnrealOLink* UnrealOLinkConnection = nullptr;
 	// remove old connection

--- a/templates/module/Source/module/Private/Generated/OLink/olinkclient.cpp.tpl
+++ b/templates/module/Source/module/Private/Generated/OLink/olinkclient.cpp.tpl
@@ -87,8 +87,13 @@ void {{$Class}}::Initialize(FSubsystemCollectionBase& Collection)
 
 	UApiGearConnectionsStore* AGCM = GEngine->GetEngineSubsystem<UApiGearConnectionsStore>();
 
-	TScriptInterface<IApiGearConnection> OLinkConnection = AGCM->GetConnection(settings->ConnectionIdentifier);
+	TScriptInterface<IApiGearConnection> OLinkConnection = AGCM->GetConnection(settings->OLinkConnectionIdentifier);
 
+	if (!OLinkConnection.GetInterface())
+	{
+		UE_LOG(Log{{$Iface}}OLinkClient, Log, TEXT("No valid olink connection for %s, please set during run time"), UTF8_TO_TCHAR(m_sink->olinkObjectName().c_str()));
+		return;
+	}
 	UseConnection(OLinkConnection);
 	OLinkConnection->Connect();
 }

--- a/templates/module/Source/module/Private/Generated/OLink/olinkclient.cpp.tpl
+++ b/templates/module/Source/module/Private/Generated/OLink/olinkclient.cpp.tpl
@@ -201,7 +201,17 @@ void {{$Class}}::Set{{Camel .Name}}_Implementation({{ueParam "In" .}})
 		[{{ueVars "" .Params }}{{if len .Params}}, {{ end }}&Promise, this]()
 		{
 			ApiGear::ObjectLink::InvokeReplyFunc Get{{$IfaceName}}StateFunc = [&Promise](ApiGear::ObjectLink::InvokeReplyArg arg)
-			{ Promise.SetValue(arg.value.get<{{$returnVal}}>()); };
+			{
+				if (!arg.value.empty())
+				{
+					Promise.SetValue(arg.value.get<{{$returnVal}}>());
+				}
+				else
+				{
+					UE_LOG(Log{{$Iface}}OLinkClient, Error, TEXT("{{Camel .Name}}: OLink service returned empty value - should have returned type of {{$returnVal}}"));
+					Promise.SetValue({{$returnVal}}());
+				}
+			};
 			static const auto memberId = ApiGear::ObjectLink::Name::createMemberId(m_sink->olinkObjectName(), "{{.Name}}");
 			m_sink->GetNode()->invokeRemote(memberId, { {{- ueVars "" .Params -}} }, Get{{$IfaceName}}StateFunc);
 		});

--- a/templates/module/Source/module/Private/pluginnamesettings.cpp.tpl
+++ b/templates/module/Source/module/Private/pluginnamesettings.cpp.tpl
@@ -42,7 +42,7 @@ void U{{$ModuleName}}Settings::PostInitProperties()
 	}
 
 	// the local backend does not require configuration
-	if (TracerServiceIdentifier == "Local")
+	if (TracerServiceIdentifier == {{$ModuleName}}LocalBackendIdentifier)
 	{
 		return;
 	}
@@ -50,6 +50,6 @@ void U{{$ModuleName}}Settings::PostInitProperties()
 	if (!AGCM->DoesConnectionExist(TracerServiceIdentifier))
 	{
 		UE_LOG(LogTemp, Warning, TEXT("U{{$ModuleName}}Settings could not find connection %s, falling back to local backend."), *TracerServiceIdentifier);
-		TracerServiceIdentifier = "Local";
+		TracerServiceIdentifier = {{$ModuleName}}LocalBackendIdentifier;
 	}
 }

--- a/templates/module/Source/module/Private/pluginnamesettings.cpp.tpl
+++ b/templates/module/Source/module/Private/pluginnamesettings.cpp.tpl
@@ -32,18 +32,24 @@ void U{{$ModuleName}}Settings::PostInitProperties()
 {
 	Super::PostInitProperties();
 
+	check(GEngine);
+	UApiGearConnectionsStore* AGCM = GEngine->GetEngineSubsystem<UApiGearConnectionsStore>();
+
+	if (!AGCM->DoesConnectionExist(OLinkConnectionIdentifier))
+	{
+		UE_LOG(LogTemp, Warning, TEXT("U{{$ModuleName}}Settings could not find connection %s."), *OLinkConnectionIdentifier);
+		OLinkConnectionIdentifier = "";
+	}
+
 	// the local backend does not require configuration
-	if (ConnectionIdentifier == "Local")
+	if (TracerServiceIdentifier == "Local")
 	{
 		return;
 	}
 
-	check(GEngine);
-	UApiGearConnectionsStore* AGCM = GEngine->GetEngineSubsystem<UApiGearConnectionsStore>();
-
-	if (!AGCM->DoesConnectionExist(ConnectionIdentifier))
+	if (!AGCM->DoesConnectionExist(TracerServiceIdentifier))
 	{
-		UE_LOG(LogTemp, Warning, TEXT("U{{$ModuleName}}Settings could not find connection %s, falling back to local backend."), *ConnectionIdentifier);
-		ConnectionIdentifier = "Local";
+		UE_LOG(LogTemp, Warning, TEXT("U{{$ModuleName}}Settings could not find connection %s, falling back to local backend."), *TracerServiceIdentifier);
+		TracerServiceIdentifier = "Local";
 	}
 }

--- a/templates/module/Source/module/Public/pluginnamesettings.h.tpl
+++ b/templates/module/Source/module/Public/pluginnamesettings.h.tpl
@@ -26,6 +26,8 @@ limitations under the License.
 #include "Engine/EngineTypes.h"
 #include "{{$ModuleName}}Settings.generated.h"
 
+const FString {{$ModuleName}}LocalBackendIdentifier = "Local";
+
 /**
  * Implements the settings for the {{$ModuleName}} plugin.
  */

--- a/templates/module/Source/module/Public/pluginnamesettings.h.tpl
+++ b/templates/module/Source/module/Public/pluginnamesettings.h.tpl
@@ -37,6 +37,10 @@ class {{$API_MACRO}} U{{$ModuleName}}Settings : public UObject
 	virtual void PostInitProperties() override;
 
 	// Choose the backend service for the logging decorator to use
-	UPROPERTY(EditAnywhere, config, Category = ServiceSetup)
-	FString ConnectionIdentifier;
+	UPROPERTY(EditAnywhere, config, Category = TracerServiceSetup)
+	FString TracerServiceIdentifier;
+
+	// Choose the olink connection to use
+	UPROPERTY(EditAnywhere, config, Category = OLinkConnectionSetup)
+	FString OLinkConnectionIdentifier;
 };

--- a/templates/module/Source/moduleeditor/Private/pluginnameconnectionsettings.cpp.tpl
+++ b/templates/module/Source/moduleeditor/Private/pluginnameconnectionsettings.cpp.tpl
@@ -7,6 +7,7 @@
 #include "{{$ModuleName}}ConnectionSettings.h"
 
 #include "ApiGearSettings.h"
+#include "apigearolink.h"
 #include "{{$ModuleName}}Settings.h"
 #include "Templates/SharedPointer.h"
 #include "IDetailCustomization.h"
@@ -113,7 +114,7 @@ TSharedRef<SWidget> F{{$ModuleName}}ConnectionSettingsDetails::MakeDefaultOLinkC
 
 	for (auto ConnectionSetting : settings->Connections)
 	{
-		if (ConnectionSetting.Value.ProtocolIdentifier == "olink")
+		if (ConnectionSetting.Value.ProtocolIdentifier == ApiGearOLinkProtocolIdentifier)
 		{
 			TSharedPtr<FText> ConnectionName = MakeShared<FText>(FText::FromString(*ConnectionSetting.Key));
 			AvailableOLinkConnectionNames->Add(ConnectionName);

--- a/templates/module/Source/moduleeditor/Private/pluginnameconnectionsettings.cpp.tpl
+++ b/templates/module/Source/moduleeditor/Private/pluginnameconnectionsettings.cpp.tpl
@@ -7,6 +7,7 @@
 #include "{{$ModuleName}}ConnectionSettings.h"
 
 #include "ApiGearSettings.h"
+#include "{{$ModuleName}}Settings.h"
 #include "Templates/SharedPointer.h"
 #include "IDetailCustomization.h"
 #include "PropertyHandle.h"
@@ -37,7 +38,7 @@ TSharedRef<SWidget> F{{$ModuleName}}ConnectionSettingsDetails::MakeDefaultBacken
 	TArray<TSharedPtr<FText>>* AvailableServicesNames = &AvailableServices;
 	FText TooltipText = FText::FromString(TEXT("Choose which service should be used as default."));
 
-	TSharedPtr<FText> LocalServiceName = TSharedPtr<FText>(new FText(FText::FromString(TEXT("Local"))));
+	TSharedPtr<FText> LocalServiceName = TSharedPtr<FText>(new FText(FText::FromString({{$ModuleName}}LocalBackendIdentifier)));
 	AvailableServicesNames->Add(LocalServiceName);
 	SelectedDefaultBackendService = LocalServiceName;
 

--- a/templates/module/Source/moduleeditor/Public/pluginnameconnectionsettings.h.tpl
+++ b/templates/module/Source/moduleeditor/Public/pluginnameconnectionsettings.h.tpl
@@ -25,8 +25,16 @@ public:
 	virtual void CustomizeDetails(IDetailLayoutBuilder& DetailBuilder) override;
 
 private:
-	TSharedRef<SWidget> MakeDefaultConnectionSelectorWidget(const TSharedPtr<IPropertyHandle>& PropertyHandle);
+	void CustomizeTracerDetails(IDetailLayoutBuilder& DetailBuilder);
+	TSharedRef<SWidget> MakeDefaultBackendServiceSelectorWidget(const TSharedPtr<IPropertyHandle>& PropertyHandle);
+	TSharedPtr<FText> SelectedDefaultBackendService;
+	TArray<TSharedPtr<FText>> AvailableServices;
 
-	TSharedPtr<FText> SelectedDefaultConnection;
-	TArray<TSharedPtr<FText>> AvailableConnections;
+{{- if $.Features.olink }}
+
+	void CustomizeOLinkDetails(IDetailLayoutBuilder& DetailBuilder);
+	TSharedRef<SWidget> MakeDefaultOLinkConnectionSelectorWidget(const TSharedPtr<IPropertyHandle>& PropertyHandle);
+	TSharedPtr<FText> SelectedDefaultOLinkConnection;
+	TArray<TSharedPtr<FText>> AvailableOLinkConnections;
+{{- end }}
 };

--- a/templates/module/Source/moduleeditor/pluginnameeditor.Build.cs.tpl
+++ b/templates/module/Source/moduleeditor/pluginnameeditor.Build.cs.tpl
@@ -20,6 +20,9 @@ namespace UnrealBuildTool.Rules
 					"UnrealEd",
 					// modules below are needed for connection settings
 					"ApiGear",
+{{- if $.Features.olink }}
+					"ApiGearOLink",
+{{- end }}
 					"InputCore",
 					"PropertyEditor",
 					"Slate",


### PR DESCRIPTION
## 📑 Description
The PR #45 enabled the configuration of multiple different connections which could be selected during runtime or from the module settings.
This PR now splits the settings for the tracer and the olink connection into two different UI widgets.

Tested with UE 4.25, 4.27, 5.2 on Windows.

## ✅ Checks
<!-- Make sure your pr passes the CI checks and do check the following fields as needed - -->
- [ ] My pull request adheres to the code style of this project
- [ ] My code requires changes to the documentation
- [x] I have updated the documentation as required
- [x] All the tests have passed
