### PR TITLE
feat(olink): add events on client (not)ready

### DIFF
--- a/goldenmaster/Plugins/ApiGear/Source/ApiGear/Public/ApiGearConnection.h
+++ b/goldenmaster/Plugins/ApiGear/Source/ApiGear/Public/ApiGearConnection.h
@@ -2,7 +2,6 @@
 
 #include "UObject/Interface.h"
 #include "CoreMinimal.h"
-#include "Containers/Ticker.h"
 #include "UObject/NoExportTypes.h"
 #include "ApiGearConnection.generated.h"
 
@@ -19,8 +18,18 @@ enum class EApiGearConnectionState : uint8
 	Connected UMETA(Displayname = "Connected")
 };
 
+///  Used when Network Layer Connection changes its state to connected(true) or any other connection state (false).
 DECLARE_MULTICAST_DELEGATE_OneParam(FApiGearConnectionIsConnectedDelegate, bool);
+///  Used when Network Layer Connection changes its state.
 DECLARE_MULTICAST_DELEGATE_OneParam(FApiGearConnectionStateChangedDelegate, EApiGearConnectionState);
+/**
+ * @brief Used when the interface client changes its subscription status:
+ * either is plugged in the network and ready to use with protocol of your choice (true)
+ * or it won't be able to properly communicate with server side (false).
+ * An established network connection (ConnectionIsConnectedDelegate with true parameter) is often necessary, but not sufficient (depending on your setup and used protocol)
+ * for the Api client implementation to be used.
+ */
+DECLARE_DYNAMIC_MULTICAST_DELEGATE_OneParam(FApiGearRemoteApiSubscriptionStatusChangedDelegate, bool, IsSubscribed);
 
 /** 
  * @brief An interface for all connections meant to be used by ApiGear

--- a/goldenmaster/Plugins/ApiGear/Source/ApiGearOLink/Private/unrealolinksink.cpp
+++ b/goldenmaster/Plugins/ApiGear/Source/ApiGearOLink/Private/unrealolinksink.cpp
@@ -34,6 +34,11 @@ void FUnrealOLinkSink::olinkOnPropertyChanged(const std::string& propertyId, con
 void FUnrealOLinkSink::olinkOnInit(const std::string& objectId, const nlohmann::json& props, ApiGear::ObjectLink::IClientNode* node)
 {
 	m_node = node;
+	if (OnInitCallback)
+	{
+		OnInitCallback();
+	}
+
 	if (PropertyChangedFunc)
 	{
 		PropertyChangedFunc(props);
@@ -42,6 +47,10 @@ void FUnrealOLinkSink::olinkOnInit(const std::string& objectId, const nlohmann::
 
 void FUnrealOLinkSink::olinkOnRelease()
 {
+	if (OnReleaseCallback)
+	{
+		OnReleaseCallback();
+	}
 	m_node = nullptr;
 }
 
@@ -55,7 +64,27 @@ void FUnrealOLinkSink::setOnSignalEmittedCallback(FSignalEmittedFunc func)
 	SignalEmittedFunc = func;
 }
 
+void FUnrealOLinkSink::setOnInitCallback(FInitializedFromSourceCallback func)
+{
+	OnInitCallback = func;
+}
+
+void FUnrealOLinkSink::setOnReleaseCallback(FSourceConnectionReleasedCallback func)
+{
+	OnReleaseCallback = func;
+}
+
 // reset callbacks
+void FUnrealOLinkSink::resetOnInitCallback()
+{
+	OnInitCallback = nullptr;
+}
+
+void FUnrealOLinkSink::resetOnReleaseCallback()
+{
+	OnReleaseCallback = nullptr;
+}
+
 void FUnrealOLinkSink::resetOnPropertyChangedCallback()
 {
 	PropertyChangedFunc = nullptr;

--- a/goldenmaster/Plugins/ApiGear/Source/ApiGearOLink/Public/unrealolinksink.h
+++ b/goldenmaster/Plugins/ApiGear/Source/ApiGearOLink/Public/unrealolinksink.h
@@ -24,11 +24,20 @@ public:
 	/** A type of function for handling signal message*/
 	using FSignalEmittedFunc = TFunction<void(const std::string& signalName, const nlohmann::json& args)>;
 
+	/** Type of function for initialized from source and ready to use callback */
+	using FInitializedFromSourceCallback = TFunction<void()>;
+	/** Type of function for unlinked from source callback */
+	using FSourceConnectionReleasedCallback = TFunction<void()>;
+
 	// set callbacks
+	void setOnInitCallback(FInitializedFromSourceCallback func);
+	void setOnReleaseCallback(FSourceConnectionReleasedCallback func);
 	void setOnPropertyChangedCallback(FPropertyChangedFunc func);
 	void setOnSignalEmittedCallback(FSignalEmittedFunc func);
 
 	// reset callbacks
+	void resetOnInitCallback();
+	void resetOnReleaseCallback();
 	void resetOnPropertyChangedCallback();
 	void resetOnSignalEmittedCallback();
 
@@ -44,4 +53,10 @@ private:
 
 	// holds function which will be called on emitted signals
 	FSignalEmittedFunc SignalEmittedFunc;
+
+	// Stores callback executed when sink is linked.
+	FInitializedFromSourceCallback OnInitCallback;
+
+	// Stores callback executed when sink is unlinked.
+	FSourceConnectionReleasedCallback OnReleaseCallback;
 };

--- a/goldenmaster/Plugins/TbEnum/Source/TbEnum/Private/Generated/OLink/TbEnumEnumInterfaceOLinkClient.cpp
+++ b/goldenmaster/Plugins/TbEnum/Source/TbEnum/Private/Generated/OLink/TbEnumEnumInterfaceOLinkClient.cpp
@@ -69,6 +69,11 @@ void UTbEnumEnumInterfaceOLinkClient::Initialize(FSubsystemCollectionBase& Colle
 {
 	Super::Initialize(Collection);
 
+	m_sink->setOnInitCallback([this]()
+		{ _SubscriptionStatusChanged.Broadcast(true); });
+	m_sink->setOnReleaseCallback([this]()
+		{ _SubscriptionStatusChanged.Broadcast(false); });
+
 	FUnrealOLinkSink::FPropertyChangedFunc PropertyChangedFunc = [this](const nlohmann::json& props)
 	{
 		this->applyState(props);
@@ -102,6 +107,8 @@ void UTbEnumEnumInterfaceOLinkClient::Deinitialize()
 	// tell the sink that we are gone and should not try to be invoked
 	m_sink->resetOnPropertyChangedCallback();
 	m_sink->resetOnSignalEmittedCallback();
+	m_sink->resetOnInitCallback();
+	m_sink->resetOnReleaseCallback();
 
 	if (Connection.GetObject())
 	{
@@ -376,6 +383,11 @@ ETbEnumEnum3 UTbEnumEnumInterfaceOLinkClient::Func3_Implementation(ETbEnumEnum3 
 		});
 
 	return Promise.GetFuture().Get();
+}
+
+bool UTbEnumEnumInterfaceOLinkClient::_IsSubscribed() const
+{
+	return m_sink->IsReady();
 }
 
 void UTbEnumEnumInterfaceOLinkClient::applyState(const nlohmann::json& fields)

--- a/goldenmaster/Plugins/TbEnum/Source/TbEnum/Public/Generated/OLink/TbEnumEnumInterfaceOLinkClient.h
+++ b/goldenmaster/Plugins/TbEnum/Source/TbEnum/Public/Generated/OLink/TbEnumEnumInterfaceOLinkClient.h
@@ -21,6 +21,7 @@ THIRD_PARTY_INCLUDES_START
 #include "olink/clientnode.h"
 THIRD_PARTY_INCLUDES_END
 #include "unrealolinksink.h"
+#include "ApiGearConnection.h"
 #include "Subsystems/GameInstanceSubsystem.h"
 #include "Runtime/Launch/Resources/Version.h"
 #if (ENGINE_MAJOR_VERSION == 4 && ENGINE_MINOR_VERSION < 27)
@@ -72,6 +73,20 @@ public:
 
 	UFUNCTION(BlueprintCallable, Category = "ApiGear|TbEnum|EnumInterface")
 	void UseConnection(TScriptInterface<class IApiGearConnection> InConnection);
+
+	/**
+	 * Used when the interface client changes subscription status:
+	 * either is linked(ready to use) with server side (true) or it is in unlinked state (false).
+	 */
+	UPROPERTY(BlueprintAssignable, Category = "ApiGear|TbEnum|EnumInterface|Remote", DisplayName = "Subscription Status Changed")
+	FApiGearRemoteApiSubscriptionStatusChangedDelegate _SubscriptionStatusChanged;
+
+	/**
+	 * Informs about the subscription state of the interface client.
+	 * @return true if the client is subscribed (plugged in the network) and ready to send and receive messages or false if the server cannot be reached.
+	 */
+	UFUNCTION(BlueprintCallable, Category = "ApiGear|TbEnum|EnumInterface|Remote")
+	bool _IsSubscribed() const;
 
 private:
 	void applyState(const nlohmann::json& fields);

--- a/goldenmaster/Plugins/TbSame1/Source/TbSame1/Private/Generated/OLink/TbSame1SameEnum1InterfaceOLinkClient.cpp
+++ b/goldenmaster/Plugins/TbSame1/Source/TbSame1/Private/Generated/OLink/TbSame1SameEnum1InterfaceOLinkClient.cpp
@@ -66,6 +66,11 @@ void UTbSame1SameEnum1InterfaceOLinkClient::Initialize(FSubsystemCollectionBase&
 {
 	Super::Initialize(Collection);
 
+	m_sink->setOnInitCallback([this]()
+		{ _SubscriptionStatusChanged.Broadcast(true); });
+	m_sink->setOnReleaseCallback([this]()
+		{ _SubscriptionStatusChanged.Broadcast(false); });
+
 	FUnrealOLinkSink::FPropertyChangedFunc PropertyChangedFunc = [this](const nlohmann::json& props)
 	{
 		this->applyState(props);
@@ -99,6 +104,8 @@ void UTbSame1SameEnum1InterfaceOLinkClient::Deinitialize()
 	// tell the sink that we are gone and should not try to be invoked
 	m_sink->resetOnPropertyChangedCallback();
 	m_sink->resetOnSignalEmittedCallback();
+	m_sink->resetOnInitCallback();
+	m_sink->resetOnReleaseCallback();
 
 	if (Connection.GetObject())
 	{
@@ -193,6 +200,11 @@ ETbSame1Enum1 UTbSame1SameEnum1InterfaceOLinkClient::Func1_Implementation(ETbSam
 		});
 
 	return Promise.GetFuture().Get();
+}
+
+bool UTbSame1SameEnum1InterfaceOLinkClient::_IsSubscribed() const
+{
+	return m_sink->IsReady();
 }
 
 void UTbSame1SameEnum1InterfaceOLinkClient::applyState(const nlohmann::json& fields)

--- a/goldenmaster/Plugins/TbSame1/Source/TbSame1/Private/Generated/OLink/TbSame1SameEnum2InterfaceOLinkClient.cpp
+++ b/goldenmaster/Plugins/TbSame1/Source/TbSame1/Private/Generated/OLink/TbSame1SameEnum2InterfaceOLinkClient.cpp
@@ -67,6 +67,11 @@ void UTbSame1SameEnum2InterfaceOLinkClient::Initialize(FSubsystemCollectionBase&
 {
 	Super::Initialize(Collection);
 
+	m_sink->setOnInitCallback([this]()
+		{ _SubscriptionStatusChanged.Broadcast(true); });
+	m_sink->setOnReleaseCallback([this]()
+		{ _SubscriptionStatusChanged.Broadcast(false); });
+
 	FUnrealOLinkSink::FPropertyChangedFunc PropertyChangedFunc = [this](const nlohmann::json& props)
 	{
 		this->applyState(props);
@@ -100,6 +105,8 @@ void UTbSame1SameEnum2InterfaceOLinkClient::Deinitialize()
 	// tell the sink that we are gone and should not try to be invoked
 	m_sink->resetOnPropertyChangedCallback();
 	m_sink->resetOnSignalEmittedCallback();
+	m_sink->resetOnInitCallback();
+	m_sink->resetOnReleaseCallback();
 
 	if (Connection.GetObject())
 	{
@@ -254,6 +261,11 @@ ETbSame1Enum1 UTbSame1SameEnum2InterfaceOLinkClient::Func2_Implementation(ETbSam
 		});
 
 	return Promise.GetFuture().Get();
+}
+
+bool UTbSame1SameEnum2InterfaceOLinkClient::_IsSubscribed() const
+{
+	return m_sink->IsReady();
 }
 
 void UTbSame1SameEnum2InterfaceOLinkClient::applyState(const nlohmann::json& fields)

--- a/goldenmaster/Plugins/TbSame1/Source/TbSame1/Private/Generated/OLink/TbSame1SameStruct1InterfaceOLinkClient.cpp
+++ b/goldenmaster/Plugins/TbSame1/Source/TbSame1/Private/Generated/OLink/TbSame1SameStruct1InterfaceOLinkClient.cpp
@@ -66,6 +66,11 @@ void UTbSame1SameStruct1InterfaceOLinkClient::Initialize(FSubsystemCollectionBas
 {
 	Super::Initialize(Collection);
 
+	m_sink->setOnInitCallback([this]()
+		{ _SubscriptionStatusChanged.Broadcast(true); });
+	m_sink->setOnReleaseCallback([this]()
+		{ _SubscriptionStatusChanged.Broadcast(false); });
+
 	FUnrealOLinkSink::FPropertyChangedFunc PropertyChangedFunc = [this](const nlohmann::json& props)
 	{
 		this->applyState(props);
@@ -99,6 +104,8 @@ void UTbSame1SameStruct1InterfaceOLinkClient::Deinitialize()
 	// tell the sink that we are gone and should not try to be invoked
 	m_sink->resetOnPropertyChangedCallback();
 	m_sink->resetOnSignalEmittedCallback();
+	m_sink->resetOnInitCallback();
+	m_sink->resetOnReleaseCallback();
 
 	if (Connection.GetObject())
 	{
@@ -193,6 +200,11 @@ FTbSame1Struct1 UTbSame1SameStruct1InterfaceOLinkClient::Func1_Implementation(co
 		});
 
 	return Promise.GetFuture().Get();
+}
+
+bool UTbSame1SameStruct1InterfaceOLinkClient::_IsSubscribed() const
+{
+	return m_sink->IsReady();
 }
 
 void UTbSame1SameStruct1InterfaceOLinkClient::applyState(const nlohmann::json& fields)

--- a/goldenmaster/Plugins/TbSame1/Source/TbSame1/Private/Generated/OLink/TbSame1SameStruct2InterfaceOLinkClient.cpp
+++ b/goldenmaster/Plugins/TbSame1/Source/TbSame1/Private/Generated/OLink/TbSame1SameStruct2InterfaceOLinkClient.cpp
@@ -67,6 +67,11 @@ void UTbSame1SameStruct2InterfaceOLinkClient::Initialize(FSubsystemCollectionBas
 {
 	Super::Initialize(Collection);
 
+	m_sink->setOnInitCallback([this]()
+		{ _SubscriptionStatusChanged.Broadcast(true); });
+	m_sink->setOnReleaseCallback([this]()
+		{ _SubscriptionStatusChanged.Broadcast(false); });
+
 	FUnrealOLinkSink::FPropertyChangedFunc PropertyChangedFunc = [this](const nlohmann::json& props)
 	{
 		this->applyState(props);
@@ -100,6 +105,8 @@ void UTbSame1SameStruct2InterfaceOLinkClient::Deinitialize()
 	// tell the sink that we are gone and should not try to be invoked
 	m_sink->resetOnPropertyChangedCallback();
 	m_sink->resetOnSignalEmittedCallback();
+	m_sink->resetOnInitCallback();
+	m_sink->resetOnReleaseCallback();
 
 	if (Connection.GetObject())
 	{
@@ -254,6 +261,11 @@ FTbSame1Struct1 UTbSame1SameStruct2InterfaceOLinkClient::Func2_Implementation(co
 		});
 
 	return Promise.GetFuture().Get();
+}
+
+bool UTbSame1SameStruct2InterfaceOLinkClient::_IsSubscribed() const
+{
+	return m_sink->IsReady();
 }
 
 void UTbSame1SameStruct2InterfaceOLinkClient::applyState(const nlohmann::json& fields)

--- a/goldenmaster/Plugins/TbSame1/Source/TbSame1/Public/Generated/OLink/TbSame1SameEnum1InterfaceOLinkClient.h
+++ b/goldenmaster/Plugins/TbSame1/Source/TbSame1/Public/Generated/OLink/TbSame1SameEnum1InterfaceOLinkClient.h
@@ -21,6 +21,7 @@ THIRD_PARTY_INCLUDES_START
 #include "olink/clientnode.h"
 THIRD_PARTY_INCLUDES_END
 #include "unrealolinksink.h"
+#include "ApiGearConnection.h"
 #include "Subsystems/GameInstanceSubsystem.h"
 #include "Runtime/Launch/Resources/Version.h"
 #if (ENGINE_MAJOR_VERSION == 4 && ENGINE_MINOR_VERSION < 27)
@@ -57,6 +58,20 @@ public:
 
 	UFUNCTION(BlueprintCallable, Category = "ApiGear|TbSame1|SameEnum1Interface")
 	void UseConnection(TScriptInterface<class IApiGearConnection> InConnection);
+
+	/**
+	 * Used when the interface client changes subscription status:
+	 * either is linked(ready to use) with server side (true) or it is in unlinked state (false).
+	 */
+	UPROPERTY(BlueprintAssignable, Category = "ApiGear|TbSame1|SameEnum1Interface|Remote", DisplayName = "Subscription Status Changed")
+	FApiGearRemoteApiSubscriptionStatusChangedDelegate _SubscriptionStatusChanged;
+
+	/**
+	 * Informs about the subscription state of the interface client.
+	 * @return true if the client is subscribed (plugged in the network) and ready to send and receive messages or false if the server cannot be reached.
+	 */
+	UFUNCTION(BlueprintCallable, Category = "ApiGear|TbSame1|SameEnum1Interface|Remote")
+	bool _IsSubscribed() const;
 
 private:
 	void applyState(const nlohmann::json& fields);

--- a/goldenmaster/Plugins/TbSame1/Source/TbSame1/Public/Generated/OLink/TbSame1SameEnum2InterfaceOLinkClient.h
+++ b/goldenmaster/Plugins/TbSame1/Source/TbSame1/Public/Generated/OLink/TbSame1SameEnum2InterfaceOLinkClient.h
@@ -21,6 +21,7 @@ THIRD_PARTY_INCLUDES_START
 #include "olink/clientnode.h"
 THIRD_PARTY_INCLUDES_END
 #include "unrealolinksink.h"
+#include "ApiGearConnection.h"
 #include "Subsystems/GameInstanceSubsystem.h"
 #include "Runtime/Launch/Resources/Version.h"
 #if (ENGINE_MAJOR_VERSION == 4 && ENGINE_MINOR_VERSION < 27)
@@ -62,6 +63,20 @@ public:
 
 	UFUNCTION(BlueprintCallable, Category = "ApiGear|TbSame1|SameEnum2Interface")
 	void UseConnection(TScriptInterface<class IApiGearConnection> InConnection);
+
+	/**
+	 * Used when the interface client changes subscription status:
+	 * either is linked(ready to use) with server side (true) or it is in unlinked state (false).
+	 */
+	UPROPERTY(BlueprintAssignable, Category = "ApiGear|TbSame1|SameEnum2Interface|Remote", DisplayName = "Subscription Status Changed")
+	FApiGearRemoteApiSubscriptionStatusChangedDelegate _SubscriptionStatusChanged;
+
+	/**
+	 * Informs about the subscription state of the interface client.
+	 * @return true if the client is subscribed (plugged in the network) and ready to send and receive messages or false if the server cannot be reached.
+	 */
+	UFUNCTION(BlueprintCallable, Category = "ApiGear|TbSame1|SameEnum2Interface|Remote")
+	bool _IsSubscribed() const;
 
 private:
 	void applyState(const nlohmann::json& fields);

--- a/goldenmaster/Plugins/TbSame1/Source/TbSame1/Public/Generated/OLink/TbSame1SameStruct1InterfaceOLinkClient.h
+++ b/goldenmaster/Plugins/TbSame1/Source/TbSame1/Public/Generated/OLink/TbSame1SameStruct1InterfaceOLinkClient.h
@@ -21,6 +21,7 @@ THIRD_PARTY_INCLUDES_START
 #include "olink/clientnode.h"
 THIRD_PARTY_INCLUDES_END
 #include "unrealolinksink.h"
+#include "ApiGearConnection.h"
 #include "Subsystems/GameInstanceSubsystem.h"
 #include "Runtime/Launch/Resources/Version.h"
 #if (ENGINE_MAJOR_VERSION == 4 && ENGINE_MINOR_VERSION < 27)
@@ -57,6 +58,20 @@ public:
 
 	UFUNCTION(BlueprintCallable, Category = "ApiGear|TbSame1|SameStruct1Interface")
 	void UseConnection(TScriptInterface<class IApiGearConnection> InConnection);
+
+	/**
+	 * Used when the interface client changes subscription status:
+	 * either is linked(ready to use) with server side (true) or it is in unlinked state (false).
+	 */
+	UPROPERTY(BlueprintAssignable, Category = "ApiGear|TbSame1|SameStruct1Interface|Remote", DisplayName = "Subscription Status Changed")
+	FApiGearRemoteApiSubscriptionStatusChangedDelegate _SubscriptionStatusChanged;
+
+	/**
+	 * Informs about the subscription state of the interface client.
+	 * @return true if the client is subscribed (plugged in the network) and ready to send and receive messages or false if the server cannot be reached.
+	 */
+	UFUNCTION(BlueprintCallable, Category = "ApiGear|TbSame1|SameStruct1Interface|Remote")
+	bool _IsSubscribed() const;
 
 private:
 	void applyState(const nlohmann::json& fields);

--- a/goldenmaster/Plugins/TbSame1/Source/TbSame1/Public/Generated/OLink/TbSame1SameStruct2InterfaceOLinkClient.h
+++ b/goldenmaster/Plugins/TbSame1/Source/TbSame1/Public/Generated/OLink/TbSame1SameStruct2InterfaceOLinkClient.h
@@ -21,6 +21,7 @@ THIRD_PARTY_INCLUDES_START
 #include "olink/clientnode.h"
 THIRD_PARTY_INCLUDES_END
 #include "unrealolinksink.h"
+#include "ApiGearConnection.h"
 #include "Subsystems/GameInstanceSubsystem.h"
 #include "Runtime/Launch/Resources/Version.h"
 #if (ENGINE_MAJOR_VERSION == 4 && ENGINE_MINOR_VERSION < 27)
@@ -62,6 +63,20 @@ public:
 
 	UFUNCTION(BlueprintCallable, Category = "ApiGear|TbSame1|SameStruct2Interface")
 	void UseConnection(TScriptInterface<class IApiGearConnection> InConnection);
+
+	/**
+	 * Used when the interface client changes subscription status:
+	 * either is linked(ready to use) with server side (true) or it is in unlinked state (false).
+	 */
+	UPROPERTY(BlueprintAssignable, Category = "ApiGear|TbSame1|SameStruct2Interface|Remote", DisplayName = "Subscription Status Changed")
+	FApiGearRemoteApiSubscriptionStatusChangedDelegate _SubscriptionStatusChanged;
+
+	/**
+	 * Informs about the subscription state of the interface client.
+	 * @return true if the client is subscribed (plugged in the network) and ready to send and receive messages or false if the server cannot be reached.
+	 */
+	UFUNCTION(BlueprintCallable, Category = "ApiGear|TbSame1|SameStruct2Interface|Remote")
+	bool _IsSubscribed() const;
 
 private:
 	void applyState(const nlohmann::json& fields);

--- a/goldenmaster/Plugins/TbSame2/Source/TbSame2/Private/Generated/OLink/TbSame2SameEnum1InterfaceOLinkClient.cpp
+++ b/goldenmaster/Plugins/TbSame2/Source/TbSame2/Private/Generated/OLink/TbSame2SameEnum1InterfaceOLinkClient.cpp
@@ -66,6 +66,11 @@ void UTbSame2SameEnum1InterfaceOLinkClient::Initialize(FSubsystemCollectionBase&
 {
 	Super::Initialize(Collection);
 
+	m_sink->setOnInitCallback([this]()
+		{ _SubscriptionStatusChanged.Broadcast(true); });
+	m_sink->setOnReleaseCallback([this]()
+		{ _SubscriptionStatusChanged.Broadcast(false); });
+
 	FUnrealOLinkSink::FPropertyChangedFunc PropertyChangedFunc = [this](const nlohmann::json& props)
 	{
 		this->applyState(props);
@@ -99,6 +104,8 @@ void UTbSame2SameEnum1InterfaceOLinkClient::Deinitialize()
 	// tell the sink that we are gone and should not try to be invoked
 	m_sink->resetOnPropertyChangedCallback();
 	m_sink->resetOnSignalEmittedCallback();
+	m_sink->resetOnInitCallback();
+	m_sink->resetOnReleaseCallback();
 
 	if (Connection.GetObject())
 	{
@@ -193,6 +200,11 @@ ETbSame2Enum1 UTbSame2SameEnum1InterfaceOLinkClient::Func1_Implementation(ETbSam
 		});
 
 	return Promise.GetFuture().Get();
+}
+
+bool UTbSame2SameEnum1InterfaceOLinkClient::_IsSubscribed() const
+{
+	return m_sink->IsReady();
 }
 
 void UTbSame2SameEnum1InterfaceOLinkClient::applyState(const nlohmann::json& fields)

--- a/goldenmaster/Plugins/TbSame2/Source/TbSame2/Private/Generated/OLink/TbSame2SameEnum2InterfaceOLinkClient.cpp
+++ b/goldenmaster/Plugins/TbSame2/Source/TbSame2/Private/Generated/OLink/TbSame2SameEnum2InterfaceOLinkClient.cpp
@@ -67,6 +67,11 @@ void UTbSame2SameEnum2InterfaceOLinkClient::Initialize(FSubsystemCollectionBase&
 {
 	Super::Initialize(Collection);
 
+	m_sink->setOnInitCallback([this]()
+		{ _SubscriptionStatusChanged.Broadcast(true); });
+	m_sink->setOnReleaseCallback([this]()
+		{ _SubscriptionStatusChanged.Broadcast(false); });
+
 	FUnrealOLinkSink::FPropertyChangedFunc PropertyChangedFunc = [this](const nlohmann::json& props)
 	{
 		this->applyState(props);
@@ -100,6 +105,8 @@ void UTbSame2SameEnum2InterfaceOLinkClient::Deinitialize()
 	// tell the sink that we are gone and should not try to be invoked
 	m_sink->resetOnPropertyChangedCallback();
 	m_sink->resetOnSignalEmittedCallback();
+	m_sink->resetOnInitCallback();
+	m_sink->resetOnReleaseCallback();
 
 	if (Connection.GetObject())
 	{
@@ -254,6 +261,11 @@ ETbSame2Enum1 UTbSame2SameEnum2InterfaceOLinkClient::Func2_Implementation(ETbSam
 		});
 
 	return Promise.GetFuture().Get();
+}
+
+bool UTbSame2SameEnum2InterfaceOLinkClient::_IsSubscribed() const
+{
+	return m_sink->IsReady();
 }
 
 void UTbSame2SameEnum2InterfaceOLinkClient::applyState(const nlohmann::json& fields)

--- a/goldenmaster/Plugins/TbSame2/Source/TbSame2/Private/Generated/OLink/TbSame2SameStruct1InterfaceOLinkClient.cpp
+++ b/goldenmaster/Plugins/TbSame2/Source/TbSame2/Private/Generated/OLink/TbSame2SameStruct1InterfaceOLinkClient.cpp
@@ -66,6 +66,11 @@ void UTbSame2SameStruct1InterfaceOLinkClient::Initialize(FSubsystemCollectionBas
 {
 	Super::Initialize(Collection);
 
+	m_sink->setOnInitCallback([this]()
+		{ _SubscriptionStatusChanged.Broadcast(true); });
+	m_sink->setOnReleaseCallback([this]()
+		{ _SubscriptionStatusChanged.Broadcast(false); });
+
 	FUnrealOLinkSink::FPropertyChangedFunc PropertyChangedFunc = [this](const nlohmann::json& props)
 	{
 		this->applyState(props);
@@ -99,6 +104,8 @@ void UTbSame2SameStruct1InterfaceOLinkClient::Deinitialize()
 	// tell the sink that we are gone and should not try to be invoked
 	m_sink->resetOnPropertyChangedCallback();
 	m_sink->resetOnSignalEmittedCallback();
+	m_sink->resetOnInitCallback();
+	m_sink->resetOnReleaseCallback();
 
 	if (Connection.GetObject())
 	{
@@ -193,6 +200,11 @@ FTbSame2Struct1 UTbSame2SameStruct1InterfaceOLinkClient::Func1_Implementation(co
 		});
 
 	return Promise.GetFuture().Get();
+}
+
+bool UTbSame2SameStruct1InterfaceOLinkClient::_IsSubscribed() const
+{
+	return m_sink->IsReady();
 }
 
 void UTbSame2SameStruct1InterfaceOLinkClient::applyState(const nlohmann::json& fields)

--- a/goldenmaster/Plugins/TbSame2/Source/TbSame2/Private/Generated/OLink/TbSame2SameStruct2InterfaceOLinkClient.cpp
+++ b/goldenmaster/Plugins/TbSame2/Source/TbSame2/Private/Generated/OLink/TbSame2SameStruct2InterfaceOLinkClient.cpp
@@ -67,6 +67,11 @@ void UTbSame2SameStruct2InterfaceOLinkClient::Initialize(FSubsystemCollectionBas
 {
 	Super::Initialize(Collection);
 
+	m_sink->setOnInitCallback([this]()
+		{ _SubscriptionStatusChanged.Broadcast(true); });
+	m_sink->setOnReleaseCallback([this]()
+		{ _SubscriptionStatusChanged.Broadcast(false); });
+
 	FUnrealOLinkSink::FPropertyChangedFunc PropertyChangedFunc = [this](const nlohmann::json& props)
 	{
 		this->applyState(props);
@@ -100,6 +105,8 @@ void UTbSame2SameStruct2InterfaceOLinkClient::Deinitialize()
 	// tell the sink that we are gone and should not try to be invoked
 	m_sink->resetOnPropertyChangedCallback();
 	m_sink->resetOnSignalEmittedCallback();
+	m_sink->resetOnInitCallback();
+	m_sink->resetOnReleaseCallback();
 
 	if (Connection.GetObject())
 	{
@@ -254,6 +261,11 @@ FTbSame2Struct1 UTbSame2SameStruct2InterfaceOLinkClient::Func2_Implementation(co
 		});
 
 	return Promise.GetFuture().Get();
+}
+
+bool UTbSame2SameStruct2InterfaceOLinkClient::_IsSubscribed() const
+{
+	return m_sink->IsReady();
 }
 
 void UTbSame2SameStruct2InterfaceOLinkClient::applyState(const nlohmann::json& fields)

--- a/goldenmaster/Plugins/TbSame2/Source/TbSame2/Public/Generated/OLink/TbSame2SameEnum1InterfaceOLinkClient.h
+++ b/goldenmaster/Plugins/TbSame2/Source/TbSame2/Public/Generated/OLink/TbSame2SameEnum1InterfaceOLinkClient.h
@@ -21,6 +21,7 @@ THIRD_PARTY_INCLUDES_START
 #include "olink/clientnode.h"
 THIRD_PARTY_INCLUDES_END
 #include "unrealolinksink.h"
+#include "ApiGearConnection.h"
 #include "Subsystems/GameInstanceSubsystem.h"
 #include "Runtime/Launch/Resources/Version.h"
 #if (ENGINE_MAJOR_VERSION == 4 && ENGINE_MINOR_VERSION < 27)
@@ -57,6 +58,20 @@ public:
 
 	UFUNCTION(BlueprintCallable, Category = "ApiGear|TbSame2|SameEnum1Interface")
 	void UseConnection(TScriptInterface<class IApiGearConnection> InConnection);
+
+	/**
+	 * Used when the interface client changes subscription status:
+	 * either is linked(ready to use) with server side (true) or it is in unlinked state (false).
+	 */
+	UPROPERTY(BlueprintAssignable, Category = "ApiGear|TbSame2|SameEnum1Interface|Remote", DisplayName = "Subscription Status Changed")
+	FApiGearRemoteApiSubscriptionStatusChangedDelegate _SubscriptionStatusChanged;
+
+	/**
+	 * Informs about the subscription state of the interface client.
+	 * @return true if the client is subscribed (plugged in the network) and ready to send and receive messages or false if the server cannot be reached.
+	 */
+	UFUNCTION(BlueprintCallable, Category = "ApiGear|TbSame2|SameEnum1Interface|Remote")
+	bool _IsSubscribed() const;
 
 private:
 	void applyState(const nlohmann::json& fields);

--- a/goldenmaster/Plugins/TbSame2/Source/TbSame2/Public/Generated/OLink/TbSame2SameEnum2InterfaceOLinkClient.h
+++ b/goldenmaster/Plugins/TbSame2/Source/TbSame2/Public/Generated/OLink/TbSame2SameEnum2InterfaceOLinkClient.h
@@ -21,6 +21,7 @@ THIRD_PARTY_INCLUDES_START
 #include "olink/clientnode.h"
 THIRD_PARTY_INCLUDES_END
 #include "unrealolinksink.h"
+#include "ApiGearConnection.h"
 #include "Subsystems/GameInstanceSubsystem.h"
 #include "Runtime/Launch/Resources/Version.h"
 #if (ENGINE_MAJOR_VERSION == 4 && ENGINE_MINOR_VERSION < 27)
@@ -62,6 +63,20 @@ public:
 
 	UFUNCTION(BlueprintCallable, Category = "ApiGear|TbSame2|SameEnum2Interface")
 	void UseConnection(TScriptInterface<class IApiGearConnection> InConnection);
+
+	/**
+	 * Used when the interface client changes subscription status:
+	 * either is linked(ready to use) with server side (true) or it is in unlinked state (false).
+	 */
+	UPROPERTY(BlueprintAssignable, Category = "ApiGear|TbSame2|SameEnum2Interface|Remote", DisplayName = "Subscription Status Changed")
+	FApiGearRemoteApiSubscriptionStatusChangedDelegate _SubscriptionStatusChanged;
+
+	/**
+	 * Informs about the subscription state of the interface client.
+	 * @return true if the client is subscribed (plugged in the network) and ready to send and receive messages or false if the server cannot be reached.
+	 */
+	UFUNCTION(BlueprintCallable, Category = "ApiGear|TbSame2|SameEnum2Interface|Remote")
+	bool _IsSubscribed() const;
 
 private:
 	void applyState(const nlohmann::json& fields);

--- a/goldenmaster/Plugins/TbSame2/Source/TbSame2/Public/Generated/OLink/TbSame2SameStruct1InterfaceOLinkClient.h
+++ b/goldenmaster/Plugins/TbSame2/Source/TbSame2/Public/Generated/OLink/TbSame2SameStruct1InterfaceOLinkClient.h
@@ -21,6 +21,7 @@ THIRD_PARTY_INCLUDES_START
 #include "olink/clientnode.h"
 THIRD_PARTY_INCLUDES_END
 #include "unrealolinksink.h"
+#include "ApiGearConnection.h"
 #include "Subsystems/GameInstanceSubsystem.h"
 #include "Runtime/Launch/Resources/Version.h"
 #if (ENGINE_MAJOR_VERSION == 4 && ENGINE_MINOR_VERSION < 27)
@@ -57,6 +58,20 @@ public:
 
 	UFUNCTION(BlueprintCallable, Category = "ApiGear|TbSame2|SameStruct1Interface")
 	void UseConnection(TScriptInterface<class IApiGearConnection> InConnection);
+
+	/**
+	 * Used when the interface client changes subscription status:
+	 * either is linked(ready to use) with server side (true) or it is in unlinked state (false).
+	 */
+	UPROPERTY(BlueprintAssignable, Category = "ApiGear|TbSame2|SameStruct1Interface|Remote", DisplayName = "Subscription Status Changed")
+	FApiGearRemoteApiSubscriptionStatusChangedDelegate _SubscriptionStatusChanged;
+
+	/**
+	 * Informs about the subscription state of the interface client.
+	 * @return true if the client is subscribed (plugged in the network) and ready to send and receive messages or false if the server cannot be reached.
+	 */
+	UFUNCTION(BlueprintCallable, Category = "ApiGear|TbSame2|SameStruct1Interface|Remote")
+	bool _IsSubscribed() const;
 
 private:
 	void applyState(const nlohmann::json& fields);

--- a/goldenmaster/Plugins/TbSame2/Source/TbSame2/Public/Generated/OLink/TbSame2SameStruct2InterfaceOLinkClient.h
+++ b/goldenmaster/Plugins/TbSame2/Source/TbSame2/Public/Generated/OLink/TbSame2SameStruct2InterfaceOLinkClient.h
@@ -21,6 +21,7 @@ THIRD_PARTY_INCLUDES_START
 #include "olink/clientnode.h"
 THIRD_PARTY_INCLUDES_END
 #include "unrealolinksink.h"
+#include "ApiGearConnection.h"
 #include "Subsystems/GameInstanceSubsystem.h"
 #include "Runtime/Launch/Resources/Version.h"
 #if (ENGINE_MAJOR_VERSION == 4 && ENGINE_MINOR_VERSION < 27)
@@ -62,6 +63,20 @@ public:
 
 	UFUNCTION(BlueprintCallable, Category = "ApiGear|TbSame2|SameStruct2Interface")
 	void UseConnection(TScriptInterface<class IApiGearConnection> InConnection);
+
+	/**
+	 * Used when the interface client changes subscription status:
+	 * either is linked(ready to use) with server side (true) or it is in unlinked state (false).
+	 */
+	UPROPERTY(BlueprintAssignable, Category = "ApiGear|TbSame2|SameStruct2Interface|Remote", DisplayName = "Subscription Status Changed")
+	FApiGearRemoteApiSubscriptionStatusChangedDelegate _SubscriptionStatusChanged;
+
+	/**
+	 * Informs about the subscription state of the interface client.
+	 * @return true if the client is subscribed (plugged in the network) and ready to send and receive messages or false if the server cannot be reached.
+	 */
+	UFUNCTION(BlueprintCallable, Category = "ApiGear|TbSame2|SameStruct2Interface|Remote")
+	bool _IsSubscribed() const;
 
 private:
 	void applyState(const nlohmann::json& fields);

--- a/goldenmaster/Plugins/TbSimple/Source/TbSimple/Private/Generated/OLink/TbSimpleEmptyInterfaceOLinkClient.cpp
+++ b/goldenmaster/Plugins/TbSimple/Source/TbSimple/Private/Generated/OLink/TbSimpleEmptyInterfaceOLinkClient.cpp
@@ -53,6 +53,11 @@ void UTbSimpleEmptyInterfaceOLinkClient::Initialize(FSubsystemCollectionBase& Co
 {
 	Super::Initialize(Collection);
 
+	m_sink->setOnInitCallback([this]()
+		{ _SubscriptionStatusChanged.Broadcast(true); });
+	m_sink->setOnReleaseCallback([this]()
+		{ _SubscriptionStatusChanged.Broadcast(false); });
+
 	FUnrealOLinkSink::FPropertyChangedFunc PropertyChangedFunc = [this](const nlohmann::json& props)
 	{
 		this->applyState(props);
@@ -86,6 +91,8 @@ void UTbSimpleEmptyInterfaceOLinkClient::Deinitialize()
 	// tell the sink that we are gone and should not try to be invoked
 	m_sink->resetOnPropertyChangedCallback();
 	m_sink->resetOnSignalEmittedCallback();
+	m_sink->resetOnInitCallback();
+	m_sink->resetOnReleaseCallback();
 
 	if (Connection.GetObject())
 	{
@@ -120,6 +127,11 @@ void UTbSimpleEmptyInterfaceOLinkClient::UseConnection(TScriptInterface<IApiGear
 	UnrealOLinkConnection->linkObjectSource(m_sink->olinkObjectName());
 
 	Connection = InConnection;
+}
+
+bool UTbSimpleEmptyInterfaceOLinkClient::_IsSubscribed() const
+{
+	return m_sink->IsReady();
 }
 
 void UTbSimpleEmptyInterfaceOLinkClient::applyState(const nlohmann::json& fields)

--- a/goldenmaster/Plugins/TbSimple/Source/TbSimple/Private/Generated/OLink/TbSimpleNoOperationsInterfaceOLinkClient.cpp
+++ b/goldenmaster/Plugins/TbSimple/Source/TbSimple/Private/Generated/OLink/TbSimpleNoOperationsInterfaceOLinkClient.cpp
@@ -67,6 +67,11 @@ void UTbSimpleNoOperationsInterfaceOLinkClient::Initialize(FSubsystemCollectionB
 {
 	Super::Initialize(Collection);
 
+	m_sink->setOnInitCallback([this]()
+		{ _SubscriptionStatusChanged.Broadcast(true); });
+	m_sink->setOnReleaseCallback([this]()
+		{ _SubscriptionStatusChanged.Broadcast(false); });
+
 	FUnrealOLinkSink::FPropertyChangedFunc PropertyChangedFunc = [this](const nlohmann::json& props)
 	{
 		this->applyState(props);
@@ -100,6 +105,8 @@ void UTbSimpleNoOperationsInterfaceOLinkClient::Deinitialize()
 	// tell the sink that we are gone and should not try to be invoked
 	m_sink->resetOnPropertyChangedCallback();
 	m_sink->resetOnSignalEmittedCallback();
+	m_sink->resetOnInitCallback();
+	m_sink->resetOnReleaseCallback();
 
 	if (Connection.GetObject())
 	{
@@ -192,6 +199,11 @@ void UTbSimpleNoOperationsInterfaceOLinkClient::SetPropInt_Implementation(int32 
 	static const auto memberId = ApiGear::ObjectLink::Name::createMemberId(m_sink->olinkObjectName(), "propInt");
 	m_sink->GetNode()->setRemoteProperty(memberId, InPropInt);
 	_SentData->PropInt = InPropInt;
+}
+
+bool UTbSimpleNoOperationsInterfaceOLinkClient::_IsSubscribed() const
+{
+	return m_sink->IsReady();
 }
 
 void UTbSimpleNoOperationsInterfaceOLinkClient::applyState(const nlohmann::json& fields)

--- a/goldenmaster/Plugins/TbSimple/Source/TbSimple/Private/Generated/OLink/TbSimpleNoPropertiesInterfaceOLinkClient.cpp
+++ b/goldenmaster/Plugins/TbSimple/Source/TbSimple/Private/Generated/OLink/TbSimpleNoPropertiesInterfaceOLinkClient.cpp
@@ -53,6 +53,11 @@ void UTbSimpleNoPropertiesInterfaceOLinkClient::Initialize(FSubsystemCollectionB
 {
 	Super::Initialize(Collection);
 
+	m_sink->setOnInitCallback([this]()
+		{ _SubscriptionStatusChanged.Broadcast(true); });
+	m_sink->setOnReleaseCallback([this]()
+		{ _SubscriptionStatusChanged.Broadcast(false); });
+
 	FUnrealOLinkSink::FPropertyChangedFunc PropertyChangedFunc = [this](const nlohmann::json& props)
 	{
 		this->applyState(props);
@@ -86,6 +91,8 @@ void UTbSimpleNoPropertiesInterfaceOLinkClient::Deinitialize()
 	// tell the sink that we are gone and should not try to be invoked
 	m_sink->resetOnPropertyChangedCallback();
 	m_sink->resetOnSignalEmittedCallback();
+	m_sink->resetOnInitCallback();
+	m_sink->resetOnReleaseCallback();
 
 	if (Connection.GetObject())
 	{
@@ -164,6 +171,11 @@ bool UTbSimpleNoPropertiesInterfaceOLinkClient::FuncBool_Implementation(bool bPa
 		});
 
 	return Promise.GetFuture().Get();
+}
+
+bool UTbSimpleNoPropertiesInterfaceOLinkClient::_IsSubscribed() const
+{
+	return m_sink->IsReady();
 }
 
 void UTbSimpleNoPropertiesInterfaceOLinkClient::applyState(const nlohmann::json& fields)

--- a/goldenmaster/Plugins/TbSimple/Source/TbSimple/Private/Generated/OLink/TbSimpleNoSignalsInterfaceOLinkClient.cpp
+++ b/goldenmaster/Plugins/TbSimple/Source/TbSimple/Private/Generated/OLink/TbSimpleNoSignalsInterfaceOLinkClient.cpp
@@ -67,6 +67,11 @@ void UTbSimpleNoSignalsInterfaceOLinkClient::Initialize(FSubsystemCollectionBase
 {
 	Super::Initialize(Collection);
 
+	m_sink->setOnInitCallback([this]()
+		{ _SubscriptionStatusChanged.Broadcast(true); });
+	m_sink->setOnReleaseCallback([this]()
+		{ _SubscriptionStatusChanged.Broadcast(false); });
+
 	FUnrealOLinkSink::FPropertyChangedFunc PropertyChangedFunc = [this](const nlohmann::json& props)
 	{
 		this->applyState(props);
@@ -100,6 +105,8 @@ void UTbSimpleNoSignalsInterfaceOLinkClient::Deinitialize()
 	// tell the sink that we are gone and should not try to be invoked
 	m_sink->resetOnPropertyChangedCallback();
 	m_sink->resetOnSignalEmittedCallback();
+	m_sink->resetOnInitCallback();
+	m_sink->resetOnReleaseCallback();
 
 	if (Connection.GetObject())
 	{
@@ -236,6 +243,11 @@ bool UTbSimpleNoSignalsInterfaceOLinkClient::FuncBool_Implementation(bool bParam
 		});
 
 	return Promise.GetFuture().Get();
+}
+
+bool UTbSimpleNoSignalsInterfaceOLinkClient::_IsSubscribed() const
+{
+	return m_sink->IsReady();
 }
 
 void UTbSimpleNoSignalsInterfaceOLinkClient::applyState(const nlohmann::json& fields)

--- a/goldenmaster/Plugins/TbSimple/Source/TbSimple/Private/Generated/OLink/TbSimpleSimpleArrayInterfaceOLinkClient.cpp
+++ b/goldenmaster/Plugins/TbSimple/Source/TbSimple/Private/Generated/OLink/TbSimpleSimpleArrayInterfaceOLinkClient.cpp
@@ -73,6 +73,11 @@ void UTbSimpleSimpleArrayInterfaceOLinkClient::Initialize(FSubsystemCollectionBa
 {
 	Super::Initialize(Collection);
 
+	m_sink->setOnInitCallback([this]()
+		{ _SubscriptionStatusChanged.Broadcast(true); });
+	m_sink->setOnReleaseCallback([this]()
+		{ _SubscriptionStatusChanged.Broadcast(false); });
+
 	FUnrealOLinkSink::FPropertyChangedFunc PropertyChangedFunc = [this](const nlohmann::json& props)
 	{
 		this->applyState(props);
@@ -106,6 +111,8 @@ void UTbSimpleSimpleArrayInterfaceOLinkClient::Deinitialize()
 	// tell the sink that we are gone and should not try to be invoked
 	m_sink->resetOnPropertyChangedCallback();
 	m_sink->resetOnSignalEmittedCallback();
+	m_sink->resetOnInitCallback();
+	m_sink->resetOnReleaseCallback();
 
 	if (Connection.GetObject())
 	{
@@ -620,6 +627,11 @@ TArray<FString> UTbSimpleSimpleArrayInterfaceOLinkClient::FuncString_Implementat
 		});
 
 	return Promise.GetFuture().Get();
+}
+
+bool UTbSimpleSimpleArrayInterfaceOLinkClient::_IsSubscribed() const
+{
+	return m_sink->IsReady();
 }
 
 void UTbSimpleSimpleArrayInterfaceOLinkClient::applyState(const nlohmann::json& fields)

--- a/goldenmaster/Plugins/TbSimple/Source/TbSimple/Private/Generated/OLink/TbSimpleSimpleInterfaceOLinkClient.cpp
+++ b/goldenmaster/Plugins/TbSimple/Source/TbSimple/Private/Generated/OLink/TbSimpleSimpleInterfaceOLinkClient.cpp
@@ -74,6 +74,11 @@ void UTbSimpleSimpleInterfaceOLinkClient::Initialize(FSubsystemCollectionBase& C
 {
 	Super::Initialize(Collection);
 
+	m_sink->setOnInitCallback([this]()
+		{ _SubscriptionStatusChanged.Broadcast(true); });
+	m_sink->setOnReleaseCallback([this]()
+		{ _SubscriptionStatusChanged.Broadcast(false); });
+
 	FUnrealOLinkSink::FPropertyChangedFunc PropertyChangedFunc = [this](const nlohmann::json& props)
 	{
 		this->applyState(props);
@@ -107,6 +112,8 @@ void UTbSimpleSimpleInterfaceOLinkClient::Deinitialize()
 	// tell the sink that we are gone and should not try to be invoked
 	m_sink->resetOnPropertyChangedCallback();
 	m_sink->resetOnSignalEmittedCallback();
+	m_sink->resetOnInitCallback();
+	m_sink->resetOnReleaseCallback();
 
 	if (Connection.GetObject())
 	{
@@ -639,6 +646,11 @@ FString UTbSimpleSimpleInterfaceOLinkClient::FuncString_Implementation(const FSt
 		});
 
 	return Promise.GetFuture().Get();
+}
+
+bool UTbSimpleSimpleInterfaceOLinkClient::_IsSubscribed() const
+{
+	return m_sink->IsReady();
 }
 
 void UTbSimpleSimpleInterfaceOLinkClient::applyState(const nlohmann::json& fields)

--- a/goldenmaster/Plugins/TbSimple/Source/TbSimple/Public/Generated/OLink/TbSimpleEmptyInterfaceOLinkClient.h
+++ b/goldenmaster/Plugins/TbSimple/Source/TbSimple/Public/Generated/OLink/TbSimpleEmptyInterfaceOLinkClient.h
@@ -21,6 +21,7 @@ THIRD_PARTY_INCLUDES_START
 #include "olink/clientnode.h"
 THIRD_PARTY_INCLUDES_END
 #include "unrealolinksink.h"
+#include "ApiGearConnection.h"
 #include "Subsystems/GameInstanceSubsystem.h"
 #include "Runtime/Launch/Resources/Version.h"
 #if (ENGINE_MAJOR_VERSION == 4 && ENGINE_MINOR_VERSION < 27)
@@ -51,6 +52,20 @@ public:
 
 	UFUNCTION(BlueprintCallable, Category = "ApiGear|TbSimple|EmptyInterface")
 	void UseConnection(TScriptInterface<class IApiGearConnection> InConnection);
+
+	/**
+	 * Used when the interface client changes subscription status:
+	 * either is linked(ready to use) with server side (true) or it is in unlinked state (false).
+	 */
+	UPROPERTY(BlueprintAssignable, Category = "ApiGear|TbSimple|EmptyInterface|Remote", DisplayName = "Subscription Status Changed")
+	FApiGearRemoteApiSubscriptionStatusChangedDelegate _SubscriptionStatusChanged;
+
+	/**
+	 * Informs about the subscription state of the interface client.
+	 * @return true if the client is subscribed (plugged in the network) and ready to send and receive messages or false if the server cannot be reached.
+	 */
+	UFUNCTION(BlueprintCallable, Category = "ApiGear|TbSimple|EmptyInterface|Remote")
+	bool _IsSubscribed() const;
 
 private:
 	void applyState(const nlohmann::json& fields);

--- a/goldenmaster/Plugins/TbSimple/Source/TbSimple/Public/Generated/OLink/TbSimpleNoOperationsInterfaceOLinkClient.h
+++ b/goldenmaster/Plugins/TbSimple/Source/TbSimple/Public/Generated/OLink/TbSimpleNoOperationsInterfaceOLinkClient.h
@@ -21,6 +21,7 @@ THIRD_PARTY_INCLUDES_START
 #include "olink/clientnode.h"
 THIRD_PARTY_INCLUDES_END
 #include "unrealolinksink.h"
+#include "ApiGearConnection.h"
 #include "Subsystems/GameInstanceSubsystem.h"
 #include "Runtime/Launch/Resources/Version.h"
 #if (ENGINE_MAJOR_VERSION == 4 && ENGINE_MINOR_VERSION < 27)
@@ -59,6 +60,20 @@ public:
 
 	UFUNCTION(BlueprintCallable, Category = "ApiGear|TbSimple|NoOperationsInterface")
 	void UseConnection(TScriptInterface<class IApiGearConnection> InConnection);
+
+	/**
+	 * Used when the interface client changes subscription status:
+	 * either is linked(ready to use) with server side (true) or it is in unlinked state (false).
+	 */
+	UPROPERTY(BlueprintAssignable, Category = "ApiGear|TbSimple|NoOperationsInterface|Remote", DisplayName = "Subscription Status Changed")
+	FApiGearRemoteApiSubscriptionStatusChangedDelegate _SubscriptionStatusChanged;
+
+	/**
+	 * Informs about the subscription state of the interface client.
+	 * @return true if the client is subscribed (plugged in the network) and ready to send and receive messages or false if the server cannot be reached.
+	 */
+	UFUNCTION(BlueprintCallable, Category = "ApiGear|TbSimple|NoOperationsInterface|Remote")
+	bool _IsSubscribed() const;
 
 private:
 	void applyState(const nlohmann::json& fields);

--- a/goldenmaster/Plugins/TbSimple/Source/TbSimple/Public/Generated/OLink/TbSimpleNoPropertiesInterfaceOLinkClient.h
+++ b/goldenmaster/Plugins/TbSimple/Source/TbSimple/Public/Generated/OLink/TbSimpleNoPropertiesInterfaceOLinkClient.h
@@ -21,6 +21,7 @@ THIRD_PARTY_INCLUDES_START
 #include "olink/clientnode.h"
 THIRD_PARTY_INCLUDES_END
 #include "unrealolinksink.h"
+#include "ApiGearConnection.h"
 #include "Subsystems/GameInstanceSubsystem.h"
 #include "Runtime/Launch/Resources/Version.h"
 #if (ENGINE_MAJOR_VERSION == 4 && ENGINE_MINOR_VERSION < 27)
@@ -54,6 +55,20 @@ public:
 
 	UFUNCTION(BlueprintCallable, Category = "ApiGear|TbSimple|NoPropertiesInterface")
 	void UseConnection(TScriptInterface<class IApiGearConnection> InConnection);
+
+	/**
+	 * Used when the interface client changes subscription status:
+	 * either is linked(ready to use) with server side (true) or it is in unlinked state (false).
+	 */
+	UPROPERTY(BlueprintAssignable, Category = "ApiGear|TbSimple|NoPropertiesInterface|Remote", DisplayName = "Subscription Status Changed")
+	FApiGearRemoteApiSubscriptionStatusChangedDelegate _SubscriptionStatusChanged;
+
+	/**
+	 * Informs about the subscription state of the interface client.
+	 * @return true if the client is subscribed (plugged in the network) and ready to send and receive messages or false if the server cannot be reached.
+	 */
+	UFUNCTION(BlueprintCallable, Category = "ApiGear|TbSimple|NoPropertiesInterface|Remote")
+	bool _IsSubscribed() const;
 
 private:
 	void applyState(const nlohmann::json& fields);

--- a/goldenmaster/Plugins/TbSimple/Source/TbSimple/Public/Generated/OLink/TbSimpleNoSignalsInterfaceOLinkClient.h
+++ b/goldenmaster/Plugins/TbSimple/Source/TbSimple/Public/Generated/OLink/TbSimpleNoSignalsInterfaceOLinkClient.h
@@ -21,6 +21,7 @@ THIRD_PARTY_INCLUDES_START
 #include "olink/clientnode.h"
 THIRD_PARTY_INCLUDES_END
 #include "unrealolinksink.h"
+#include "ApiGearConnection.h"
 #include "Subsystems/GameInstanceSubsystem.h"
 #include "Runtime/Launch/Resources/Version.h"
 #if (ENGINE_MAJOR_VERSION == 4 && ENGINE_MINOR_VERSION < 27)
@@ -62,6 +63,20 @@ public:
 
 	UFUNCTION(BlueprintCallable, Category = "ApiGear|TbSimple|NoSignalsInterface")
 	void UseConnection(TScriptInterface<class IApiGearConnection> InConnection);
+
+	/**
+	 * Used when the interface client changes subscription status:
+	 * either is linked(ready to use) with server side (true) or it is in unlinked state (false).
+	 */
+	UPROPERTY(BlueprintAssignable, Category = "ApiGear|TbSimple|NoSignalsInterface|Remote", DisplayName = "Subscription Status Changed")
+	FApiGearRemoteApiSubscriptionStatusChangedDelegate _SubscriptionStatusChanged;
+
+	/**
+	 * Informs about the subscription state of the interface client.
+	 * @return true if the client is subscribed (plugged in the network) and ready to send and receive messages or false if the server cannot be reached.
+	 */
+	UFUNCTION(BlueprintCallable, Category = "ApiGear|TbSimple|NoSignalsInterface|Remote")
+	bool _IsSubscribed() const;
 
 private:
 	void applyState(const nlohmann::json& fields);

--- a/goldenmaster/Plugins/TbSimple/Source/TbSimple/Public/Generated/OLink/TbSimpleSimpleArrayInterfaceOLinkClient.h
+++ b/goldenmaster/Plugins/TbSimple/Source/TbSimple/Public/Generated/OLink/TbSimpleSimpleArrayInterfaceOLinkClient.h
@@ -21,6 +21,7 @@ THIRD_PARTY_INCLUDES_START
 #include "olink/clientnode.h"
 THIRD_PARTY_INCLUDES_END
 #include "unrealolinksink.h"
+#include "ApiGearConnection.h"
 #include "Subsystems/GameInstanceSubsystem.h"
 #include "Runtime/Launch/Resources/Version.h"
 #if (ENGINE_MAJOR_VERSION == 4 && ENGINE_MINOR_VERSION < 27)
@@ -92,6 +93,20 @@ public:
 
 	UFUNCTION(BlueprintCallable, Category = "ApiGear|TbSimple|SimpleArrayInterface")
 	void UseConnection(TScriptInterface<class IApiGearConnection> InConnection);
+
+	/**
+	 * Used when the interface client changes subscription status:
+	 * either is linked(ready to use) with server side (true) or it is in unlinked state (false).
+	 */
+	UPROPERTY(BlueprintAssignable, Category = "ApiGear|TbSimple|SimpleArrayInterface|Remote", DisplayName = "Subscription Status Changed")
+	FApiGearRemoteApiSubscriptionStatusChangedDelegate _SubscriptionStatusChanged;
+
+	/**
+	 * Informs about the subscription state of the interface client.
+	 * @return true if the client is subscribed (plugged in the network) and ready to send and receive messages or false if the server cannot be reached.
+	 */
+	UFUNCTION(BlueprintCallable, Category = "ApiGear|TbSimple|SimpleArrayInterface|Remote")
+	bool _IsSubscribed() const;
 
 private:
 	void applyState(const nlohmann::json& fields);

--- a/goldenmaster/Plugins/TbSimple/Source/TbSimple/Public/Generated/OLink/TbSimpleSimpleInterfaceOLinkClient.h
+++ b/goldenmaster/Plugins/TbSimple/Source/TbSimple/Public/Generated/OLink/TbSimpleSimpleInterfaceOLinkClient.h
@@ -21,6 +21,7 @@ THIRD_PARTY_INCLUDES_START
 #include "olink/clientnode.h"
 THIRD_PARTY_INCLUDES_END
 #include "unrealolinksink.h"
+#include "ApiGearConnection.h"
 #include "Subsystems/GameInstanceSubsystem.h"
 #include "Runtime/Launch/Resources/Version.h"
 #if (ENGINE_MAJOR_VERSION == 4 && ENGINE_MINOR_VERSION < 27)
@@ -96,6 +97,20 @@ public:
 
 	UFUNCTION(BlueprintCallable, Category = "ApiGear|TbSimple|SimpleInterface")
 	void UseConnection(TScriptInterface<class IApiGearConnection> InConnection);
+
+	/**
+	 * Used when the interface client changes subscription status:
+	 * either is linked(ready to use) with server side (true) or it is in unlinked state (false).
+	 */
+	UPROPERTY(BlueprintAssignable, Category = "ApiGear|TbSimple|SimpleInterface|Remote", DisplayName = "Subscription Status Changed")
+	FApiGearRemoteApiSubscriptionStatusChangedDelegate _SubscriptionStatusChanged;
+
+	/**
+	 * Informs about the subscription state of the interface client.
+	 * @return true if the client is subscribed (plugged in the network) and ready to send and receive messages or false if the server cannot be reached.
+	 */
+	UFUNCTION(BlueprintCallable, Category = "ApiGear|TbSimple|SimpleInterface|Remote")
+	bool _IsSubscribed() const;
 
 private:
 	void applyState(const nlohmann::json& fields);

--- a/goldenmaster/Plugins/Testbed1/Source/Testbed1/Private/Generated/OLink/Testbed1StructArrayInterfaceOLinkClient.cpp
+++ b/goldenmaster/Plugins/Testbed1/Source/Testbed1/Private/Generated/OLink/Testbed1StructArrayInterfaceOLinkClient.cpp
@@ -69,6 +69,11 @@ void UTestbed1StructArrayInterfaceOLinkClient::Initialize(FSubsystemCollectionBa
 {
 	Super::Initialize(Collection);
 
+	m_sink->setOnInitCallback([this]()
+		{ _SubscriptionStatusChanged.Broadcast(true); });
+	m_sink->setOnReleaseCallback([this]()
+		{ _SubscriptionStatusChanged.Broadcast(false); });
+
 	FUnrealOLinkSink::FPropertyChangedFunc PropertyChangedFunc = [this](const nlohmann::json& props)
 	{
 		this->applyState(props);
@@ -102,6 +107,8 @@ void UTestbed1StructArrayInterfaceOLinkClient::Deinitialize()
 	// tell the sink that we are gone and should not try to be invoked
 	m_sink->resetOnPropertyChangedCallback();
 	m_sink->resetOnSignalEmittedCallback();
+	m_sink->resetOnInitCallback();
+	m_sink->resetOnReleaseCallback();
 
 	if (Connection.GetObject())
 	{
@@ -376,6 +383,11 @@ FTestbed1StructBool UTestbed1StructArrayInterfaceOLinkClient::FuncString_Impleme
 		});
 
 	return Promise.GetFuture().Get();
+}
+
+bool UTestbed1StructArrayInterfaceOLinkClient::_IsSubscribed() const
+{
+	return m_sink->IsReady();
 }
 
 void UTestbed1StructArrayInterfaceOLinkClient::applyState(const nlohmann::json& fields)

--- a/goldenmaster/Plugins/Testbed1/Source/Testbed1/Private/Generated/OLink/Testbed1StructInterfaceOLinkClient.cpp
+++ b/goldenmaster/Plugins/Testbed1/Source/Testbed1/Private/Generated/OLink/Testbed1StructInterfaceOLinkClient.cpp
@@ -69,6 +69,11 @@ void UTestbed1StructInterfaceOLinkClient::Initialize(FSubsystemCollectionBase& C
 {
 	Super::Initialize(Collection);
 
+	m_sink->setOnInitCallback([this]()
+		{ _SubscriptionStatusChanged.Broadcast(true); });
+	m_sink->setOnReleaseCallback([this]()
+		{ _SubscriptionStatusChanged.Broadcast(false); });
+
 	FUnrealOLinkSink::FPropertyChangedFunc PropertyChangedFunc = [this](const nlohmann::json& props)
 	{
 		this->applyState(props);
@@ -102,6 +107,8 @@ void UTestbed1StructInterfaceOLinkClient::Deinitialize()
 	// tell the sink that we are gone and should not try to be invoked
 	m_sink->resetOnPropertyChangedCallback();
 	m_sink->resetOnSignalEmittedCallback();
+	m_sink->resetOnInitCallback();
+	m_sink->resetOnReleaseCallback();
 
 	if (Connection.GetObject())
 	{
@@ -376,6 +383,11 @@ FTestbed1StructString UTestbed1StructInterfaceOLinkClient::FuncString_Implementa
 		});
 
 	return Promise.GetFuture().Get();
+}
+
+bool UTestbed1StructInterfaceOLinkClient::_IsSubscribed() const
+{
+	return m_sink->IsReady();
 }
 
 void UTestbed1StructInterfaceOLinkClient::applyState(const nlohmann::json& fields)

--- a/goldenmaster/Plugins/Testbed1/Source/Testbed1/Public/Generated/OLink/Testbed1StructArrayInterfaceOLinkClient.h
+++ b/goldenmaster/Plugins/Testbed1/Source/Testbed1/Public/Generated/OLink/Testbed1StructArrayInterfaceOLinkClient.h
@@ -21,6 +21,7 @@ THIRD_PARTY_INCLUDES_START
 #include "olink/clientnode.h"
 THIRD_PARTY_INCLUDES_END
 #include "unrealolinksink.h"
+#include "ApiGearConnection.h"
 #include "Subsystems/GameInstanceSubsystem.h"
 #include "Runtime/Launch/Resources/Version.h"
 #if (ENGINE_MAJOR_VERSION == 4 && ENGINE_MINOR_VERSION < 27)
@@ -72,6 +73,20 @@ public:
 
 	UFUNCTION(BlueprintCallable, Category = "ApiGear|Testbed1|StructArrayInterface")
 	void UseConnection(TScriptInterface<class IApiGearConnection> InConnection);
+
+	/**
+	 * Used when the interface client changes subscription status:
+	 * either is linked(ready to use) with server side (true) or it is in unlinked state (false).
+	 */
+	UPROPERTY(BlueprintAssignable, Category = "ApiGear|Testbed1|StructArrayInterface|Remote", DisplayName = "Subscription Status Changed")
+	FApiGearRemoteApiSubscriptionStatusChangedDelegate _SubscriptionStatusChanged;
+
+	/**
+	 * Informs about the subscription state of the interface client.
+	 * @return true if the client is subscribed (plugged in the network) and ready to send and receive messages or false if the server cannot be reached.
+	 */
+	UFUNCTION(BlueprintCallable, Category = "ApiGear|Testbed1|StructArrayInterface|Remote")
+	bool _IsSubscribed() const;
 
 private:
 	void applyState(const nlohmann::json& fields);

--- a/goldenmaster/Plugins/Testbed1/Source/Testbed1/Public/Generated/OLink/Testbed1StructInterfaceOLinkClient.h
+++ b/goldenmaster/Plugins/Testbed1/Source/Testbed1/Public/Generated/OLink/Testbed1StructInterfaceOLinkClient.h
@@ -21,6 +21,7 @@ THIRD_PARTY_INCLUDES_START
 #include "olink/clientnode.h"
 THIRD_PARTY_INCLUDES_END
 #include "unrealolinksink.h"
+#include "ApiGearConnection.h"
 #include "Subsystems/GameInstanceSubsystem.h"
 #include "Runtime/Launch/Resources/Version.h"
 #if (ENGINE_MAJOR_VERSION == 4 && ENGINE_MINOR_VERSION < 27)
@@ -72,6 +73,20 @@ public:
 
 	UFUNCTION(BlueprintCallable, Category = "ApiGear|Testbed1|StructInterface")
 	void UseConnection(TScriptInterface<class IApiGearConnection> InConnection);
+
+	/**
+	 * Used when the interface client changes subscription status:
+	 * either is linked(ready to use) with server side (true) or it is in unlinked state (false).
+	 */
+	UPROPERTY(BlueprintAssignable, Category = "ApiGear|Testbed1|StructInterface|Remote", DisplayName = "Subscription Status Changed")
+	FApiGearRemoteApiSubscriptionStatusChangedDelegate _SubscriptionStatusChanged;
+
+	/**
+	 * Informs about the subscription state of the interface client.
+	 * @return true if the client is subscribed (plugged in the network) and ready to send and receive messages or false if the server cannot be reached.
+	 */
+	UFUNCTION(BlueprintCallable, Category = "ApiGear|Testbed1|StructInterface|Remote")
+	bool _IsSubscribed() const;
 
 private:
 	void applyState(const nlohmann::json& fields);

--- a/goldenmaster/Plugins/Testbed2/Source/Testbed2/Private/Generated/OLink/Testbed2ManyParamInterfaceOLinkClient.cpp
+++ b/goldenmaster/Plugins/Testbed2/Source/Testbed2/Private/Generated/OLink/Testbed2ManyParamInterfaceOLinkClient.cpp
@@ -69,6 +69,11 @@ void UTestbed2ManyParamInterfaceOLinkClient::Initialize(FSubsystemCollectionBase
 {
 	Super::Initialize(Collection);
 
+	m_sink->setOnInitCallback([this]()
+		{ _SubscriptionStatusChanged.Broadcast(true); });
+	m_sink->setOnReleaseCallback([this]()
+		{ _SubscriptionStatusChanged.Broadcast(false); });
+
 	FUnrealOLinkSink::FPropertyChangedFunc PropertyChangedFunc = [this](const nlohmann::json& props)
 	{
 		this->applyState(props);
@@ -102,6 +107,8 @@ void UTestbed2ManyParamInterfaceOLinkClient::Deinitialize()
 	// tell the sink that we are gone and should not try to be invoked
 	m_sink->resetOnPropertyChangedCallback();
 	m_sink->resetOnSignalEmittedCallback();
+	m_sink->resetOnInitCallback();
+	m_sink->resetOnReleaseCallback();
 
 	if (Connection.GetObject())
 	{
@@ -376,6 +383,11 @@ int32 UTestbed2ManyParamInterfaceOLinkClient::Func4_Implementation(int32 Param1,
 		});
 
 	return Promise.GetFuture().Get();
+}
+
+bool UTestbed2ManyParamInterfaceOLinkClient::_IsSubscribed() const
+{
+	return m_sink->IsReady();
 }
 
 void UTestbed2ManyParamInterfaceOLinkClient::applyState(const nlohmann::json& fields)

--- a/goldenmaster/Plugins/Testbed2/Source/Testbed2/Private/Generated/OLink/Testbed2NestedStruct1InterfaceOLinkClient.cpp
+++ b/goldenmaster/Plugins/Testbed2/Source/Testbed2/Private/Generated/OLink/Testbed2NestedStruct1InterfaceOLinkClient.cpp
@@ -66,6 +66,11 @@ void UTestbed2NestedStruct1InterfaceOLinkClient::Initialize(FSubsystemCollection
 {
 	Super::Initialize(Collection);
 
+	m_sink->setOnInitCallback([this]()
+		{ _SubscriptionStatusChanged.Broadcast(true); });
+	m_sink->setOnReleaseCallback([this]()
+		{ _SubscriptionStatusChanged.Broadcast(false); });
+
 	FUnrealOLinkSink::FPropertyChangedFunc PropertyChangedFunc = [this](const nlohmann::json& props)
 	{
 		this->applyState(props);
@@ -99,6 +104,8 @@ void UTestbed2NestedStruct1InterfaceOLinkClient::Deinitialize()
 	// tell the sink that we are gone and should not try to be invoked
 	m_sink->resetOnPropertyChangedCallback();
 	m_sink->resetOnSignalEmittedCallback();
+	m_sink->resetOnInitCallback();
+	m_sink->resetOnReleaseCallback();
 
 	if (Connection.GetObject())
 	{
@@ -193,6 +200,11 @@ FTestbed2NestedStruct1 UTestbed2NestedStruct1InterfaceOLinkClient::Func1_Impleme
 		});
 
 	return Promise.GetFuture().Get();
+}
+
+bool UTestbed2NestedStruct1InterfaceOLinkClient::_IsSubscribed() const
+{
+	return m_sink->IsReady();
 }
 
 void UTestbed2NestedStruct1InterfaceOLinkClient::applyState(const nlohmann::json& fields)

--- a/goldenmaster/Plugins/Testbed2/Source/Testbed2/Private/Generated/OLink/Testbed2NestedStruct2InterfaceOLinkClient.cpp
+++ b/goldenmaster/Plugins/Testbed2/Source/Testbed2/Private/Generated/OLink/Testbed2NestedStruct2InterfaceOLinkClient.cpp
@@ -67,6 +67,11 @@ void UTestbed2NestedStruct2InterfaceOLinkClient::Initialize(FSubsystemCollection
 {
 	Super::Initialize(Collection);
 
+	m_sink->setOnInitCallback([this]()
+		{ _SubscriptionStatusChanged.Broadcast(true); });
+	m_sink->setOnReleaseCallback([this]()
+		{ _SubscriptionStatusChanged.Broadcast(false); });
+
 	FUnrealOLinkSink::FPropertyChangedFunc PropertyChangedFunc = [this](const nlohmann::json& props)
 	{
 		this->applyState(props);
@@ -100,6 +105,8 @@ void UTestbed2NestedStruct2InterfaceOLinkClient::Deinitialize()
 	// tell the sink that we are gone and should not try to be invoked
 	m_sink->resetOnPropertyChangedCallback();
 	m_sink->resetOnSignalEmittedCallback();
+	m_sink->resetOnInitCallback();
+	m_sink->resetOnReleaseCallback();
 
 	if (Connection.GetObject())
 	{
@@ -254,6 +261,11 @@ FTestbed2NestedStruct1 UTestbed2NestedStruct2InterfaceOLinkClient::Func2_Impleme
 		});
 
 	return Promise.GetFuture().Get();
+}
+
+bool UTestbed2NestedStruct2InterfaceOLinkClient::_IsSubscribed() const
+{
+	return m_sink->IsReady();
 }
 
 void UTestbed2NestedStruct2InterfaceOLinkClient::applyState(const nlohmann::json& fields)

--- a/goldenmaster/Plugins/Testbed2/Source/Testbed2/Private/Generated/OLink/Testbed2NestedStruct3InterfaceOLinkClient.cpp
+++ b/goldenmaster/Plugins/Testbed2/Source/Testbed2/Private/Generated/OLink/Testbed2NestedStruct3InterfaceOLinkClient.cpp
@@ -68,6 +68,11 @@ void UTestbed2NestedStruct3InterfaceOLinkClient::Initialize(FSubsystemCollection
 {
 	Super::Initialize(Collection);
 
+	m_sink->setOnInitCallback([this]()
+		{ _SubscriptionStatusChanged.Broadcast(true); });
+	m_sink->setOnReleaseCallback([this]()
+		{ _SubscriptionStatusChanged.Broadcast(false); });
+
 	FUnrealOLinkSink::FPropertyChangedFunc PropertyChangedFunc = [this](const nlohmann::json& props)
 	{
 		this->applyState(props);
@@ -101,6 +106,8 @@ void UTestbed2NestedStruct3InterfaceOLinkClient::Deinitialize()
 	// tell the sink that we are gone and should not try to be invoked
 	m_sink->resetOnPropertyChangedCallback();
 	m_sink->resetOnSignalEmittedCallback();
+	m_sink->resetOnInitCallback();
+	m_sink->resetOnReleaseCallback();
 
 	if (Connection.GetObject())
 	{
@@ -315,6 +322,11 @@ FTestbed2NestedStruct1 UTestbed2NestedStruct3InterfaceOLinkClient::Func3_Impleme
 		});
 
 	return Promise.GetFuture().Get();
+}
+
+bool UTestbed2NestedStruct3InterfaceOLinkClient::_IsSubscribed() const
+{
+	return m_sink->IsReady();
 }
 
 void UTestbed2NestedStruct3InterfaceOLinkClient::applyState(const nlohmann::json& fields)

--- a/goldenmaster/Plugins/Testbed2/Source/Testbed2/Public/Generated/OLink/Testbed2ManyParamInterfaceOLinkClient.h
+++ b/goldenmaster/Plugins/Testbed2/Source/Testbed2/Public/Generated/OLink/Testbed2ManyParamInterfaceOLinkClient.h
@@ -21,6 +21,7 @@ THIRD_PARTY_INCLUDES_START
 #include "olink/clientnode.h"
 THIRD_PARTY_INCLUDES_END
 #include "unrealolinksink.h"
+#include "ApiGearConnection.h"
 #include "Subsystems/GameInstanceSubsystem.h"
 #include "Runtime/Launch/Resources/Version.h"
 #if (ENGINE_MAJOR_VERSION == 4 && ENGINE_MINOR_VERSION < 27)
@@ -72,6 +73,20 @@ public:
 
 	UFUNCTION(BlueprintCallable, Category = "ApiGear|Testbed2|ManyParamInterface")
 	void UseConnection(TScriptInterface<class IApiGearConnection> InConnection);
+
+	/**
+	 * Used when the interface client changes subscription status:
+	 * either is linked(ready to use) with server side (true) or it is in unlinked state (false).
+	 */
+	UPROPERTY(BlueprintAssignable, Category = "ApiGear|Testbed2|ManyParamInterface|Remote", DisplayName = "Subscription Status Changed")
+	FApiGearRemoteApiSubscriptionStatusChangedDelegate _SubscriptionStatusChanged;
+
+	/**
+	 * Informs about the subscription state of the interface client.
+	 * @return true if the client is subscribed (plugged in the network) and ready to send and receive messages or false if the server cannot be reached.
+	 */
+	UFUNCTION(BlueprintCallable, Category = "ApiGear|Testbed2|ManyParamInterface|Remote")
+	bool _IsSubscribed() const;
 
 private:
 	void applyState(const nlohmann::json& fields);

--- a/goldenmaster/Plugins/Testbed2/Source/Testbed2/Public/Generated/OLink/Testbed2NestedStruct1InterfaceOLinkClient.h
+++ b/goldenmaster/Plugins/Testbed2/Source/Testbed2/Public/Generated/OLink/Testbed2NestedStruct1InterfaceOLinkClient.h
@@ -21,6 +21,7 @@ THIRD_PARTY_INCLUDES_START
 #include "olink/clientnode.h"
 THIRD_PARTY_INCLUDES_END
 #include "unrealolinksink.h"
+#include "ApiGearConnection.h"
 #include "Subsystems/GameInstanceSubsystem.h"
 #include "Runtime/Launch/Resources/Version.h"
 #if (ENGINE_MAJOR_VERSION == 4 && ENGINE_MINOR_VERSION < 27)
@@ -57,6 +58,20 @@ public:
 
 	UFUNCTION(BlueprintCallable, Category = "ApiGear|Testbed2|NestedStruct1Interface")
 	void UseConnection(TScriptInterface<class IApiGearConnection> InConnection);
+
+	/**
+	 * Used when the interface client changes subscription status:
+	 * either is linked(ready to use) with server side (true) or it is in unlinked state (false).
+	 */
+	UPROPERTY(BlueprintAssignable, Category = "ApiGear|Testbed2|NestedStruct1Interface|Remote", DisplayName = "Subscription Status Changed")
+	FApiGearRemoteApiSubscriptionStatusChangedDelegate _SubscriptionStatusChanged;
+
+	/**
+	 * Informs about the subscription state of the interface client.
+	 * @return true if the client is subscribed (plugged in the network) and ready to send and receive messages or false if the server cannot be reached.
+	 */
+	UFUNCTION(BlueprintCallable, Category = "ApiGear|Testbed2|NestedStruct1Interface|Remote")
+	bool _IsSubscribed() const;
 
 private:
 	void applyState(const nlohmann::json& fields);

--- a/goldenmaster/Plugins/Testbed2/Source/Testbed2/Public/Generated/OLink/Testbed2NestedStruct2InterfaceOLinkClient.h
+++ b/goldenmaster/Plugins/Testbed2/Source/Testbed2/Public/Generated/OLink/Testbed2NestedStruct2InterfaceOLinkClient.h
@@ -21,6 +21,7 @@ THIRD_PARTY_INCLUDES_START
 #include "olink/clientnode.h"
 THIRD_PARTY_INCLUDES_END
 #include "unrealolinksink.h"
+#include "ApiGearConnection.h"
 #include "Subsystems/GameInstanceSubsystem.h"
 #include "Runtime/Launch/Resources/Version.h"
 #if (ENGINE_MAJOR_VERSION == 4 && ENGINE_MINOR_VERSION < 27)
@@ -62,6 +63,20 @@ public:
 
 	UFUNCTION(BlueprintCallable, Category = "ApiGear|Testbed2|NestedStruct2Interface")
 	void UseConnection(TScriptInterface<class IApiGearConnection> InConnection);
+
+	/**
+	 * Used when the interface client changes subscription status:
+	 * either is linked(ready to use) with server side (true) or it is in unlinked state (false).
+	 */
+	UPROPERTY(BlueprintAssignable, Category = "ApiGear|Testbed2|NestedStruct2Interface|Remote", DisplayName = "Subscription Status Changed")
+	FApiGearRemoteApiSubscriptionStatusChangedDelegate _SubscriptionStatusChanged;
+
+	/**
+	 * Informs about the subscription state of the interface client.
+	 * @return true if the client is subscribed (plugged in the network) and ready to send and receive messages or false if the server cannot be reached.
+	 */
+	UFUNCTION(BlueprintCallable, Category = "ApiGear|Testbed2|NestedStruct2Interface|Remote")
+	bool _IsSubscribed() const;
 
 private:
 	void applyState(const nlohmann::json& fields);

--- a/goldenmaster/Plugins/Testbed2/Source/Testbed2/Public/Generated/OLink/Testbed2NestedStruct3InterfaceOLinkClient.h
+++ b/goldenmaster/Plugins/Testbed2/Source/Testbed2/Public/Generated/OLink/Testbed2NestedStruct3InterfaceOLinkClient.h
@@ -21,6 +21,7 @@ THIRD_PARTY_INCLUDES_START
 #include "olink/clientnode.h"
 THIRD_PARTY_INCLUDES_END
 #include "unrealolinksink.h"
+#include "ApiGearConnection.h"
 #include "Subsystems/GameInstanceSubsystem.h"
 #include "Runtime/Launch/Resources/Version.h"
 #if (ENGINE_MAJOR_VERSION == 4 && ENGINE_MINOR_VERSION < 27)
@@ -67,6 +68,20 @@ public:
 
 	UFUNCTION(BlueprintCallable, Category = "ApiGear|Testbed2|NestedStruct3Interface")
 	void UseConnection(TScriptInterface<class IApiGearConnection> InConnection);
+
+	/**
+	 * Used when the interface client changes subscription status:
+	 * either is linked(ready to use) with server side (true) or it is in unlinked state (false).
+	 */
+	UPROPERTY(BlueprintAssignable, Category = "ApiGear|Testbed2|NestedStruct3Interface|Remote", DisplayName = "Subscription Status Changed")
+	FApiGearRemoteApiSubscriptionStatusChangedDelegate _SubscriptionStatusChanged;
+
+	/**
+	 * Informs about the subscription state of the interface client.
+	 * @return true if the client is subscribed (plugged in the network) and ready to send and receive messages or false if the server cannot be reached.
+	 */
+	UFUNCTION(BlueprintCallable, Category = "ApiGear|Testbed2|NestedStruct3Interface|Remote")
+	bool _IsSubscribed() const;
 
 private:
 	void applyState(const nlohmann::json& fields);

--- a/templates/ApiGear/Source/ApiGear/Public/ApiGearConnection.h
+++ b/templates/ApiGear/Source/ApiGear/Public/ApiGearConnection.h
@@ -2,7 +2,6 @@
 
 #include "UObject/Interface.h"
 #include "CoreMinimal.h"
-#include "Containers/Ticker.h"
 #include "UObject/NoExportTypes.h"
 #include "ApiGearConnection.generated.h"
 
@@ -19,8 +18,18 @@ enum class EApiGearConnectionState : uint8
 	Connected UMETA(Displayname = "Connected")
 };
 
+///  Used when Network Layer Connection changes its state to connected(true) or any other connection state (false).
 DECLARE_MULTICAST_DELEGATE_OneParam(FApiGearConnectionIsConnectedDelegate, bool);
+///  Used when Network Layer Connection changes its state.
 DECLARE_MULTICAST_DELEGATE_OneParam(FApiGearConnectionStateChangedDelegate, EApiGearConnectionState);
+/**
+ * @brief Used when the interface client changes its subscription status:
+ * either is plugged in the network and ready to use with protocol of your choice (true)
+ * or it won't be able to properly communicate with server side (false).
+ * An established network connection (ConnectionIsConnectedDelegate with true parameter) is often necessary, but not sufficient (depending on your setup and used protocol)
+ * for the Api client implementation to be used.
+ */
+DECLARE_DYNAMIC_MULTICAST_DELEGATE_OneParam(FApiGearRemoteApiSubscriptionStatusChangedDelegate, bool, IsSubscribed);
 
 /** 
  * @brief An interface for all connections meant to be used by ApiGear

--- a/templates/ApiGear/Source/ApiGearOLink/Private/unrealolinksink.cpp
+++ b/templates/ApiGear/Source/ApiGearOLink/Private/unrealolinksink.cpp
@@ -34,6 +34,11 @@ void FUnrealOLinkSink::olinkOnPropertyChanged(const std::string& propertyId, con
 void FUnrealOLinkSink::olinkOnInit(const std::string& objectId, const nlohmann::json& props, ApiGear::ObjectLink::IClientNode* node)
 {
 	m_node = node;
+	if (OnInitCallback)
+	{
+		OnInitCallback();
+	}
+
 	if (PropertyChangedFunc)
 	{
 		PropertyChangedFunc(props);
@@ -42,6 +47,10 @@ void FUnrealOLinkSink::olinkOnInit(const std::string& objectId, const nlohmann::
 
 void FUnrealOLinkSink::olinkOnRelease()
 {
+	if (OnReleaseCallback)
+	{
+		OnReleaseCallback();
+	}
 	m_node = nullptr;
 }
 
@@ -55,7 +64,27 @@ void FUnrealOLinkSink::setOnSignalEmittedCallback(FSignalEmittedFunc func)
 	SignalEmittedFunc = func;
 }
 
+void FUnrealOLinkSink::setOnInitCallback(FInitializedFromSourceCallback func)
+{
+	OnInitCallback = func;
+}
+
+void FUnrealOLinkSink::setOnReleaseCallback(FSourceConnectionReleasedCallback func)
+{
+	OnReleaseCallback = func;
+}
+
 // reset callbacks
+void FUnrealOLinkSink::resetOnInitCallback()
+{
+	OnInitCallback = nullptr;
+}
+
+void FUnrealOLinkSink::resetOnReleaseCallback()
+{
+	OnReleaseCallback = nullptr;
+}
+
 void FUnrealOLinkSink::resetOnPropertyChangedCallback()
 {
 	PropertyChangedFunc = nullptr;

--- a/templates/ApiGear/Source/ApiGearOLink/Public/unrealolinksink.h
+++ b/templates/ApiGear/Source/ApiGearOLink/Public/unrealolinksink.h
@@ -24,11 +24,20 @@ public:
 	/** A type of function for handling signal message*/
 	using FSignalEmittedFunc = TFunction<void(const std::string& signalName, const nlohmann::json& args)>;
 
+	/** Type of function for initialized from source and ready to use callback */
+	using FInitializedFromSourceCallback = TFunction<void()>;
+	/** Type of function for unlinked from source callback */
+	using FSourceConnectionReleasedCallback = TFunction<void()>;
+
 	// set callbacks
+	void setOnInitCallback(FInitializedFromSourceCallback func);
+	void setOnReleaseCallback(FSourceConnectionReleasedCallback func);
 	void setOnPropertyChangedCallback(FPropertyChangedFunc func);
 	void setOnSignalEmittedCallback(FSignalEmittedFunc func);
 
 	// reset callbacks
+	void resetOnInitCallback();
+	void resetOnReleaseCallback();
 	void resetOnPropertyChangedCallback();
 	void resetOnSignalEmittedCallback();
 
@@ -44,4 +53,10 @@ private:
 
 	// holds function which will be called on emitted signals
 	FSignalEmittedFunc SignalEmittedFunc;
+
+	// Stores callback executed when sink is linked.
+	FInitializedFromSourceCallback OnInitCallback;
+
+	// Stores callback executed when sink is unlinked.
+	FSourceConnectionReleasedCallback OnReleaseCallback;
 };

--- a/templates/module/Source/module/Private/Generated/OLink/olinkclient.cpp.tpl
+++ b/templates/module/Source/module/Private/Generated/OLink/olinkclient.cpp.tpl
@@ -71,6 +71,11 @@ void {{$Class}}::Initialize(FSubsystemCollectionBase& Collection)
 {
 	Super::Initialize(Collection);
 
+	m_sink->setOnInitCallback([this]()
+		{ _SubscriptionStatusChanged.Broadcast(true); });
+	m_sink->setOnReleaseCallback([this]()
+		{ _SubscriptionStatusChanged.Broadcast(false); });
+
 	FUnrealOLinkSink::FPropertyChangedFunc PropertyChangedFunc = [this](const nlohmann::json& props)
 	{
 		this->applyState(props);
@@ -104,6 +109,8 @@ void {{$Class}}::Deinitialize()
 	// tell the sink that we are gone and should not try to be invoked
 	m_sink->resetOnPropertyChangedCallback();
 	m_sink->resetOnSignalEmittedCallback();
+	m_sink->resetOnInitCallback();
+	m_sink->resetOnReleaseCallback();
 
 	if (Connection.GetObject())
 	{
@@ -226,6 +233,11 @@ void {{$Class}}::Set{{Camel .Name}}_Implementation({{ueParam "In" .}})
 	{{- end }}
 }
 {{- end }}
+
+bool {{$Class}}::_IsSubscribed() const
+{
+	return m_sink->IsReady();
+}
 
 void {{$Class}}::applyState(const nlohmann::json& fields)
 {

--- a/templates/module/Source/module/Public/Generated/OLink/olinkclient.h.tpl
+++ b/templates/module/Source/module/Public/Generated/OLink/olinkclient.h.tpl
@@ -16,6 +16,7 @@ THIRD_PARTY_INCLUDES_START
 #include "olink/clientnode.h"
 THIRD_PARTY_INCLUDES_END
 #include "unrealolinksink.h"
+#include "ApiGearConnection.h"
 #include "Subsystems/GameInstanceSubsystem.h"
 #include "Runtime/Launch/Resources/Version.h"
 #if (ENGINE_MAJOR_VERSION == 4 && ENGINE_MINOR_VERSION < 27)
@@ -61,6 +62,20 @@ public:
 
 	UFUNCTION(BlueprintCallable, Category = "ApiGear|{{$ModuleName}}|{{$IfaceName}}")
 	void UseConnection(TScriptInterface<class IApiGearConnection> InConnection);
+
+	/**
+	 * Used when the interface client changes subscription status:
+	 * either is linked(ready to use) with server side (true) or it is in unlinked state (false).
+	 */
+	UPROPERTY(BlueprintAssignable, Category = "ApiGear|{{$ModuleName}}|{{$IfaceName}}|Remote", DisplayName = "Subscription Status Changed")
+	FApiGearRemoteApiSubscriptionStatusChangedDelegate _SubscriptionStatusChanged;
+
+	/**
+	 * Informs about the subscription state of the interface client.
+	 * @return true if the client is subscribed (plugged in the network) and ready to send and receive messages or false if the server cannot be reached.
+	 */
+	UFUNCTION(BlueprintCallable, Category = "ApiGear|{{$ModuleName}}|{{$IfaceName}}|Remote")
+	bool _IsSubscribed() const;
 
 private:
 	void applyState(const nlohmann::json& fields);


### PR DESCRIPTION
When client gets init message from source it broadcast event that it is ready for which anyone can subscribe.
Also when client has its link released there is event. Also added a method to check if the client is ready to use (is linked).

<!-- 
Thanks for creating this pull request 🤗

Please make sure that the pull request is limited to one type (docs, feature, etc.) and keep it as small as possible. You can open multiple prs instead of opening a huge one.
-->

<!-- If this pull request closes an issue, please mention the issue number below -->
Closes # <!-- Issue # here -->

## 📑 Description
<!-- Add a brief description of the pr -->

<!-- You can also choose to add a list of changes and if they have been completed or not by using the markdown to-do list syntax
- [ ] Not Completed
- [x] Completed
-->

## ✅ Checks
<!-- Make sure your pr passes the CI checks and do check the following fields as needed - -->
- [ ] My pull request adheres to the code style of this project
- [ ] My code requires changes to the documentation
- [ ] I have updated the documentation as required
- [ ] All the tests have passed

## ℹ Additional Information
<!-- Any additional information like breaking changes, dependencies added, screenshots, comparisons between new and old behavior, etc. -->