### PR TITLE
Make sure BP inheritance works in UE 4.27

### DIFF
--- a/goldenmaster/Plugins/ApiGear/apigear.uplugin
+++ b/goldenmaster/Plugins/ApiGear/apigear.uplugin
@@ -1,7 +1,7 @@
 {
 	"FileVersion": 3,
 	"Version": 1,
-	"VersionName": "3.1.1",
+	"VersionName": "3.1.2",
 	"FriendlyName": "ApiGear",
 	"Description": "ApiGear ThirdParty libraries for tracing, simulation and IPC support",
 	"Category": "Other",

--- a/goldenmaster/Plugins/TbEnum/Source/TbEnum/Private/Generated/OLink/TbEnumEnumInterfaceOLinkAdapter.cpp
+++ b/goldenmaster/Plugins/TbEnum/Source/TbEnum/Private/Generated/OLink/TbEnumEnumInterfaceOLinkAdapter.cpp
@@ -72,7 +72,7 @@ void UTbEnumEnumInterfaceOLinkAdapter::setBackendService(TScriptInterface<ITbEnu
 	// subscribe to new backend
 	BackendService = InService;
 	UTbEnumEnumInterfaceSignals* BackendSignals = BackendService->Execute__GetSignals(BackendService.GetObject());
-	checkf(BackendSignals, TEXT("Cannot unsubscribe from delegates from backend service TbEnumEnumInterface"));
+	checkf(BackendSignals, TEXT("Cannot subscribe to delegates from backend service TbEnumEnumInterface"));
 	// connect property changed signals or simple events
 	BackendSignals->OnProp0Changed.AddDynamic(this, &UTbEnumEnumInterfaceOLinkAdapter::OnProp0Changed);
 	BackendSignals->OnProp1Changed.AddDynamic(this, &UTbEnumEnumInterfaceOLinkAdapter::OnProp1Changed);

--- a/goldenmaster/Plugins/TbEnum/Source/TbEnum/Private/Generated/api/AbstractTbEnumEnumInterface.cpp
+++ b/goldenmaster/Plugins/TbEnum/Source/TbEnum/Private/Generated/api/AbstractTbEnumEnumInterface.cpp
@@ -66,6 +66,15 @@ UAbstractTbEnumEnumInterface::UAbstractTbEnumEnumInterface()
 	TbEnumEnumInterfaceSignals = NewObject<UTbEnumEnumInterfaceSignals>();
 }
 
+UTbEnumEnumInterfaceSignals* UAbstractTbEnumEnumInterface::_GetSignals_Implementation()
+{
+	if (!TbEnumEnumInterfaceSignals)
+	{
+		TbEnumEnumInterfaceSignals = NewObject<UTbEnumEnumInterfaceSignals>();
+	}
+	return TbEnumEnumInterfaceSignals;
+}
+
 ETbEnumEnum0 UAbstractTbEnumEnumInterface::GetProp0_Private() const
 {
 	return Execute_GetProp0(this);

--- a/goldenmaster/Plugins/TbEnum/Source/TbEnum/Public/Generated/api/AbstractTbEnumEnumInterface.h
+++ b/goldenmaster/Plugins/TbEnum/Source/TbEnum/Public/Generated/api/AbstractTbEnumEnumInterface.h
@@ -38,10 +38,7 @@ public:
 	virtual void Deinitialize() override;
 
 	// signals
-	virtual UTbEnumEnumInterfaceSignals* _GetSignals_Implementation() override
-	{
-		return TbEnumEnumInterfaceSignals;
-	};
+	virtual UTbEnumEnumInterfaceSignals* _GetSignals_Implementation() override;
 
 	// methods
 	virtual void Func0Async_Implementation(UObject* WorldContextObject, FLatentActionInfo LatentInfo, ETbEnumEnum0& Result, ETbEnumEnum0 Param0) override;

--- a/goldenmaster/Plugins/TbSame1/Source/TbSame1/Private/Generated/OLink/TbSame1SameEnum1InterfaceOLinkAdapter.cpp
+++ b/goldenmaster/Plugins/TbSame1/Source/TbSame1/Private/Generated/OLink/TbSame1SameEnum1InterfaceOLinkAdapter.cpp
@@ -66,7 +66,7 @@ void UTbSame1SameEnum1InterfaceOLinkAdapter::setBackendService(TScriptInterface<
 	// subscribe to new backend
 	BackendService = InService;
 	UTbSame1SameEnum1InterfaceSignals* BackendSignals = BackendService->Execute__GetSignals(BackendService.GetObject());
-	checkf(BackendSignals, TEXT("Cannot unsubscribe from delegates from backend service TbSame1SameEnum1Interface"));
+	checkf(BackendSignals, TEXT("Cannot subscribe to delegates from backend service TbSame1SameEnum1Interface"));
 	// connect property changed signals or simple events
 	BackendSignals->OnProp1Changed.AddDynamic(this, &UTbSame1SameEnum1InterfaceOLinkAdapter::OnProp1Changed);
 	BackendSignals->OnSig1Signal.AddDynamic(this, &UTbSame1SameEnum1InterfaceOLinkAdapter::OnSig1);

--- a/goldenmaster/Plugins/TbSame1/Source/TbSame1/Private/Generated/OLink/TbSame1SameEnum2InterfaceOLinkAdapter.cpp
+++ b/goldenmaster/Plugins/TbSame1/Source/TbSame1/Private/Generated/OLink/TbSame1SameEnum2InterfaceOLinkAdapter.cpp
@@ -68,7 +68,7 @@ void UTbSame1SameEnum2InterfaceOLinkAdapter::setBackendService(TScriptInterface<
 	// subscribe to new backend
 	BackendService = InService;
 	UTbSame1SameEnum2InterfaceSignals* BackendSignals = BackendService->Execute__GetSignals(BackendService.GetObject());
-	checkf(BackendSignals, TEXT("Cannot unsubscribe from delegates from backend service TbSame1SameEnum2Interface"));
+	checkf(BackendSignals, TEXT("Cannot subscribe to delegates from backend service TbSame1SameEnum2Interface"));
 	// connect property changed signals or simple events
 	BackendSignals->OnProp1Changed.AddDynamic(this, &UTbSame1SameEnum2InterfaceOLinkAdapter::OnProp1Changed);
 	BackendSignals->OnProp2Changed.AddDynamic(this, &UTbSame1SameEnum2InterfaceOLinkAdapter::OnProp2Changed);

--- a/goldenmaster/Plugins/TbSame1/Source/TbSame1/Private/Generated/OLink/TbSame1SameStruct1InterfaceOLinkAdapter.cpp
+++ b/goldenmaster/Plugins/TbSame1/Source/TbSame1/Private/Generated/OLink/TbSame1SameStruct1InterfaceOLinkAdapter.cpp
@@ -66,7 +66,7 @@ void UTbSame1SameStruct1InterfaceOLinkAdapter::setBackendService(TScriptInterfac
 	// subscribe to new backend
 	BackendService = InService;
 	UTbSame1SameStruct1InterfaceSignals* BackendSignals = BackendService->Execute__GetSignals(BackendService.GetObject());
-	checkf(BackendSignals, TEXT("Cannot unsubscribe from delegates from backend service TbSame1SameStruct1Interface"));
+	checkf(BackendSignals, TEXT("Cannot subscribe to delegates from backend service TbSame1SameStruct1Interface"));
 	// connect property changed signals or simple events
 	BackendSignals->OnProp1Changed.AddDynamic(this, &UTbSame1SameStruct1InterfaceOLinkAdapter::OnProp1Changed);
 	BackendSignals->OnSig1Signal.AddDynamic(this, &UTbSame1SameStruct1InterfaceOLinkAdapter::OnSig1);

--- a/goldenmaster/Plugins/TbSame1/Source/TbSame1/Private/Generated/OLink/TbSame1SameStruct2InterfaceOLinkAdapter.cpp
+++ b/goldenmaster/Plugins/TbSame1/Source/TbSame1/Private/Generated/OLink/TbSame1SameStruct2InterfaceOLinkAdapter.cpp
@@ -68,7 +68,7 @@ void UTbSame1SameStruct2InterfaceOLinkAdapter::setBackendService(TScriptInterfac
 	// subscribe to new backend
 	BackendService = InService;
 	UTbSame1SameStruct2InterfaceSignals* BackendSignals = BackendService->Execute__GetSignals(BackendService.GetObject());
-	checkf(BackendSignals, TEXT("Cannot unsubscribe from delegates from backend service TbSame1SameStruct2Interface"));
+	checkf(BackendSignals, TEXT("Cannot subscribe to delegates from backend service TbSame1SameStruct2Interface"));
 	// connect property changed signals or simple events
 	BackendSignals->OnProp1Changed.AddDynamic(this, &UTbSame1SameStruct2InterfaceOLinkAdapter::OnProp1Changed);
 	BackendSignals->OnProp2Changed.AddDynamic(this, &UTbSame1SameStruct2InterfaceOLinkAdapter::OnProp2Changed);

--- a/goldenmaster/Plugins/TbSame1/Source/TbSame1/Private/Generated/api/AbstractTbSame1SameEnum1Interface.cpp
+++ b/goldenmaster/Plugins/TbSame1/Source/TbSame1/Private/Generated/api/AbstractTbSame1SameEnum1Interface.cpp
@@ -66,6 +66,15 @@ UAbstractTbSame1SameEnum1Interface::UAbstractTbSame1SameEnum1Interface()
 	TbSame1SameEnum1InterfaceSignals = NewObject<UTbSame1SameEnum1InterfaceSignals>();
 }
 
+UTbSame1SameEnum1InterfaceSignals* UAbstractTbSame1SameEnum1Interface::_GetSignals_Implementation()
+{
+	if (!TbSame1SameEnum1InterfaceSignals)
+	{
+		TbSame1SameEnum1InterfaceSignals = NewObject<UTbSame1SameEnum1InterfaceSignals>();
+	}
+	return TbSame1SameEnum1InterfaceSignals;
+}
+
 ETbSame1Enum1 UAbstractTbSame1SameEnum1Interface::GetProp1_Private() const
 {
 	return Execute_GetProp1(this);

--- a/goldenmaster/Plugins/TbSame1/Source/TbSame1/Private/Generated/api/AbstractTbSame1SameEnum2Interface.cpp
+++ b/goldenmaster/Plugins/TbSame1/Source/TbSame1/Private/Generated/api/AbstractTbSame1SameEnum2Interface.cpp
@@ -66,6 +66,15 @@ UAbstractTbSame1SameEnum2Interface::UAbstractTbSame1SameEnum2Interface()
 	TbSame1SameEnum2InterfaceSignals = NewObject<UTbSame1SameEnum2InterfaceSignals>();
 }
 
+UTbSame1SameEnum2InterfaceSignals* UAbstractTbSame1SameEnum2Interface::_GetSignals_Implementation()
+{
+	if (!TbSame1SameEnum2InterfaceSignals)
+	{
+		TbSame1SameEnum2InterfaceSignals = NewObject<UTbSame1SameEnum2InterfaceSignals>();
+	}
+	return TbSame1SameEnum2InterfaceSignals;
+}
+
 ETbSame1Enum1 UAbstractTbSame1SameEnum2Interface::GetProp1_Private() const
 {
 	return Execute_GetProp1(this);

--- a/goldenmaster/Plugins/TbSame1/Source/TbSame1/Private/Generated/api/AbstractTbSame1SameStruct1Interface.cpp
+++ b/goldenmaster/Plugins/TbSame1/Source/TbSame1/Private/Generated/api/AbstractTbSame1SameStruct1Interface.cpp
@@ -66,6 +66,15 @@ UAbstractTbSame1SameStruct1Interface::UAbstractTbSame1SameStruct1Interface()
 	TbSame1SameStruct1InterfaceSignals = NewObject<UTbSame1SameStruct1InterfaceSignals>();
 }
 
+UTbSame1SameStruct1InterfaceSignals* UAbstractTbSame1SameStruct1Interface::_GetSignals_Implementation()
+{
+	if (!TbSame1SameStruct1InterfaceSignals)
+	{
+		TbSame1SameStruct1InterfaceSignals = NewObject<UTbSame1SameStruct1InterfaceSignals>();
+	}
+	return TbSame1SameStruct1InterfaceSignals;
+}
+
 FTbSame1Struct1 UAbstractTbSame1SameStruct1Interface::GetProp1_Private() const
 {
 	return Execute_GetProp1(this);

--- a/goldenmaster/Plugins/TbSame1/Source/TbSame1/Private/Generated/api/AbstractTbSame1SameStruct2Interface.cpp
+++ b/goldenmaster/Plugins/TbSame1/Source/TbSame1/Private/Generated/api/AbstractTbSame1SameStruct2Interface.cpp
@@ -66,6 +66,15 @@ UAbstractTbSame1SameStruct2Interface::UAbstractTbSame1SameStruct2Interface()
 	TbSame1SameStruct2InterfaceSignals = NewObject<UTbSame1SameStruct2InterfaceSignals>();
 }
 
+UTbSame1SameStruct2InterfaceSignals* UAbstractTbSame1SameStruct2Interface::_GetSignals_Implementation()
+{
+	if (!TbSame1SameStruct2InterfaceSignals)
+	{
+		TbSame1SameStruct2InterfaceSignals = NewObject<UTbSame1SameStruct2InterfaceSignals>();
+	}
+	return TbSame1SameStruct2InterfaceSignals;
+}
+
 FTbSame1Struct2 UAbstractTbSame1SameStruct2Interface::GetProp1_Private() const
 {
 	return Execute_GetProp1(this);

--- a/goldenmaster/Plugins/TbSame1/Source/TbSame1/Public/Generated/api/AbstractTbSame1SameEnum1Interface.h
+++ b/goldenmaster/Plugins/TbSame1/Source/TbSame1/Public/Generated/api/AbstractTbSame1SameEnum1Interface.h
@@ -38,10 +38,7 @@ public:
 	virtual void Deinitialize() override;
 
 	// signals
-	virtual UTbSame1SameEnum1InterfaceSignals* _GetSignals_Implementation() override
-	{
-		return TbSame1SameEnum1InterfaceSignals;
-	};
+	virtual UTbSame1SameEnum1InterfaceSignals* _GetSignals_Implementation() override;
 
 	// methods
 	virtual void Func1Async_Implementation(UObject* WorldContextObject, FLatentActionInfo LatentInfo, ETbSame1Enum1& Result, ETbSame1Enum1 Param1) override;

--- a/goldenmaster/Plugins/TbSame1/Source/TbSame1/Public/Generated/api/AbstractTbSame1SameEnum2Interface.h
+++ b/goldenmaster/Plugins/TbSame1/Source/TbSame1/Public/Generated/api/AbstractTbSame1SameEnum2Interface.h
@@ -38,10 +38,7 @@ public:
 	virtual void Deinitialize() override;
 
 	// signals
-	virtual UTbSame1SameEnum2InterfaceSignals* _GetSignals_Implementation() override
-	{
-		return TbSame1SameEnum2InterfaceSignals;
-	};
+	virtual UTbSame1SameEnum2InterfaceSignals* _GetSignals_Implementation() override;
 
 	// methods
 	virtual void Func1Async_Implementation(UObject* WorldContextObject, FLatentActionInfo LatentInfo, ETbSame1Enum1& Result, ETbSame1Enum1 Param1) override;

--- a/goldenmaster/Plugins/TbSame1/Source/TbSame1/Public/Generated/api/AbstractTbSame1SameStruct1Interface.h
+++ b/goldenmaster/Plugins/TbSame1/Source/TbSame1/Public/Generated/api/AbstractTbSame1SameStruct1Interface.h
@@ -38,10 +38,7 @@ public:
 	virtual void Deinitialize() override;
 
 	// signals
-	virtual UTbSame1SameStruct1InterfaceSignals* _GetSignals_Implementation() override
-	{
-		return TbSame1SameStruct1InterfaceSignals;
-	};
+	virtual UTbSame1SameStruct1InterfaceSignals* _GetSignals_Implementation() override;
 
 	// methods
 	virtual void Func1Async_Implementation(UObject* WorldContextObject, FLatentActionInfo LatentInfo, FTbSame1Struct1& Result, const FTbSame1Struct1& Param1) override;

--- a/goldenmaster/Plugins/TbSame1/Source/TbSame1/Public/Generated/api/AbstractTbSame1SameStruct2Interface.h
+++ b/goldenmaster/Plugins/TbSame1/Source/TbSame1/Public/Generated/api/AbstractTbSame1SameStruct2Interface.h
@@ -38,10 +38,7 @@ public:
 	virtual void Deinitialize() override;
 
 	// signals
-	virtual UTbSame1SameStruct2InterfaceSignals* _GetSignals_Implementation() override
-	{
-		return TbSame1SameStruct2InterfaceSignals;
-	};
+	virtual UTbSame1SameStruct2InterfaceSignals* _GetSignals_Implementation() override;
 
 	// methods
 	virtual void Func1Async_Implementation(UObject* WorldContextObject, FLatentActionInfo LatentInfo, FTbSame1Struct1& Result, const FTbSame1Struct1& Param1) override;

--- a/goldenmaster/Plugins/TbSame2/Source/TbSame2/Private/Generated/OLink/TbSame2SameEnum1InterfaceOLinkAdapter.cpp
+++ b/goldenmaster/Plugins/TbSame2/Source/TbSame2/Private/Generated/OLink/TbSame2SameEnum1InterfaceOLinkAdapter.cpp
@@ -66,7 +66,7 @@ void UTbSame2SameEnum1InterfaceOLinkAdapter::setBackendService(TScriptInterface<
 	// subscribe to new backend
 	BackendService = InService;
 	UTbSame2SameEnum1InterfaceSignals* BackendSignals = BackendService->Execute__GetSignals(BackendService.GetObject());
-	checkf(BackendSignals, TEXT("Cannot unsubscribe from delegates from backend service TbSame2SameEnum1Interface"));
+	checkf(BackendSignals, TEXT("Cannot subscribe to delegates from backend service TbSame2SameEnum1Interface"));
 	// connect property changed signals or simple events
 	BackendSignals->OnProp1Changed.AddDynamic(this, &UTbSame2SameEnum1InterfaceOLinkAdapter::OnProp1Changed);
 	BackendSignals->OnSig1Signal.AddDynamic(this, &UTbSame2SameEnum1InterfaceOLinkAdapter::OnSig1);

--- a/goldenmaster/Plugins/TbSame2/Source/TbSame2/Private/Generated/OLink/TbSame2SameEnum2InterfaceOLinkAdapter.cpp
+++ b/goldenmaster/Plugins/TbSame2/Source/TbSame2/Private/Generated/OLink/TbSame2SameEnum2InterfaceOLinkAdapter.cpp
@@ -68,7 +68,7 @@ void UTbSame2SameEnum2InterfaceOLinkAdapter::setBackendService(TScriptInterface<
 	// subscribe to new backend
 	BackendService = InService;
 	UTbSame2SameEnum2InterfaceSignals* BackendSignals = BackendService->Execute__GetSignals(BackendService.GetObject());
-	checkf(BackendSignals, TEXT("Cannot unsubscribe from delegates from backend service TbSame2SameEnum2Interface"));
+	checkf(BackendSignals, TEXT("Cannot subscribe to delegates from backend service TbSame2SameEnum2Interface"));
 	// connect property changed signals or simple events
 	BackendSignals->OnProp1Changed.AddDynamic(this, &UTbSame2SameEnum2InterfaceOLinkAdapter::OnProp1Changed);
 	BackendSignals->OnProp2Changed.AddDynamic(this, &UTbSame2SameEnum2InterfaceOLinkAdapter::OnProp2Changed);

--- a/goldenmaster/Plugins/TbSame2/Source/TbSame2/Private/Generated/OLink/TbSame2SameStruct1InterfaceOLinkAdapter.cpp
+++ b/goldenmaster/Plugins/TbSame2/Source/TbSame2/Private/Generated/OLink/TbSame2SameStruct1InterfaceOLinkAdapter.cpp
@@ -66,7 +66,7 @@ void UTbSame2SameStruct1InterfaceOLinkAdapter::setBackendService(TScriptInterfac
 	// subscribe to new backend
 	BackendService = InService;
 	UTbSame2SameStruct1InterfaceSignals* BackendSignals = BackendService->Execute__GetSignals(BackendService.GetObject());
-	checkf(BackendSignals, TEXT("Cannot unsubscribe from delegates from backend service TbSame2SameStruct1Interface"));
+	checkf(BackendSignals, TEXT("Cannot subscribe to delegates from backend service TbSame2SameStruct1Interface"));
 	// connect property changed signals or simple events
 	BackendSignals->OnProp1Changed.AddDynamic(this, &UTbSame2SameStruct1InterfaceOLinkAdapter::OnProp1Changed);
 	BackendSignals->OnSig1Signal.AddDynamic(this, &UTbSame2SameStruct1InterfaceOLinkAdapter::OnSig1);

--- a/goldenmaster/Plugins/TbSame2/Source/TbSame2/Private/Generated/OLink/TbSame2SameStruct2InterfaceOLinkAdapter.cpp
+++ b/goldenmaster/Plugins/TbSame2/Source/TbSame2/Private/Generated/OLink/TbSame2SameStruct2InterfaceOLinkAdapter.cpp
@@ -68,7 +68,7 @@ void UTbSame2SameStruct2InterfaceOLinkAdapter::setBackendService(TScriptInterfac
 	// subscribe to new backend
 	BackendService = InService;
 	UTbSame2SameStruct2InterfaceSignals* BackendSignals = BackendService->Execute__GetSignals(BackendService.GetObject());
-	checkf(BackendSignals, TEXT("Cannot unsubscribe from delegates from backend service TbSame2SameStruct2Interface"));
+	checkf(BackendSignals, TEXT("Cannot subscribe to delegates from backend service TbSame2SameStruct2Interface"));
 	// connect property changed signals or simple events
 	BackendSignals->OnProp1Changed.AddDynamic(this, &UTbSame2SameStruct2InterfaceOLinkAdapter::OnProp1Changed);
 	BackendSignals->OnProp2Changed.AddDynamic(this, &UTbSame2SameStruct2InterfaceOLinkAdapter::OnProp2Changed);

--- a/goldenmaster/Plugins/TbSame2/Source/TbSame2/Private/Generated/api/AbstractTbSame2SameEnum1Interface.cpp
+++ b/goldenmaster/Plugins/TbSame2/Source/TbSame2/Private/Generated/api/AbstractTbSame2SameEnum1Interface.cpp
@@ -66,6 +66,15 @@ UAbstractTbSame2SameEnum1Interface::UAbstractTbSame2SameEnum1Interface()
 	TbSame2SameEnum1InterfaceSignals = NewObject<UTbSame2SameEnum1InterfaceSignals>();
 }
 
+UTbSame2SameEnum1InterfaceSignals* UAbstractTbSame2SameEnum1Interface::_GetSignals_Implementation()
+{
+	if (!TbSame2SameEnum1InterfaceSignals)
+	{
+		TbSame2SameEnum1InterfaceSignals = NewObject<UTbSame2SameEnum1InterfaceSignals>();
+	}
+	return TbSame2SameEnum1InterfaceSignals;
+}
+
 ETbSame2Enum1 UAbstractTbSame2SameEnum1Interface::GetProp1_Private() const
 {
 	return Execute_GetProp1(this);

--- a/goldenmaster/Plugins/TbSame2/Source/TbSame2/Private/Generated/api/AbstractTbSame2SameEnum2Interface.cpp
+++ b/goldenmaster/Plugins/TbSame2/Source/TbSame2/Private/Generated/api/AbstractTbSame2SameEnum2Interface.cpp
@@ -66,6 +66,15 @@ UAbstractTbSame2SameEnum2Interface::UAbstractTbSame2SameEnum2Interface()
 	TbSame2SameEnum2InterfaceSignals = NewObject<UTbSame2SameEnum2InterfaceSignals>();
 }
 
+UTbSame2SameEnum2InterfaceSignals* UAbstractTbSame2SameEnum2Interface::_GetSignals_Implementation()
+{
+	if (!TbSame2SameEnum2InterfaceSignals)
+	{
+		TbSame2SameEnum2InterfaceSignals = NewObject<UTbSame2SameEnum2InterfaceSignals>();
+	}
+	return TbSame2SameEnum2InterfaceSignals;
+}
+
 ETbSame2Enum1 UAbstractTbSame2SameEnum2Interface::GetProp1_Private() const
 {
 	return Execute_GetProp1(this);

--- a/goldenmaster/Plugins/TbSame2/Source/TbSame2/Private/Generated/api/AbstractTbSame2SameStruct1Interface.cpp
+++ b/goldenmaster/Plugins/TbSame2/Source/TbSame2/Private/Generated/api/AbstractTbSame2SameStruct1Interface.cpp
@@ -66,6 +66,15 @@ UAbstractTbSame2SameStruct1Interface::UAbstractTbSame2SameStruct1Interface()
 	TbSame2SameStruct1InterfaceSignals = NewObject<UTbSame2SameStruct1InterfaceSignals>();
 }
 
+UTbSame2SameStruct1InterfaceSignals* UAbstractTbSame2SameStruct1Interface::_GetSignals_Implementation()
+{
+	if (!TbSame2SameStruct1InterfaceSignals)
+	{
+		TbSame2SameStruct1InterfaceSignals = NewObject<UTbSame2SameStruct1InterfaceSignals>();
+	}
+	return TbSame2SameStruct1InterfaceSignals;
+}
+
 FTbSame2Struct1 UAbstractTbSame2SameStruct1Interface::GetProp1_Private() const
 {
 	return Execute_GetProp1(this);

--- a/goldenmaster/Plugins/TbSame2/Source/TbSame2/Private/Generated/api/AbstractTbSame2SameStruct2Interface.cpp
+++ b/goldenmaster/Plugins/TbSame2/Source/TbSame2/Private/Generated/api/AbstractTbSame2SameStruct2Interface.cpp
@@ -66,6 +66,15 @@ UAbstractTbSame2SameStruct2Interface::UAbstractTbSame2SameStruct2Interface()
 	TbSame2SameStruct2InterfaceSignals = NewObject<UTbSame2SameStruct2InterfaceSignals>();
 }
 
+UTbSame2SameStruct2InterfaceSignals* UAbstractTbSame2SameStruct2Interface::_GetSignals_Implementation()
+{
+	if (!TbSame2SameStruct2InterfaceSignals)
+	{
+		TbSame2SameStruct2InterfaceSignals = NewObject<UTbSame2SameStruct2InterfaceSignals>();
+	}
+	return TbSame2SameStruct2InterfaceSignals;
+}
+
 FTbSame2Struct2 UAbstractTbSame2SameStruct2Interface::GetProp1_Private() const
 {
 	return Execute_GetProp1(this);

--- a/goldenmaster/Plugins/TbSame2/Source/TbSame2/Public/Generated/api/AbstractTbSame2SameEnum1Interface.h
+++ b/goldenmaster/Plugins/TbSame2/Source/TbSame2/Public/Generated/api/AbstractTbSame2SameEnum1Interface.h
@@ -38,10 +38,7 @@ public:
 	virtual void Deinitialize() override;
 
 	// signals
-	virtual UTbSame2SameEnum1InterfaceSignals* _GetSignals_Implementation() override
-	{
-		return TbSame2SameEnum1InterfaceSignals;
-	};
+	virtual UTbSame2SameEnum1InterfaceSignals* _GetSignals_Implementation() override;
 
 	// methods
 	virtual void Func1Async_Implementation(UObject* WorldContextObject, FLatentActionInfo LatentInfo, ETbSame2Enum1& Result, ETbSame2Enum1 Param1) override;

--- a/goldenmaster/Plugins/TbSame2/Source/TbSame2/Public/Generated/api/AbstractTbSame2SameEnum2Interface.h
+++ b/goldenmaster/Plugins/TbSame2/Source/TbSame2/Public/Generated/api/AbstractTbSame2SameEnum2Interface.h
@@ -38,10 +38,7 @@ public:
 	virtual void Deinitialize() override;
 
 	// signals
-	virtual UTbSame2SameEnum2InterfaceSignals* _GetSignals_Implementation() override
-	{
-		return TbSame2SameEnum2InterfaceSignals;
-	};
+	virtual UTbSame2SameEnum2InterfaceSignals* _GetSignals_Implementation() override;
 
 	// methods
 	virtual void Func1Async_Implementation(UObject* WorldContextObject, FLatentActionInfo LatentInfo, ETbSame2Enum1& Result, ETbSame2Enum1 Param1) override;

--- a/goldenmaster/Plugins/TbSame2/Source/TbSame2/Public/Generated/api/AbstractTbSame2SameStruct1Interface.h
+++ b/goldenmaster/Plugins/TbSame2/Source/TbSame2/Public/Generated/api/AbstractTbSame2SameStruct1Interface.h
@@ -38,10 +38,7 @@ public:
 	virtual void Deinitialize() override;
 
 	// signals
-	virtual UTbSame2SameStruct1InterfaceSignals* _GetSignals_Implementation() override
-	{
-		return TbSame2SameStruct1InterfaceSignals;
-	};
+	virtual UTbSame2SameStruct1InterfaceSignals* _GetSignals_Implementation() override;
 
 	// methods
 	virtual void Func1Async_Implementation(UObject* WorldContextObject, FLatentActionInfo LatentInfo, FTbSame2Struct1& Result, const FTbSame2Struct1& Param1) override;

--- a/goldenmaster/Plugins/TbSame2/Source/TbSame2/Public/Generated/api/AbstractTbSame2SameStruct2Interface.h
+++ b/goldenmaster/Plugins/TbSame2/Source/TbSame2/Public/Generated/api/AbstractTbSame2SameStruct2Interface.h
@@ -38,10 +38,7 @@ public:
 	virtual void Deinitialize() override;
 
 	// signals
-	virtual UTbSame2SameStruct2InterfaceSignals* _GetSignals_Implementation() override
-	{
-		return TbSame2SameStruct2InterfaceSignals;
-	};
+	virtual UTbSame2SameStruct2InterfaceSignals* _GetSignals_Implementation() override;
 
 	// methods
 	virtual void Func1Async_Implementation(UObject* WorldContextObject, FLatentActionInfo LatentInfo, FTbSame2Struct1& Result, const FTbSame2Struct1& Param1) override;

--- a/goldenmaster/Plugins/TbSimple/Source/TbSimple/Private/Generated/OLink/TbSimpleNoOperationsInterfaceOLinkAdapter.cpp
+++ b/goldenmaster/Plugins/TbSimple/Source/TbSimple/Private/Generated/OLink/TbSimpleNoOperationsInterfaceOLinkAdapter.cpp
@@ -68,7 +68,7 @@ void UTbSimpleNoOperationsInterfaceOLinkAdapter::setBackendService(TScriptInterf
 	// subscribe to new backend
 	BackendService = InService;
 	UTbSimpleNoOperationsInterfaceSignals* BackendSignals = BackendService->Execute__GetSignals(BackendService.GetObject());
-	checkf(BackendSignals, TEXT("Cannot unsubscribe from delegates from backend service TbSimpleNoOperationsInterface"));
+	checkf(BackendSignals, TEXT("Cannot subscribe to delegates from backend service TbSimpleNoOperationsInterface"));
 	// connect property changed signals or simple events
 	BackendSignals->OnPropBoolChanged.AddDynamic(this, &UTbSimpleNoOperationsInterfaceOLinkAdapter::OnPropBoolChanged);
 	BackendSignals->OnPropIntChanged.AddDynamic(this, &UTbSimpleNoOperationsInterfaceOLinkAdapter::OnPropIntChanged);

--- a/goldenmaster/Plugins/TbSimple/Source/TbSimple/Private/Generated/OLink/TbSimpleNoPropertiesInterfaceOLinkAdapter.cpp
+++ b/goldenmaster/Plugins/TbSimple/Source/TbSimple/Private/Generated/OLink/TbSimpleNoPropertiesInterfaceOLinkAdapter.cpp
@@ -66,7 +66,7 @@ void UTbSimpleNoPropertiesInterfaceOLinkAdapter::setBackendService(TScriptInterf
 	// subscribe to new backend
 	BackendService = InService;
 	UTbSimpleNoPropertiesInterfaceSignals* BackendSignals = BackendService->Execute__GetSignals(BackendService.GetObject());
-	checkf(BackendSignals, TEXT("Cannot unsubscribe from delegates from backend service TbSimpleNoPropertiesInterface"));
+	checkf(BackendSignals, TEXT("Cannot subscribe to delegates from backend service TbSimpleNoPropertiesInterface"));
 	// connect property changed signals or simple events
 	BackendSignals->OnSigVoidSignal.AddDynamic(this, &UTbSimpleNoPropertiesInterfaceOLinkAdapter::OnSigVoid);
 	BackendSignals->OnSigBoolSignal.AddDynamic(this, &UTbSimpleNoPropertiesInterfaceOLinkAdapter::OnSigBool);

--- a/goldenmaster/Plugins/TbSimple/Source/TbSimple/Private/Generated/OLink/TbSimpleNoSignalsInterfaceOLinkAdapter.cpp
+++ b/goldenmaster/Plugins/TbSimple/Source/TbSimple/Private/Generated/OLink/TbSimpleNoSignalsInterfaceOLinkAdapter.cpp
@@ -66,7 +66,7 @@ void UTbSimpleNoSignalsInterfaceOLinkAdapter::setBackendService(TScriptInterface
 	// subscribe to new backend
 	BackendService = InService;
 	UTbSimpleNoSignalsInterfaceSignals* BackendSignals = BackendService->Execute__GetSignals(BackendService.GetObject());
-	checkf(BackendSignals, TEXT("Cannot unsubscribe from delegates from backend service TbSimpleNoSignalsInterface"));
+	checkf(BackendSignals, TEXT("Cannot subscribe to delegates from backend service TbSimpleNoSignalsInterface"));
 	// connect property changed signals or simple events
 	BackendSignals->OnPropBoolChanged.AddDynamic(this, &UTbSimpleNoSignalsInterfaceOLinkAdapter::OnPropBoolChanged);
 	BackendSignals->OnPropIntChanged.AddDynamic(this, &UTbSimpleNoSignalsInterfaceOLinkAdapter::OnPropIntChanged);

--- a/goldenmaster/Plugins/TbSimple/Source/TbSimple/Private/Generated/OLink/TbSimpleSimpleArrayInterfaceOLinkAdapter.cpp
+++ b/goldenmaster/Plugins/TbSimple/Source/TbSimple/Private/Generated/OLink/TbSimpleSimpleArrayInterfaceOLinkAdapter.cpp
@@ -80,7 +80,7 @@ void UTbSimpleSimpleArrayInterfaceOLinkAdapter::setBackendService(TScriptInterfa
 	// subscribe to new backend
 	BackendService = InService;
 	UTbSimpleSimpleArrayInterfaceSignals* BackendSignals = BackendService->Execute__GetSignals(BackendService.GetObject());
-	checkf(BackendSignals, TEXT("Cannot unsubscribe from delegates from backend service TbSimpleSimpleArrayInterface"));
+	checkf(BackendSignals, TEXT("Cannot subscribe to delegates from backend service TbSimpleSimpleArrayInterface"));
 	// connect property changed signals or simple events
 	BackendSignals->OnPropBoolChanged.AddDynamic(this, &UTbSimpleSimpleArrayInterfaceOLinkAdapter::OnPropBoolChanged);
 	BackendSignals->OnPropIntChanged.AddDynamic(this, &UTbSimpleSimpleArrayInterfaceOLinkAdapter::OnPropIntChanged);

--- a/goldenmaster/Plugins/TbSimple/Source/TbSimple/Private/Generated/OLink/TbSimpleSimpleInterfaceOLinkAdapter.cpp
+++ b/goldenmaster/Plugins/TbSimple/Source/TbSimple/Private/Generated/OLink/TbSimpleSimpleInterfaceOLinkAdapter.cpp
@@ -82,7 +82,7 @@ void UTbSimpleSimpleInterfaceOLinkAdapter::setBackendService(TScriptInterface<IT
 	// subscribe to new backend
 	BackendService = InService;
 	UTbSimpleSimpleInterfaceSignals* BackendSignals = BackendService->Execute__GetSignals(BackendService.GetObject());
-	checkf(BackendSignals, TEXT("Cannot unsubscribe from delegates from backend service TbSimpleSimpleInterface"));
+	checkf(BackendSignals, TEXT("Cannot subscribe to delegates from backend service TbSimpleSimpleInterface"));
 	// connect property changed signals or simple events
 	BackendSignals->OnPropBoolChanged.AddDynamic(this, &UTbSimpleSimpleInterfaceOLinkAdapter::OnPropBoolChanged);
 	BackendSignals->OnPropIntChanged.AddDynamic(this, &UTbSimpleSimpleInterfaceOLinkAdapter::OnPropIntChanged);

--- a/goldenmaster/Plugins/TbSimple/Source/TbSimple/Private/Generated/api/AbstractTbSimpleNoOperationsInterface.cpp
+++ b/goldenmaster/Plugins/TbSimple/Source/TbSimple/Private/Generated/api/AbstractTbSimpleNoOperationsInterface.cpp
@@ -25,6 +25,15 @@ UAbstractTbSimpleNoOperationsInterface::UAbstractTbSimpleNoOperationsInterface()
 	TbSimpleNoOperationsInterfaceSignals = NewObject<UTbSimpleNoOperationsInterfaceSignals>();
 }
 
+UTbSimpleNoOperationsInterfaceSignals* UAbstractTbSimpleNoOperationsInterface::_GetSignals_Implementation()
+{
+	if (!TbSimpleNoOperationsInterfaceSignals)
+	{
+		TbSimpleNoOperationsInterfaceSignals = NewObject<UTbSimpleNoOperationsInterfaceSignals>();
+	}
+	return TbSimpleNoOperationsInterfaceSignals;
+}
+
 bool UAbstractTbSimpleNoOperationsInterface::GetPropBool_Private() const
 {
 	return Execute_GetPropBool(this);

--- a/goldenmaster/Plugins/TbSimple/Source/TbSimple/Private/Generated/api/AbstractTbSimpleNoPropertiesInterface.cpp
+++ b/goldenmaster/Plugins/TbSimple/Source/TbSimple/Private/Generated/api/AbstractTbSimpleNoPropertiesInterface.cpp
@@ -66,6 +66,15 @@ UAbstractTbSimpleNoPropertiesInterface::UAbstractTbSimpleNoPropertiesInterface()
 	TbSimpleNoPropertiesInterfaceSignals = NewObject<UTbSimpleNoPropertiesInterfaceSignals>();
 }
 
+UTbSimpleNoPropertiesInterfaceSignals* UAbstractTbSimpleNoPropertiesInterface::_GetSignals_Implementation()
+{
+	if (!TbSimpleNoPropertiesInterfaceSignals)
+	{
+		TbSimpleNoPropertiesInterfaceSignals = NewObject<UTbSimpleNoPropertiesInterfaceSignals>();
+	}
+	return TbSimpleNoPropertiesInterfaceSignals;
+}
+
 void UAbstractTbSimpleNoPropertiesInterface::FuncBoolAsync_Implementation(UObject* WorldContextObject, FLatentActionInfo LatentInfo, bool& Result, bool bParamBool)
 {
 	if (UWorld* World = GEngine->GetWorldFromContextObjectChecked(WorldContextObject))

--- a/goldenmaster/Plugins/TbSimple/Source/TbSimple/Private/Generated/api/AbstractTbSimpleNoSignalsInterface.cpp
+++ b/goldenmaster/Plugins/TbSimple/Source/TbSimple/Private/Generated/api/AbstractTbSimpleNoSignalsInterface.cpp
@@ -66,6 +66,15 @@ UAbstractTbSimpleNoSignalsInterface::UAbstractTbSimpleNoSignalsInterface()
 	TbSimpleNoSignalsInterfaceSignals = NewObject<UTbSimpleNoSignalsInterfaceSignals>();
 }
 
+UTbSimpleNoSignalsInterfaceSignals* UAbstractTbSimpleNoSignalsInterface::_GetSignals_Implementation()
+{
+	if (!TbSimpleNoSignalsInterfaceSignals)
+	{
+		TbSimpleNoSignalsInterfaceSignals = NewObject<UTbSimpleNoSignalsInterfaceSignals>();
+	}
+	return TbSimpleNoSignalsInterfaceSignals;
+}
+
 bool UAbstractTbSimpleNoSignalsInterface::GetPropBool_Private() const
 {
 	return Execute_GetPropBool(this);

--- a/goldenmaster/Plugins/TbSimple/Source/TbSimple/Private/Generated/api/AbstractTbSimpleSimpleArrayInterface.cpp
+++ b/goldenmaster/Plugins/TbSimple/Source/TbSimple/Private/Generated/api/AbstractTbSimpleSimpleArrayInterface.cpp
@@ -66,6 +66,15 @@ UAbstractTbSimpleSimpleArrayInterface::UAbstractTbSimpleSimpleArrayInterface()
 	TbSimpleSimpleArrayInterfaceSignals = NewObject<UTbSimpleSimpleArrayInterfaceSignals>();
 }
 
+UTbSimpleSimpleArrayInterfaceSignals* UAbstractTbSimpleSimpleArrayInterface::_GetSignals_Implementation()
+{
+	if (!TbSimpleSimpleArrayInterfaceSignals)
+	{
+		TbSimpleSimpleArrayInterfaceSignals = NewObject<UTbSimpleSimpleArrayInterfaceSignals>();
+	}
+	return TbSimpleSimpleArrayInterfaceSignals;
+}
+
 TArray<bool> UAbstractTbSimpleSimpleArrayInterface::GetPropBool_Private() const
 {
 	return Execute_GetPropBool(this);

--- a/goldenmaster/Plugins/TbSimple/Source/TbSimple/Private/Generated/api/AbstractTbSimpleSimpleInterface.cpp
+++ b/goldenmaster/Plugins/TbSimple/Source/TbSimple/Private/Generated/api/AbstractTbSimpleSimpleInterface.cpp
@@ -66,6 +66,15 @@ UAbstractTbSimpleSimpleInterface::UAbstractTbSimpleSimpleInterface()
 	TbSimpleSimpleInterfaceSignals = NewObject<UTbSimpleSimpleInterfaceSignals>();
 }
 
+UTbSimpleSimpleInterfaceSignals* UAbstractTbSimpleSimpleInterface::_GetSignals_Implementation()
+{
+	if (!TbSimpleSimpleInterfaceSignals)
+	{
+		TbSimpleSimpleInterfaceSignals = NewObject<UTbSimpleSimpleInterfaceSignals>();
+	}
+	return TbSimpleSimpleInterfaceSignals;
+}
+
 bool UAbstractTbSimpleSimpleInterface::GetPropBool_Private() const
 {
 	return Execute_GetPropBool(this);

--- a/goldenmaster/Plugins/TbSimple/Source/TbSimple/Public/Generated/api/AbstractTbSimpleNoOperationsInterface.h
+++ b/goldenmaster/Plugins/TbSimple/Source/TbSimple/Public/Generated/api/AbstractTbSimpleNoOperationsInterface.h
@@ -38,10 +38,7 @@ public:
 	virtual void Deinitialize() override;
 
 	// signals
-	virtual UTbSimpleNoOperationsInterfaceSignals* _GetSignals_Implementation() override
-	{
-		return TbSimpleNoOperationsInterfaceSignals;
-	};
+	virtual UTbSimpleNoOperationsInterfaceSignals* _GetSignals_Implementation() override;
 
 	// methods
 

--- a/goldenmaster/Plugins/TbSimple/Source/TbSimple/Public/Generated/api/AbstractTbSimpleNoPropertiesInterface.h
+++ b/goldenmaster/Plugins/TbSimple/Source/TbSimple/Public/Generated/api/AbstractTbSimpleNoPropertiesInterface.h
@@ -38,10 +38,7 @@ public:
 	virtual void Deinitialize() override;
 
 	// signals
-	virtual UTbSimpleNoPropertiesInterfaceSignals* _GetSignals_Implementation() override
-	{
-		return TbSimpleNoPropertiesInterfaceSignals;
-	};
+	virtual UTbSimpleNoPropertiesInterfaceSignals* _GetSignals_Implementation() override;
 
 	// methods
 	virtual void FuncVoid_Implementation() override PURE_VIRTUAL(UAbstractTbSimpleNoPropertiesInterface::FuncVoid_Implementation, return;);

--- a/goldenmaster/Plugins/TbSimple/Source/TbSimple/Public/Generated/api/AbstractTbSimpleNoSignalsInterface.h
+++ b/goldenmaster/Plugins/TbSimple/Source/TbSimple/Public/Generated/api/AbstractTbSimpleNoSignalsInterface.h
@@ -38,10 +38,7 @@ public:
 	virtual void Deinitialize() override;
 
 	// signals
-	virtual UTbSimpleNoSignalsInterfaceSignals* _GetSignals_Implementation() override
-	{
-		return TbSimpleNoSignalsInterfaceSignals;
-	};
+	virtual UTbSimpleNoSignalsInterfaceSignals* _GetSignals_Implementation() override;
 
 	// methods
 	virtual void FuncVoid_Implementation() override PURE_VIRTUAL(UAbstractTbSimpleNoSignalsInterface::FuncVoid_Implementation, return;);

--- a/goldenmaster/Plugins/TbSimple/Source/TbSimple/Public/Generated/api/AbstractTbSimpleSimpleArrayInterface.h
+++ b/goldenmaster/Plugins/TbSimple/Source/TbSimple/Public/Generated/api/AbstractTbSimpleSimpleArrayInterface.h
@@ -38,10 +38,7 @@ public:
 	virtual void Deinitialize() override;
 
 	// signals
-	virtual UTbSimpleSimpleArrayInterfaceSignals* _GetSignals_Implementation() override
-	{
-		return TbSimpleSimpleArrayInterfaceSignals;
-	};
+	virtual UTbSimpleSimpleArrayInterfaceSignals* _GetSignals_Implementation() override;
 
 	// methods
 	virtual void FuncBoolAsync_Implementation(UObject* WorldContextObject, FLatentActionInfo LatentInfo, TArray<bool>& Result, const TArray<bool>& ParamBool) override;

--- a/goldenmaster/Plugins/TbSimple/Source/TbSimple/Public/Generated/api/AbstractTbSimpleSimpleInterface.h
+++ b/goldenmaster/Plugins/TbSimple/Source/TbSimple/Public/Generated/api/AbstractTbSimpleSimpleInterface.h
@@ -38,10 +38,7 @@ public:
 	virtual void Deinitialize() override;
 
 	// signals
-	virtual UTbSimpleSimpleInterfaceSignals* _GetSignals_Implementation() override
-	{
-		return TbSimpleSimpleInterfaceSignals;
-	};
+	virtual UTbSimpleSimpleInterfaceSignals* _GetSignals_Implementation() override;
 
 	// methods
 	virtual void FuncVoid_Implementation() override PURE_VIRTUAL(UAbstractTbSimpleSimpleInterface::FuncVoid_Implementation, return;);

--- a/goldenmaster/Plugins/Testbed1/Source/Testbed1/Private/Generated/OLink/Testbed1StructArrayInterfaceOLinkAdapter.cpp
+++ b/goldenmaster/Plugins/Testbed1/Source/Testbed1/Private/Generated/OLink/Testbed1StructArrayInterfaceOLinkAdapter.cpp
@@ -72,7 +72,7 @@ void UTestbed1StructArrayInterfaceOLinkAdapter::setBackendService(TScriptInterfa
 	// subscribe to new backend
 	BackendService = InService;
 	UTestbed1StructArrayInterfaceSignals* BackendSignals = BackendService->Execute__GetSignals(BackendService.GetObject());
-	checkf(BackendSignals, TEXT("Cannot unsubscribe from delegates from backend service Testbed1StructArrayInterface"));
+	checkf(BackendSignals, TEXT("Cannot subscribe to delegates from backend service Testbed1StructArrayInterface"));
 	// connect property changed signals or simple events
 	BackendSignals->OnPropBoolChanged.AddDynamic(this, &UTestbed1StructArrayInterfaceOLinkAdapter::OnPropBoolChanged);
 	BackendSignals->OnPropIntChanged.AddDynamic(this, &UTestbed1StructArrayInterfaceOLinkAdapter::OnPropIntChanged);

--- a/goldenmaster/Plugins/Testbed1/Source/Testbed1/Private/Generated/OLink/Testbed1StructInterfaceOLinkAdapter.cpp
+++ b/goldenmaster/Plugins/Testbed1/Source/Testbed1/Private/Generated/OLink/Testbed1StructInterfaceOLinkAdapter.cpp
@@ -72,7 +72,7 @@ void UTestbed1StructInterfaceOLinkAdapter::setBackendService(TScriptInterface<IT
 	// subscribe to new backend
 	BackendService = InService;
 	UTestbed1StructInterfaceSignals* BackendSignals = BackendService->Execute__GetSignals(BackendService.GetObject());
-	checkf(BackendSignals, TEXT("Cannot unsubscribe from delegates from backend service Testbed1StructInterface"));
+	checkf(BackendSignals, TEXT("Cannot subscribe to delegates from backend service Testbed1StructInterface"));
 	// connect property changed signals or simple events
 	BackendSignals->OnPropBoolChanged.AddDynamic(this, &UTestbed1StructInterfaceOLinkAdapter::OnPropBoolChanged);
 	BackendSignals->OnPropIntChanged.AddDynamic(this, &UTestbed1StructInterfaceOLinkAdapter::OnPropIntChanged);

--- a/goldenmaster/Plugins/Testbed1/Source/Testbed1/Private/Generated/api/AbstractTestbed1StructArrayInterface.cpp
+++ b/goldenmaster/Plugins/Testbed1/Source/Testbed1/Private/Generated/api/AbstractTestbed1StructArrayInterface.cpp
@@ -66,6 +66,15 @@ UAbstractTestbed1StructArrayInterface::UAbstractTestbed1StructArrayInterface()
 	Testbed1StructArrayInterfaceSignals = NewObject<UTestbed1StructArrayInterfaceSignals>();
 }
 
+UTestbed1StructArrayInterfaceSignals* UAbstractTestbed1StructArrayInterface::_GetSignals_Implementation()
+{
+	if (!Testbed1StructArrayInterfaceSignals)
+	{
+		Testbed1StructArrayInterfaceSignals = NewObject<UTestbed1StructArrayInterfaceSignals>();
+	}
+	return Testbed1StructArrayInterfaceSignals;
+}
+
 TArray<FTestbed1StructBool> UAbstractTestbed1StructArrayInterface::GetPropBool_Private() const
 {
 	return Execute_GetPropBool(this);

--- a/goldenmaster/Plugins/Testbed1/Source/Testbed1/Private/Generated/api/AbstractTestbed1StructInterface.cpp
+++ b/goldenmaster/Plugins/Testbed1/Source/Testbed1/Private/Generated/api/AbstractTestbed1StructInterface.cpp
@@ -66,6 +66,15 @@ UAbstractTestbed1StructInterface::UAbstractTestbed1StructInterface()
 	Testbed1StructInterfaceSignals = NewObject<UTestbed1StructInterfaceSignals>();
 }
 
+UTestbed1StructInterfaceSignals* UAbstractTestbed1StructInterface::_GetSignals_Implementation()
+{
+	if (!Testbed1StructInterfaceSignals)
+	{
+		Testbed1StructInterfaceSignals = NewObject<UTestbed1StructInterfaceSignals>();
+	}
+	return Testbed1StructInterfaceSignals;
+}
+
 FTestbed1StructBool UAbstractTestbed1StructInterface::GetPropBool_Private() const
 {
 	return Execute_GetPropBool(this);

--- a/goldenmaster/Plugins/Testbed1/Source/Testbed1/Public/Generated/api/AbstractTestbed1StructArrayInterface.h
+++ b/goldenmaster/Plugins/Testbed1/Source/Testbed1/Public/Generated/api/AbstractTestbed1StructArrayInterface.h
@@ -38,10 +38,7 @@ public:
 	virtual void Deinitialize() override;
 
 	// signals
-	virtual UTestbed1StructArrayInterfaceSignals* _GetSignals_Implementation() override
-	{
-		return Testbed1StructArrayInterfaceSignals;
-	};
+	virtual UTestbed1StructArrayInterfaceSignals* _GetSignals_Implementation() override;
 
 	// methods
 	virtual void FuncBoolAsync_Implementation(UObject* WorldContextObject, FLatentActionInfo LatentInfo, FTestbed1StructBool& Result, const TArray<FTestbed1StructBool>& ParamBool) override;

--- a/goldenmaster/Plugins/Testbed1/Source/Testbed1/Public/Generated/api/AbstractTestbed1StructInterface.h
+++ b/goldenmaster/Plugins/Testbed1/Source/Testbed1/Public/Generated/api/AbstractTestbed1StructInterface.h
@@ -38,10 +38,7 @@ public:
 	virtual void Deinitialize() override;
 
 	// signals
-	virtual UTestbed1StructInterfaceSignals* _GetSignals_Implementation() override
-	{
-		return Testbed1StructInterfaceSignals;
-	};
+	virtual UTestbed1StructInterfaceSignals* _GetSignals_Implementation() override;
 
 	// methods
 	virtual void FuncBoolAsync_Implementation(UObject* WorldContextObject, FLatentActionInfo LatentInfo, FTestbed1StructBool& Result, const FTestbed1StructBool& ParamBool) override;

--- a/goldenmaster/Plugins/Testbed2/Source/Testbed2/Private/Generated/OLink/Testbed2ManyParamInterfaceOLinkAdapter.cpp
+++ b/goldenmaster/Plugins/Testbed2/Source/Testbed2/Private/Generated/OLink/Testbed2ManyParamInterfaceOLinkAdapter.cpp
@@ -72,7 +72,7 @@ void UTestbed2ManyParamInterfaceOLinkAdapter::setBackendService(TScriptInterface
 	// subscribe to new backend
 	BackendService = InService;
 	UTestbed2ManyParamInterfaceSignals* BackendSignals = BackendService->Execute__GetSignals(BackendService.GetObject());
-	checkf(BackendSignals, TEXT("Cannot unsubscribe from delegates from backend service Testbed2ManyParamInterface"));
+	checkf(BackendSignals, TEXT("Cannot subscribe to delegates from backend service Testbed2ManyParamInterface"));
 	// connect property changed signals or simple events
 	BackendSignals->OnProp1Changed.AddDynamic(this, &UTestbed2ManyParamInterfaceOLinkAdapter::OnProp1Changed);
 	BackendSignals->OnProp2Changed.AddDynamic(this, &UTestbed2ManyParamInterfaceOLinkAdapter::OnProp2Changed);

--- a/goldenmaster/Plugins/Testbed2/Source/Testbed2/Private/Generated/OLink/Testbed2NestedStruct1InterfaceOLinkAdapter.cpp
+++ b/goldenmaster/Plugins/Testbed2/Source/Testbed2/Private/Generated/OLink/Testbed2NestedStruct1InterfaceOLinkAdapter.cpp
@@ -66,7 +66,7 @@ void UTestbed2NestedStruct1InterfaceOLinkAdapter::setBackendService(TScriptInter
 	// subscribe to new backend
 	BackendService = InService;
 	UTestbed2NestedStruct1InterfaceSignals* BackendSignals = BackendService->Execute__GetSignals(BackendService.GetObject());
-	checkf(BackendSignals, TEXT("Cannot unsubscribe from delegates from backend service Testbed2NestedStruct1Interface"));
+	checkf(BackendSignals, TEXT("Cannot subscribe to delegates from backend service Testbed2NestedStruct1Interface"));
 	// connect property changed signals or simple events
 	BackendSignals->OnProp1Changed.AddDynamic(this, &UTestbed2NestedStruct1InterfaceOLinkAdapter::OnProp1Changed);
 	BackendSignals->OnSig1Signal.AddDynamic(this, &UTestbed2NestedStruct1InterfaceOLinkAdapter::OnSig1);

--- a/goldenmaster/Plugins/Testbed2/Source/Testbed2/Private/Generated/OLink/Testbed2NestedStruct2InterfaceOLinkAdapter.cpp
+++ b/goldenmaster/Plugins/Testbed2/Source/Testbed2/Private/Generated/OLink/Testbed2NestedStruct2InterfaceOLinkAdapter.cpp
@@ -68,7 +68,7 @@ void UTestbed2NestedStruct2InterfaceOLinkAdapter::setBackendService(TScriptInter
 	// subscribe to new backend
 	BackendService = InService;
 	UTestbed2NestedStruct2InterfaceSignals* BackendSignals = BackendService->Execute__GetSignals(BackendService.GetObject());
-	checkf(BackendSignals, TEXT("Cannot unsubscribe from delegates from backend service Testbed2NestedStruct2Interface"));
+	checkf(BackendSignals, TEXT("Cannot subscribe to delegates from backend service Testbed2NestedStruct2Interface"));
 	// connect property changed signals or simple events
 	BackendSignals->OnProp1Changed.AddDynamic(this, &UTestbed2NestedStruct2InterfaceOLinkAdapter::OnProp1Changed);
 	BackendSignals->OnProp2Changed.AddDynamic(this, &UTestbed2NestedStruct2InterfaceOLinkAdapter::OnProp2Changed);

--- a/goldenmaster/Plugins/Testbed2/Source/Testbed2/Private/Generated/OLink/Testbed2NestedStruct3InterfaceOLinkAdapter.cpp
+++ b/goldenmaster/Plugins/Testbed2/Source/Testbed2/Private/Generated/OLink/Testbed2NestedStruct3InterfaceOLinkAdapter.cpp
@@ -70,7 +70,7 @@ void UTestbed2NestedStruct3InterfaceOLinkAdapter::setBackendService(TScriptInter
 	// subscribe to new backend
 	BackendService = InService;
 	UTestbed2NestedStruct3InterfaceSignals* BackendSignals = BackendService->Execute__GetSignals(BackendService.GetObject());
-	checkf(BackendSignals, TEXT("Cannot unsubscribe from delegates from backend service Testbed2NestedStruct3Interface"));
+	checkf(BackendSignals, TEXT("Cannot subscribe to delegates from backend service Testbed2NestedStruct3Interface"));
 	// connect property changed signals or simple events
 	BackendSignals->OnProp1Changed.AddDynamic(this, &UTestbed2NestedStruct3InterfaceOLinkAdapter::OnProp1Changed);
 	BackendSignals->OnProp2Changed.AddDynamic(this, &UTestbed2NestedStruct3InterfaceOLinkAdapter::OnProp2Changed);

--- a/goldenmaster/Plugins/Testbed2/Source/Testbed2/Private/Generated/api/AbstractTestbed2ManyParamInterface.cpp
+++ b/goldenmaster/Plugins/Testbed2/Source/Testbed2/Private/Generated/api/AbstractTestbed2ManyParamInterface.cpp
@@ -66,6 +66,15 @@ UAbstractTestbed2ManyParamInterface::UAbstractTestbed2ManyParamInterface()
 	Testbed2ManyParamInterfaceSignals = NewObject<UTestbed2ManyParamInterfaceSignals>();
 }
 
+UTestbed2ManyParamInterfaceSignals* UAbstractTestbed2ManyParamInterface::_GetSignals_Implementation()
+{
+	if (!Testbed2ManyParamInterfaceSignals)
+	{
+		Testbed2ManyParamInterfaceSignals = NewObject<UTestbed2ManyParamInterfaceSignals>();
+	}
+	return Testbed2ManyParamInterfaceSignals;
+}
+
 int32 UAbstractTestbed2ManyParamInterface::GetProp1_Private() const
 {
 	return Execute_GetProp1(this);

--- a/goldenmaster/Plugins/Testbed2/Source/Testbed2/Private/Generated/api/AbstractTestbed2NestedStruct1Interface.cpp
+++ b/goldenmaster/Plugins/Testbed2/Source/Testbed2/Private/Generated/api/AbstractTestbed2NestedStruct1Interface.cpp
@@ -66,6 +66,15 @@ UAbstractTestbed2NestedStruct1Interface::UAbstractTestbed2NestedStruct1Interface
 	Testbed2NestedStruct1InterfaceSignals = NewObject<UTestbed2NestedStruct1InterfaceSignals>();
 }
 
+UTestbed2NestedStruct1InterfaceSignals* UAbstractTestbed2NestedStruct1Interface::_GetSignals_Implementation()
+{
+	if (!Testbed2NestedStruct1InterfaceSignals)
+	{
+		Testbed2NestedStruct1InterfaceSignals = NewObject<UTestbed2NestedStruct1InterfaceSignals>();
+	}
+	return Testbed2NestedStruct1InterfaceSignals;
+}
+
 FTestbed2NestedStruct1 UAbstractTestbed2NestedStruct1Interface::GetProp1_Private() const
 {
 	return Execute_GetProp1(this);

--- a/goldenmaster/Plugins/Testbed2/Source/Testbed2/Private/Generated/api/AbstractTestbed2NestedStruct2Interface.cpp
+++ b/goldenmaster/Plugins/Testbed2/Source/Testbed2/Private/Generated/api/AbstractTestbed2NestedStruct2Interface.cpp
@@ -66,6 +66,15 @@ UAbstractTestbed2NestedStruct2Interface::UAbstractTestbed2NestedStruct2Interface
 	Testbed2NestedStruct2InterfaceSignals = NewObject<UTestbed2NestedStruct2InterfaceSignals>();
 }
 
+UTestbed2NestedStruct2InterfaceSignals* UAbstractTestbed2NestedStruct2Interface::_GetSignals_Implementation()
+{
+	if (!Testbed2NestedStruct2InterfaceSignals)
+	{
+		Testbed2NestedStruct2InterfaceSignals = NewObject<UTestbed2NestedStruct2InterfaceSignals>();
+	}
+	return Testbed2NestedStruct2InterfaceSignals;
+}
+
 FTestbed2NestedStruct1 UAbstractTestbed2NestedStruct2Interface::GetProp1_Private() const
 {
 	return Execute_GetProp1(this);

--- a/goldenmaster/Plugins/Testbed2/Source/Testbed2/Private/Generated/api/AbstractTestbed2NestedStruct3Interface.cpp
+++ b/goldenmaster/Plugins/Testbed2/Source/Testbed2/Private/Generated/api/AbstractTestbed2NestedStruct3Interface.cpp
@@ -66,6 +66,15 @@ UAbstractTestbed2NestedStruct3Interface::UAbstractTestbed2NestedStruct3Interface
 	Testbed2NestedStruct3InterfaceSignals = NewObject<UTestbed2NestedStruct3InterfaceSignals>();
 }
 
+UTestbed2NestedStruct3InterfaceSignals* UAbstractTestbed2NestedStruct3Interface::_GetSignals_Implementation()
+{
+	if (!Testbed2NestedStruct3InterfaceSignals)
+	{
+		Testbed2NestedStruct3InterfaceSignals = NewObject<UTestbed2NestedStruct3InterfaceSignals>();
+	}
+	return Testbed2NestedStruct3InterfaceSignals;
+}
+
 FTestbed2NestedStruct1 UAbstractTestbed2NestedStruct3Interface::GetProp1_Private() const
 {
 	return Execute_GetProp1(this);

--- a/goldenmaster/Plugins/Testbed2/Source/Testbed2/Public/Generated/api/AbstractTestbed2ManyParamInterface.h
+++ b/goldenmaster/Plugins/Testbed2/Source/Testbed2/Public/Generated/api/AbstractTestbed2ManyParamInterface.h
@@ -38,10 +38,7 @@ public:
 	virtual void Deinitialize() override;
 
 	// signals
-	virtual UTestbed2ManyParamInterfaceSignals* _GetSignals_Implementation() override
-	{
-		return Testbed2ManyParamInterfaceSignals;
-	};
+	virtual UTestbed2ManyParamInterfaceSignals* _GetSignals_Implementation() override;
 
 	// methods
 	virtual void Func1Async_Implementation(UObject* WorldContextObject, FLatentActionInfo LatentInfo, int32& Result, int32 Param1) override;

--- a/goldenmaster/Plugins/Testbed2/Source/Testbed2/Public/Generated/api/AbstractTestbed2NestedStruct1Interface.h
+++ b/goldenmaster/Plugins/Testbed2/Source/Testbed2/Public/Generated/api/AbstractTestbed2NestedStruct1Interface.h
@@ -38,10 +38,7 @@ public:
 	virtual void Deinitialize() override;
 
 	// signals
-	virtual UTestbed2NestedStruct1InterfaceSignals* _GetSignals_Implementation() override
-	{
-		return Testbed2NestedStruct1InterfaceSignals;
-	};
+	virtual UTestbed2NestedStruct1InterfaceSignals* _GetSignals_Implementation() override;
 
 	// methods
 	virtual void Func1Async_Implementation(UObject* WorldContextObject, FLatentActionInfo LatentInfo, FTestbed2NestedStruct1& Result, const FTestbed2NestedStruct1& Param1) override;

--- a/goldenmaster/Plugins/Testbed2/Source/Testbed2/Public/Generated/api/AbstractTestbed2NestedStruct2Interface.h
+++ b/goldenmaster/Plugins/Testbed2/Source/Testbed2/Public/Generated/api/AbstractTestbed2NestedStruct2Interface.h
@@ -38,10 +38,7 @@ public:
 	virtual void Deinitialize() override;
 
 	// signals
-	virtual UTestbed2NestedStruct2InterfaceSignals* _GetSignals_Implementation() override
-	{
-		return Testbed2NestedStruct2InterfaceSignals;
-	};
+	virtual UTestbed2NestedStruct2InterfaceSignals* _GetSignals_Implementation() override;
 
 	// methods
 	virtual void Func1Async_Implementation(UObject* WorldContextObject, FLatentActionInfo LatentInfo, FTestbed2NestedStruct1& Result, const FTestbed2NestedStruct1& Param1) override;

--- a/goldenmaster/Plugins/Testbed2/Source/Testbed2/Public/Generated/api/AbstractTestbed2NestedStruct3Interface.h
+++ b/goldenmaster/Plugins/Testbed2/Source/Testbed2/Public/Generated/api/AbstractTestbed2NestedStruct3Interface.h
@@ -38,10 +38,7 @@ public:
 	virtual void Deinitialize() override;
 
 	// signals
-	virtual UTestbed2NestedStruct3InterfaceSignals* _GetSignals_Implementation() override
-	{
-		return Testbed2NestedStruct3InterfaceSignals;
-	};
+	virtual UTestbed2NestedStruct3InterfaceSignals* _GetSignals_Implementation() override;
 
 	// methods
 	virtual void Func1Async_Implementation(UObject* WorldContextObject, FLatentActionInfo LatentInfo, FTestbed2NestedStruct1& Result, const FTestbed2NestedStruct1& Param1) override;

--- a/templates/ApiGear/apigear.uplugin
+++ b/templates/ApiGear/apigear.uplugin
@@ -1,7 +1,7 @@
 {
 	"FileVersion": 3,
 	"Version": 1,
-	"VersionName": "3.1.1",
+	"VersionName": "3.1.2",
 	"FriendlyName": "ApiGear",
 	"Description": "ApiGear ThirdParty libraries for tracing, simulation and IPC support",
 	"Category": "Other",

--- a/templates/module/Source/module/Private/Generated/OLink/olinkadapter.cpp.tpl
+++ b/templates/module/Source/module/Private/Generated/OLink/olinkadapter.cpp.tpl
@@ -73,7 +73,7 @@ void {{$Class}}::setBackendService(TScriptInterface<I{{Camel .Module.Name}}{{Cam
 	BackendService = InService;
 {{- if or (len .Interface.Properties) (.Interface.Signals) }}
 	U{{$Iface}}Signals* BackendSignals = BackendService->Execute__GetSignals(BackendService.GetObject());
-	checkf(BackendSignals, TEXT("Cannot unsubscribe from delegates from backend service {{$Iface}}"));
+	checkf(BackendSignals, TEXT("Cannot subscribe to delegates from backend service {{$Iface}}"));
 {{- end }}
 	// connect property changed signals or simple events
 {{- range .Interface.Properties }}

--- a/templates/module/Source/module/Private/Generated/api/abstract.cpp.tpl
+++ b/templates/module/Source/module/Private/Generated/api/abstract.cpp.tpl
@@ -79,6 +79,18 @@ public:
 {{- end }}
 }
 
+{{- if or (len .Properties) (len .Signals) }}
+{{- nl }}
+U{{$Class}}Signals* {{$abstractclass}}::_GetSignals_Implementation()
+{
+	if (!{{$Iface}}Signals)
+	{
+		{{$Iface}}Signals = NewObject<U{{$Class}}Signals>();
+	}
+	return {{$Class}}Signals;
+}
+{{- end }}
+
 {{- if len .Properties }}{{ nl }}{{ end }}
 {{- range $i, $e := .Properties }}
 {{- if $i }}{{nl}}{{ end }}

--- a/templates/module/Source/module/Public/Generated/api/abstract.h.tpl
+++ b/templates/module/Source/module/Public/Generated/api/abstract.h.tpl
@@ -48,10 +48,7 @@ public:
 {{- if or (len .Properties) (len .Signals) }}
 {{- nl }}
 	// signals
-	virtual U{{$Class}}Signals* _GetSignals_Implementation() override
-	{
-		return {{$Class}}Signals;
-	};
+	virtual U{{$Class}}Signals* _GetSignals_Implementation() override;
 {{- end }}
 
 	// methods


### PR DESCRIPTION
## 📑 Description
In UE 4.27, when inheriting from a C++ based implementation in BP, the constructor was not called and thus no signal struct created.
This PR checks whether the signal struct was already created and otherwise creates it.

## ✅ Checks
<!-- Make sure your pr passes the CI checks and do check the following fields as needed - -->
- [ ] My pull request adheres to the code style of this project
- [ ] My code requires changes to the documentation
- [ ] I have updated the documentation as required
- [x] All the tests have passed

## ℹ Additional Information
<!-- Any additional information like breaking changes, dependencies added, screenshots, comparisons between new and old behavior, etc. -->