### PR TITLE
fix(olink): get exact type in olinkInvoke

### DIFF
--- a/goldenmaster/Plugins/ApiGear/apigear.uplugin
+++ b/goldenmaster/Plugins/ApiGear/apigear.uplugin
@@ -1,7 +1,7 @@
 {
 	"FileVersion": 3,
 	"Version": 1,
-	"VersionName": "3.0.0",
+	"VersionName": "3.0.1",
 	"FriendlyName": "ApiGear",
 	"Description": "ApiGear ThirdParty libraries for tracing, simulation and IPC support",
 	"Category": "Other",

--- a/goldenmaster/Plugins/TbEnum/Source/TbEnum/Private/Generated/OLink/TbEnumEnumInterfaceOLinkSource.cpp
+++ b/goldenmaster/Plugins/TbEnum/Source/TbEnum/Private/Generated/OLink/TbEnumEnumInterfaceOLinkSource.cpp
@@ -197,25 +197,25 @@ nlohmann::json TbEnumEnumInterfaceOLinkSource::olinkInvoke(const std::string& me
 	const std::string path = Name::getMemberName(methodId);
 	if (path == "func0")
 	{
-		ETbEnumEnum0 Param0 = args.at(0);
+		ETbEnumEnum0 Param0 = args.at(0).get<ETbEnumEnum0>();
 		ETbEnumEnum0 result = BackendService->Execute_Func0(BackendService.GetObject(), Param0);
 		return result;
 	}
 	if (path == "func1")
 	{
-		ETbEnumEnum1 Param1 = args.at(0);
+		ETbEnumEnum1 Param1 = args.at(0).get<ETbEnumEnum1>();
 		ETbEnumEnum1 result = BackendService->Execute_Func1(BackendService.GetObject(), Param1);
 		return result;
 	}
 	if (path == "func2")
 	{
-		ETbEnumEnum2 Param2 = args.at(0);
+		ETbEnumEnum2 Param2 = args.at(0).get<ETbEnumEnum2>();
 		ETbEnumEnum2 result = BackendService->Execute_Func2(BackendService.GetObject(), Param2);
 		return result;
 	}
 	if (path == "func3")
 	{
-		ETbEnumEnum3 Param3 = args.at(0);
+		ETbEnumEnum3 Param3 = args.at(0).get<ETbEnumEnum3>();
 		ETbEnumEnum3 result = BackendService->Execute_Func3(BackendService.GetObject(), Param3);
 		return result;
 	}

--- a/goldenmaster/Plugins/TbSame1/Source/TbSame1/Private/Generated/OLink/TbSame1SameEnum1InterfaceOLinkSource.cpp
+++ b/goldenmaster/Plugins/TbSame1/Source/TbSame1/Private/Generated/OLink/TbSame1SameEnum1InterfaceOLinkSource.cpp
@@ -110,7 +110,7 @@ nlohmann::json TbSame1SameEnum1InterfaceOLinkSource::olinkInvoke(const std::stri
 	const std::string path = Name::getMemberName(methodId);
 	if (path == "func1")
 	{
-		ETbSame1Enum1 Param1 = args.at(0);
+		ETbSame1Enum1 Param1 = args.at(0).get<ETbSame1Enum1>();
 		ETbSame1Enum1 result = BackendService->Execute_Func1(BackendService.GetObject(), Param1);
 		return result;
 	}

--- a/goldenmaster/Plugins/TbSame1/Source/TbSame1/Private/Generated/OLink/TbSame1SameEnum2InterfaceOLinkSource.cpp
+++ b/goldenmaster/Plugins/TbSame1/Source/TbSame1/Private/Generated/OLink/TbSame1SameEnum2InterfaceOLinkSource.cpp
@@ -139,14 +139,14 @@ nlohmann::json TbSame1SameEnum2InterfaceOLinkSource::olinkInvoke(const std::stri
 	const std::string path = Name::getMemberName(methodId);
 	if (path == "func1")
 	{
-		ETbSame1Enum1 Param1 = args.at(0);
+		ETbSame1Enum1 Param1 = args.at(0).get<ETbSame1Enum1>();
 		ETbSame1Enum1 result = BackendService->Execute_Func1(BackendService.GetObject(), Param1);
 		return result;
 	}
 	if (path == "func2")
 	{
-		ETbSame1Enum1 Param1 = args.at(0);
-		ETbSame1Enum2 Param2 = args.at(1);
+		ETbSame1Enum1 Param1 = args.at(0).get<ETbSame1Enum1>();
+		ETbSame1Enum2 Param2 = args.at(1).get<ETbSame1Enum2>();
 		ETbSame1Enum1 result = BackendService->Execute_Func2(BackendService.GetObject(), Param1, Param2);
 		return result;
 	}

--- a/goldenmaster/Plugins/TbSame1/Source/TbSame1/Private/Generated/OLink/TbSame1SameStruct1InterfaceOLinkSource.cpp
+++ b/goldenmaster/Plugins/TbSame1/Source/TbSame1/Private/Generated/OLink/TbSame1SameStruct1InterfaceOLinkSource.cpp
@@ -110,7 +110,7 @@ nlohmann::json TbSame1SameStruct1InterfaceOLinkSource::olinkInvoke(const std::st
 	const std::string path = Name::getMemberName(methodId);
 	if (path == "func1")
 	{
-		FTbSame1Struct1 Param1 = args.at(0);
+		FTbSame1Struct1 Param1 = args.at(0).get<FTbSame1Struct1>();
 		FTbSame1Struct1 result = BackendService->Execute_Func1(BackendService.GetObject(), Param1);
 		return result;
 	}

--- a/goldenmaster/Plugins/TbSame1/Source/TbSame1/Private/Generated/OLink/TbSame1SameStruct2InterfaceOLinkSource.cpp
+++ b/goldenmaster/Plugins/TbSame1/Source/TbSame1/Private/Generated/OLink/TbSame1SameStruct2InterfaceOLinkSource.cpp
@@ -139,14 +139,14 @@ nlohmann::json TbSame1SameStruct2InterfaceOLinkSource::olinkInvoke(const std::st
 	const std::string path = Name::getMemberName(methodId);
 	if (path == "func1")
 	{
-		FTbSame1Struct1 Param1 = args.at(0);
+		FTbSame1Struct1 Param1 = args.at(0).get<FTbSame1Struct1>();
 		FTbSame1Struct1 result = BackendService->Execute_Func1(BackendService.GetObject(), Param1);
 		return result;
 	}
 	if (path == "func2")
 	{
-		FTbSame1Struct1 Param1 = args.at(0);
-		FTbSame1Struct2 Param2 = args.at(1);
+		FTbSame1Struct1 Param1 = args.at(0).get<FTbSame1Struct1>();
+		FTbSame1Struct2 Param2 = args.at(1).get<FTbSame1Struct2>();
 		FTbSame1Struct1 result = BackendService->Execute_Func2(BackendService.GetObject(), Param1, Param2);
 		return result;
 	}

--- a/goldenmaster/Plugins/TbSame2/Source/TbSame2/Private/Generated/OLink/TbSame2SameEnum1InterfaceOLinkSource.cpp
+++ b/goldenmaster/Plugins/TbSame2/Source/TbSame2/Private/Generated/OLink/TbSame2SameEnum1InterfaceOLinkSource.cpp
@@ -110,7 +110,7 @@ nlohmann::json TbSame2SameEnum1InterfaceOLinkSource::olinkInvoke(const std::stri
 	const std::string path = Name::getMemberName(methodId);
 	if (path == "func1")
 	{
-		ETbSame2Enum1 Param1 = args.at(0);
+		ETbSame2Enum1 Param1 = args.at(0).get<ETbSame2Enum1>();
 		ETbSame2Enum1 result = BackendService->Execute_Func1(BackendService.GetObject(), Param1);
 		return result;
 	}

--- a/goldenmaster/Plugins/TbSame2/Source/TbSame2/Private/Generated/OLink/TbSame2SameEnum2InterfaceOLinkSource.cpp
+++ b/goldenmaster/Plugins/TbSame2/Source/TbSame2/Private/Generated/OLink/TbSame2SameEnum2InterfaceOLinkSource.cpp
@@ -139,14 +139,14 @@ nlohmann::json TbSame2SameEnum2InterfaceOLinkSource::olinkInvoke(const std::stri
 	const std::string path = Name::getMemberName(methodId);
 	if (path == "func1")
 	{
-		ETbSame2Enum1 Param1 = args.at(0);
+		ETbSame2Enum1 Param1 = args.at(0).get<ETbSame2Enum1>();
 		ETbSame2Enum1 result = BackendService->Execute_Func1(BackendService.GetObject(), Param1);
 		return result;
 	}
 	if (path == "func2")
 	{
-		ETbSame2Enum1 Param1 = args.at(0);
-		ETbSame2Enum2 Param2 = args.at(1);
+		ETbSame2Enum1 Param1 = args.at(0).get<ETbSame2Enum1>();
+		ETbSame2Enum2 Param2 = args.at(1).get<ETbSame2Enum2>();
 		ETbSame2Enum1 result = BackendService->Execute_Func2(BackendService.GetObject(), Param1, Param2);
 		return result;
 	}

--- a/goldenmaster/Plugins/TbSame2/Source/TbSame2/Private/Generated/OLink/TbSame2SameStruct1InterfaceOLinkSource.cpp
+++ b/goldenmaster/Plugins/TbSame2/Source/TbSame2/Private/Generated/OLink/TbSame2SameStruct1InterfaceOLinkSource.cpp
@@ -110,7 +110,7 @@ nlohmann::json TbSame2SameStruct1InterfaceOLinkSource::olinkInvoke(const std::st
 	const std::string path = Name::getMemberName(methodId);
 	if (path == "func1")
 	{
-		FTbSame2Struct1 Param1 = args.at(0);
+		FTbSame2Struct1 Param1 = args.at(0).get<FTbSame2Struct1>();
 		FTbSame2Struct1 result = BackendService->Execute_Func1(BackendService.GetObject(), Param1);
 		return result;
 	}

--- a/goldenmaster/Plugins/TbSame2/Source/TbSame2/Private/Generated/OLink/TbSame2SameStruct2InterfaceOLinkSource.cpp
+++ b/goldenmaster/Plugins/TbSame2/Source/TbSame2/Private/Generated/OLink/TbSame2SameStruct2InterfaceOLinkSource.cpp
@@ -139,14 +139,14 @@ nlohmann::json TbSame2SameStruct2InterfaceOLinkSource::olinkInvoke(const std::st
 	const std::string path = Name::getMemberName(methodId);
 	if (path == "func1")
 	{
-		FTbSame2Struct1 Param1 = args.at(0);
+		FTbSame2Struct1 Param1 = args.at(0).get<FTbSame2Struct1>();
 		FTbSame2Struct1 result = BackendService->Execute_Func1(BackendService.GetObject(), Param1);
 		return result;
 	}
 	if (path == "func2")
 	{
-		FTbSame2Struct1 Param1 = args.at(0);
-		FTbSame2Struct2 Param2 = args.at(1);
+		FTbSame2Struct1 Param1 = args.at(0).get<FTbSame2Struct1>();
+		FTbSame2Struct2 Param2 = args.at(1).get<FTbSame2Struct2>();
 		FTbSame2Struct1 result = BackendService->Execute_Func2(BackendService.GetObject(), Param1, Param2);
 		return result;
 	}

--- a/goldenmaster/Plugins/TbSimple/Source/TbSimple/Private/Generated/OLink/TbSimpleNoPropertiesInterfaceOLinkSource.cpp
+++ b/goldenmaster/Plugins/TbSimple/Source/TbSimple/Private/Generated/OLink/TbSimpleNoPropertiesInterfaceOLinkSource.cpp
@@ -116,7 +116,7 @@ nlohmann::json TbSimpleNoPropertiesInterfaceOLinkSource::olinkInvoke(const std::
 	}
 	if (path == "funcBool")
 	{
-		bool bParamBool = args.at(0);
+		bool bParamBool = args.at(0).get<bool>();
 		bool result = BackendService->Execute_FuncBool(BackendService.GetObject(), bParamBool);
 		return result;
 	}

--- a/goldenmaster/Plugins/TbSimple/Source/TbSimple/Private/Generated/OLink/TbSimpleNoSignalsInterfaceOLinkSource.cpp
+++ b/goldenmaster/Plugins/TbSimple/Source/TbSimple/Private/Generated/OLink/TbSimpleNoSignalsInterfaceOLinkSource.cpp
@@ -114,7 +114,7 @@ nlohmann::json TbSimpleNoSignalsInterfaceOLinkSource::olinkInvoke(const std::str
 	}
 	if (path == "funcBool")
 	{
-		bool bParamBool = args.at(0);
+		bool bParamBool = args.at(0).get<bool>();
 		bool result = BackendService->Execute_FuncBool(BackendService.GetObject(), bParamBool);
 		return result;
 	}

--- a/goldenmaster/Plugins/TbSimple/Source/TbSimple/Private/Generated/OLink/TbSimpleSimpleArrayInterfaceOLinkSource.cpp
+++ b/goldenmaster/Plugins/TbSimple/Source/TbSimple/Private/Generated/OLink/TbSimpleSimpleArrayInterfaceOLinkSource.cpp
@@ -313,49 +313,49 @@ nlohmann::json TbSimpleSimpleArrayInterfaceOLinkSource::olinkInvoke(const std::s
 	const std::string path = Name::getMemberName(methodId);
 	if (path == "funcBool")
 	{
-		TArray<bool> ParamBool = args.at(0);
+		TArray<bool> ParamBool = args.at(0).get<TArray<bool>>();
 		TArray<bool> result = BackendService->Execute_FuncBool(BackendService.GetObject(), ParamBool);
 		return result;
 	}
 	if (path == "funcInt")
 	{
-		TArray<int32> ParamInt = args.at(0);
+		TArray<int32> ParamInt = args.at(0).get<TArray<int32>>();
 		TArray<int32> result = BackendService->Execute_FuncInt(BackendService.GetObject(), ParamInt);
 		return result;
 	}
 	if (path == "funcInt32")
 	{
-		TArray<int32> ParamInt32 = args.at(0);
+		TArray<int32> ParamInt32 = args.at(0).get<TArray<int32>>();
 		TArray<int32> result = BackendService->Execute_FuncInt32(BackendService.GetObject(), ParamInt32);
 		return result;
 	}
 	if (path == "funcInt64")
 	{
-		TArray<int64> ParamInt64 = args.at(0);
+		TArray<int64> ParamInt64 = args.at(0).get<TArray<int64>>();
 		TArray<int64> result = BackendService->Execute_FuncInt64(BackendService.GetObject(), ParamInt64);
 		return result;
 	}
 	if (path == "funcFloat")
 	{
-		TArray<float> ParamFloat = args.at(0);
+		TArray<float> ParamFloat = args.at(0).get<TArray<float>>();
 		TArray<float> result = BackendService->Execute_FuncFloat(BackendService.GetObject(), ParamFloat);
 		return result;
 	}
 	if (path == "funcFloat32")
 	{
-		TArray<float> ParamFloat32 = args.at(0);
+		TArray<float> ParamFloat32 = args.at(0).get<TArray<float>>();
 		TArray<float> result = BackendService->Execute_FuncFloat32(BackendService.GetObject(), ParamFloat32);
 		return result;
 	}
 	if (path == "funcFloat64")
 	{
-		TArray<double> ParamFloat = args.at(0);
+		TArray<double> ParamFloat = args.at(0).get<TArray<double>>();
 		TArray<double> result = BackendService->Execute_FuncFloat64(BackendService.GetObject(), ParamFloat);
 		return result;
 	}
 	if (path == "funcString")
 	{
-		TArray<FString> ParamString = args.at(0);
+		TArray<FString> ParamString = args.at(0).get<TArray<FString>>();
 		TArray<FString> result = BackendService->Execute_FuncString(BackendService.GetObject(), ParamString);
 		return result;
 	}

--- a/goldenmaster/Plugins/TbSimple/Source/TbSimple/Private/Generated/OLink/TbSimpleSimpleInterfaceOLinkSource.cpp
+++ b/goldenmaster/Plugins/TbSimple/Source/TbSimple/Private/Generated/OLink/TbSimpleSimpleInterfaceOLinkSource.cpp
@@ -347,49 +347,49 @@ nlohmann::json TbSimpleSimpleInterfaceOLinkSource::olinkInvoke(const std::string
 	}
 	if (path == "funcBool")
 	{
-		bool bParamBool = args.at(0);
+		bool bParamBool = args.at(0).get<bool>();
 		bool result = BackendService->Execute_FuncBool(BackendService.GetObject(), bParamBool);
 		return result;
 	}
 	if (path == "funcInt")
 	{
-		int32 ParamInt = args.at(0);
+		int32 ParamInt = args.at(0).get<int32>();
 		int32 result = BackendService->Execute_FuncInt(BackendService.GetObject(), ParamInt);
 		return result;
 	}
 	if (path == "funcInt32")
 	{
-		int32 ParamInt32 = args.at(0);
+		int32 ParamInt32 = args.at(0).get<int32>();
 		int32 result = BackendService->Execute_FuncInt32(BackendService.GetObject(), ParamInt32);
 		return result;
 	}
 	if (path == "funcInt64")
 	{
-		int64 ParamInt64 = args.at(0);
+		int64 ParamInt64 = args.at(0).get<int64>();
 		int64 result = BackendService->Execute_FuncInt64(BackendService.GetObject(), ParamInt64);
 		return result;
 	}
 	if (path == "funcFloat")
 	{
-		float ParamFloat = args.at(0);
+		float ParamFloat = args.at(0).get<float>();
 		float result = BackendService->Execute_FuncFloat(BackendService.GetObject(), ParamFloat);
 		return result;
 	}
 	if (path == "funcFloat32")
 	{
-		float ParamFloat32 = args.at(0);
+		float ParamFloat32 = args.at(0).get<float>();
 		float result = BackendService->Execute_FuncFloat32(BackendService.GetObject(), ParamFloat32);
 		return result;
 	}
 	if (path == "funcFloat64")
 	{
-		double ParamFloat = args.at(0);
+		double ParamFloat = args.at(0).get<double>();
 		double result = BackendService->Execute_FuncFloat64(BackendService.GetObject(), ParamFloat);
 		return result;
 	}
 	if (path == "funcString")
 	{
-		FString ParamString = args.at(0);
+		FString ParamString = args.at(0).get<FString>();
 		FString result = BackendService->Execute_FuncString(BackendService.GetObject(), ParamString);
 		return result;
 	}

--- a/goldenmaster/Plugins/Testbed1/Source/Testbed1/Private/Generated/OLink/Testbed1StructArrayInterfaceOLinkSource.cpp
+++ b/goldenmaster/Plugins/Testbed1/Source/Testbed1/Private/Generated/OLink/Testbed1StructArrayInterfaceOLinkSource.cpp
@@ -197,25 +197,25 @@ nlohmann::json Testbed1StructArrayInterfaceOLinkSource::olinkInvoke(const std::s
 	const std::string path = Name::getMemberName(methodId);
 	if (path == "funcBool")
 	{
-		TArray<FTestbed1StructBool> ParamBool = args.at(0);
+		TArray<FTestbed1StructBool> ParamBool = args.at(0).get<TArray<FTestbed1StructBool>>();
 		FTestbed1StructBool result = BackendService->Execute_FuncBool(BackendService.GetObject(), ParamBool);
 		return result;
 	}
 	if (path == "funcInt")
 	{
-		TArray<FTestbed1StructInt> ParamInt = args.at(0);
+		TArray<FTestbed1StructInt> ParamInt = args.at(0).get<TArray<FTestbed1StructInt>>();
 		FTestbed1StructBool result = BackendService->Execute_FuncInt(BackendService.GetObject(), ParamInt);
 		return result;
 	}
 	if (path == "funcFloat")
 	{
-		TArray<FTestbed1StructFloat> ParamFloat = args.at(0);
+		TArray<FTestbed1StructFloat> ParamFloat = args.at(0).get<TArray<FTestbed1StructFloat>>();
 		FTestbed1StructBool result = BackendService->Execute_FuncFloat(BackendService.GetObject(), ParamFloat);
 		return result;
 	}
 	if (path == "funcString")
 	{
-		TArray<FTestbed1StructString> ParamString = args.at(0);
+		TArray<FTestbed1StructString> ParamString = args.at(0).get<TArray<FTestbed1StructString>>();
 		FTestbed1StructBool result = BackendService->Execute_FuncString(BackendService.GetObject(), ParamString);
 		return result;
 	}

--- a/goldenmaster/Plugins/Testbed1/Source/Testbed1/Private/Generated/OLink/Testbed1StructInterfaceOLinkSource.cpp
+++ b/goldenmaster/Plugins/Testbed1/Source/Testbed1/Private/Generated/OLink/Testbed1StructInterfaceOLinkSource.cpp
@@ -197,25 +197,25 @@ nlohmann::json Testbed1StructInterfaceOLinkSource::olinkInvoke(const std::string
 	const std::string path = Name::getMemberName(methodId);
 	if (path == "funcBool")
 	{
-		FTestbed1StructBool ParamBool = args.at(0);
+		FTestbed1StructBool ParamBool = args.at(0).get<FTestbed1StructBool>();
 		FTestbed1StructBool result = BackendService->Execute_FuncBool(BackendService.GetObject(), ParamBool);
 		return result;
 	}
 	if (path == "funcInt")
 	{
-		FTestbed1StructInt ParamInt = args.at(0);
+		FTestbed1StructInt ParamInt = args.at(0).get<FTestbed1StructInt>();
 		FTestbed1StructBool result = BackendService->Execute_FuncInt(BackendService.GetObject(), ParamInt);
 		return result;
 	}
 	if (path == "funcFloat")
 	{
-		FTestbed1StructFloat ParamFloat = args.at(0);
+		FTestbed1StructFloat ParamFloat = args.at(0).get<FTestbed1StructFloat>();
 		FTestbed1StructFloat result = BackendService->Execute_FuncFloat(BackendService.GetObject(), ParamFloat);
 		return result;
 	}
 	if (path == "funcString")
 	{
-		FTestbed1StructString ParamString = args.at(0);
+		FTestbed1StructString ParamString = args.at(0).get<FTestbed1StructString>();
 		FTestbed1StructString result = BackendService->Execute_FuncString(BackendService.GetObject(), ParamString);
 		return result;
 	}

--- a/goldenmaster/Plugins/Testbed2/Source/Testbed2/Private/Generated/OLink/Testbed2ManyParamInterfaceOLinkSource.cpp
+++ b/goldenmaster/Plugins/Testbed2/Source/Testbed2/Private/Generated/OLink/Testbed2ManyParamInterfaceOLinkSource.cpp
@@ -197,31 +197,31 @@ nlohmann::json Testbed2ManyParamInterfaceOLinkSource::olinkInvoke(const std::str
 	const std::string path = Name::getMemberName(methodId);
 	if (path == "func1")
 	{
-		int32 Param1 = args.at(0);
+		int32 Param1 = args.at(0).get<int32>();
 		int32 result = BackendService->Execute_Func1(BackendService.GetObject(), Param1);
 		return result;
 	}
 	if (path == "func2")
 	{
-		int32 Param1 = args.at(0);
-		int32 Param2 = args.at(1);
+		int32 Param1 = args.at(0).get<int32>();
+		int32 Param2 = args.at(1).get<int32>();
 		int32 result = BackendService->Execute_Func2(BackendService.GetObject(), Param1, Param2);
 		return result;
 	}
 	if (path == "func3")
 	{
-		int32 Param1 = args.at(0);
-		int32 Param2 = args.at(1);
-		int32 Param3 = args.at(2);
+		int32 Param1 = args.at(0).get<int32>();
+		int32 Param2 = args.at(1).get<int32>();
+		int32 Param3 = args.at(2).get<int32>();
 		int32 result = BackendService->Execute_Func3(BackendService.GetObject(), Param1, Param2, Param3);
 		return result;
 	}
 	if (path == "func4")
 	{
-		int32 Param1 = args.at(0);
-		int32 Param2 = args.at(1);
-		int32 Param3 = args.at(2);
-		int32 Param4 = args.at(3);
+		int32 Param1 = args.at(0).get<int32>();
+		int32 Param2 = args.at(1).get<int32>();
+		int32 Param3 = args.at(2).get<int32>();
+		int32 Param4 = args.at(3).get<int32>();
 		int32 result = BackendService->Execute_Func4(BackendService.GetObject(), Param1, Param2, Param3, Param4);
 		return result;
 	}

--- a/goldenmaster/Plugins/Testbed2/Source/Testbed2/Private/Generated/OLink/Testbed2NestedStruct1InterfaceOLinkSource.cpp
+++ b/goldenmaster/Plugins/Testbed2/Source/Testbed2/Private/Generated/OLink/Testbed2NestedStruct1InterfaceOLinkSource.cpp
@@ -110,7 +110,7 @@ nlohmann::json Testbed2NestedStruct1InterfaceOLinkSource::olinkInvoke(const std:
 	const std::string path = Name::getMemberName(methodId);
 	if (path == "func1")
 	{
-		FTestbed2NestedStruct1 Param1 = args.at(0);
+		FTestbed2NestedStruct1 Param1 = args.at(0).get<FTestbed2NestedStruct1>();
 		FTestbed2NestedStruct1 result = BackendService->Execute_Func1(BackendService.GetObject(), Param1);
 		return result;
 	}

--- a/goldenmaster/Plugins/Testbed2/Source/Testbed2/Private/Generated/OLink/Testbed2NestedStruct2InterfaceOLinkSource.cpp
+++ b/goldenmaster/Plugins/Testbed2/Source/Testbed2/Private/Generated/OLink/Testbed2NestedStruct2InterfaceOLinkSource.cpp
@@ -139,14 +139,14 @@ nlohmann::json Testbed2NestedStruct2InterfaceOLinkSource::olinkInvoke(const std:
 	const std::string path = Name::getMemberName(methodId);
 	if (path == "func1")
 	{
-		FTestbed2NestedStruct1 Param1 = args.at(0);
+		FTestbed2NestedStruct1 Param1 = args.at(0).get<FTestbed2NestedStruct1>();
 		FTestbed2NestedStruct1 result = BackendService->Execute_Func1(BackendService.GetObject(), Param1);
 		return result;
 	}
 	if (path == "func2")
 	{
-		FTestbed2NestedStruct1 Param1 = args.at(0);
-		FTestbed2NestedStruct2 Param2 = args.at(1);
+		FTestbed2NestedStruct1 Param1 = args.at(0).get<FTestbed2NestedStruct1>();
+		FTestbed2NestedStruct2 Param2 = args.at(1).get<FTestbed2NestedStruct2>();
 		FTestbed2NestedStruct1 result = BackendService->Execute_Func2(BackendService.GetObject(), Param1, Param2);
 		return result;
 	}

--- a/goldenmaster/Plugins/Testbed2/Source/Testbed2/Private/Generated/OLink/Testbed2NestedStruct3InterfaceOLinkSource.cpp
+++ b/goldenmaster/Plugins/Testbed2/Source/Testbed2/Private/Generated/OLink/Testbed2NestedStruct3InterfaceOLinkSource.cpp
@@ -168,22 +168,22 @@ nlohmann::json Testbed2NestedStruct3InterfaceOLinkSource::olinkInvoke(const std:
 	const std::string path = Name::getMemberName(methodId);
 	if (path == "func1")
 	{
-		FTestbed2NestedStruct1 Param1 = args.at(0);
+		FTestbed2NestedStruct1 Param1 = args.at(0).get<FTestbed2NestedStruct1>();
 		FTestbed2NestedStruct1 result = BackendService->Execute_Func1(BackendService.GetObject(), Param1);
 		return result;
 	}
 	if (path == "func2")
 	{
-		FTestbed2NestedStruct1 Param1 = args.at(0);
-		FTestbed2NestedStruct2 Param2 = args.at(1);
+		FTestbed2NestedStruct1 Param1 = args.at(0).get<FTestbed2NestedStruct1>();
+		FTestbed2NestedStruct2 Param2 = args.at(1).get<FTestbed2NestedStruct2>();
 		FTestbed2NestedStruct1 result = BackendService->Execute_Func2(BackendService.GetObject(), Param1, Param2);
 		return result;
 	}
 	if (path == "func3")
 	{
-		FTestbed2NestedStruct1 Param1 = args.at(0);
-		FTestbed2NestedStruct2 Param2 = args.at(1);
-		FTestbed2NestedStruct3 Param3 = args.at(2);
+		FTestbed2NestedStruct1 Param1 = args.at(0).get<FTestbed2NestedStruct1>();
+		FTestbed2NestedStruct2 Param2 = args.at(1).get<FTestbed2NestedStruct2>();
+		FTestbed2NestedStruct3 Param3 = args.at(2).get<FTestbed2NestedStruct3>();
 		FTestbed2NestedStruct1 result = BackendService->Execute_Func3(BackendService.GetObject(), Param1, Param2, Param3);
 		return result;
 	}

--- a/templates/ApiGear/apigear.uplugin
+++ b/templates/ApiGear/apigear.uplugin
@@ -1,7 +1,7 @@
 {
 	"FileVersion": 3,
 	"Version": 1,
-	"VersionName": "3.0.0",
+	"VersionName": "3.0.1",
 	"FriendlyName": "ApiGear",
 	"Description": "ApiGear ThirdParty libraries for tracing, simulation and IPC support",
 	"Category": "Other",

--- a/templates/module/Source/module/Private/Generated/OLink/olinksource.cpp.tpl
+++ b/templates/module/Source/module/Private/Generated/OLink/olinksource.cpp.tpl
@@ -115,7 +115,7 @@ nlohmann::json {{$Class}}::olinkInvoke(const std::string& methodId, const nlohma
 	if (path == "{{.Name}}")
 	{
 {{- range  $i, $e := .Params }}
-		{{ueType "" .}} {{ueVar "" .}} = args.at({{ $i }});
+		{{ueType "" .}} {{ueVar "" .}} = args.at({{ $i }}).get<{{ueReturn "" .}}>();
 {{- end }}
 {{- if .Return.IsVoid }}
 		BackendService->Execute_{{Camel .Name}}(BackendService.GetObject(){{ if len .Params }}, {{end}}{{ ueVars "" .Params }});


### PR DESCRIPTION
## 📑 Description
Instead of using implicit casting with potential ambiguity, we now try to get the expected type from json.

Tested with 4.27 and 5.2

<!-- You can also choose to add a list of changes and if they have been completed or not by using the markdown to-do list syntax
- [ ] Not Completed
- [x] Completed
-->

## ✅ Checks
<!-- Make sure your pr passes the CI checks and do check the following fields as needed - -->
- [ ] My pull request adheres to the code style of this project
- [ ] My code requires changes to the documentation
- [x] I have updated the documentation as required
- [x] All the tests have passed