### PR TITLE
Dphan/thread safe fixes

### DIFF
--- a/goldenmaster/Plugins/ApiGear/Source/ApiGear/Private/AbstractApiGearConnection.cpp
+++ b/goldenmaster/Plugins/ApiGear/Source/ApiGear/Private/AbstractApiGearConnection.cpp
@@ -2,18 +2,6 @@
 
 DEFINE_LOG_CATEGORY(LogApiGearConnection);
 
-#if (ENGINE_MAJOR_VERSION >= 5)
-FTSTicker& GetCoreTicker()
-{
-	return FTSTicker::GetCoreTicker();
-}
-#else
-FTicker& GetCoreTicker()
-{
-	return FTicker::GetCoreTicker();
-}
-#endif
-
 UAbstractApiGearConnection::UAbstractApiGearConnection(const FObjectInitializer& ObjectInitializer)
 	: Super(ObjectInitializer)
 	, bIsAutoReconnectEnabled(true)
@@ -37,7 +25,7 @@ void UAbstractApiGearConnection::OnConnected()
 	SetConnectionState(EApiGearConnectionState::Connected);
 
 	// disable reconnect ticker
-	GetCoreTicker().RemoveTicker(RetryTickerHandle);
+	ApiGearTicker::GetCoreTicker().RemoveTicker(RetryTickerHandle);
 
 	OnConnected_Implementation();
 }
@@ -50,7 +38,7 @@ void UAbstractApiGearConnection::OnDisconnected(bool bReconnect)
 
 	if (bIsAutoReconnectEnabled && bReconnect && !bStopReconnectingRequested)
 	{
-		RetryTickerHandle = GetCoreTicker().AddTicker(RetryTickerDelegate, 1.0f);
+		RetryTickerHandle = ApiGearTicker::GetCoreTicker().AddTicker(RetryTickerDelegate, 1.0f);
 	}
 
 	if (bStopReconnectingRequested)
@@ -85,7 +73,7 @@ void UAbstractApiGearConnection::StopReconnecting()
 {
 	bStopReconnectingRequested = true;
 	// disable reconnect ticker
-	GetCoreTicker().RemoveTicker(RetryTickerHandle);
+	ApiGearTicker::GetCoreTicker().RemoveTicker(RetryTickerHandle);
 }
 
 void UAbstractApiGearConnection::SetAutoReconnectEnabled(bool enabled)
@@ -93,7 +81,7 @@ void UAbstractApiGearConnection::SetAutoReconnectEnabled(bool enabled)
 	if (bIsAutoReconnectEnabled == true && enabled == false)
 	{
 		// disable reconnect ticker
-		GetCoreTicker().RemoveTicker(RetryTickerHandle);
+		ApiGearTicker::GetCoreTicker().RemoveTicker(RetryTickerHandle);
 	}
 	bIsAutoReconnectEnabled = enabled;
 }

--- a/goldenmaster/Plugins/ApiGear/Source/ApiGear/Public/AbstractApiGearConnection.h
+++ b/goldenmaster/Plugins/ApiGear/Source/ApiGear/Public/AbstractApiGearConnection.h
@@ -3,11 +3,9 @@
 #include "ApiGearConnection.h"
 #include "ApiGearTicker.h"
 #include "CoreMinimal.h"
-#include "Containers/Ticker.h"
 #include "UObject/NoExportTypes.h"
 #include "Runtime/Launch/Resources/Version.h"
 #include "AbstractApiGearConnection.generated.h"
-
 
 /**
  * @brief Abstract base for IApiGearConnection implementation

--- a/goldenmaster/Plugins/ApiGear/Source/ApiGear/Public/AbstractApiGearConnection.h
+++ b/goldenmaster/Plugins/ApiGear/Source/ApiGear/Public/AbstractApiGearConnection.h
@@ -1,11 +1,13 @@
 #pragma once
 
 #include "ApiGearConnection.h"
+#include "ApiGearTicker.h"
 #include "CoreMinimal.h"
 #include "Containers/Ticker.h"
 #include "UObject/NoExportTypes.h"
 #include "Runtime/Launch/Resources/Version.h"
 #include "AbstractApiGearConnection.generated.h"
+
 
 /**
  * @brief Abstract base for IApiGearConnection implementation
@@ -54,11 +56,8 @@ private:
 	bool bIsAutoReconnectEnabled;
 	bool bStopReconnectingRequested;
 
-#if (ENGINE_MAJOR_VERSION >= 5)
-	FTSTicker::FDelegateHandle RetryTickerHandle;
-#else
-	FDelegateHandle RetryTickerHandle;
-#endif
+	ApiGear::FDelegateHandle RetryTickerHandle;
+
 	FTickerDelegate RetryTickerDelegate;
 
 	EApiGearConnectionState ConnectionState;

--- a/goldenmaster/Plugins/ApiGear/Source/ApiGear/Public/ApiGearTicker.h
+++ b/goldenmaster/Plugins/ApiGear/Source/ApiGear/Public/ApiGearTicker.h
@@ -1,0 +1,30 @@
+// Copyright Epic Games, Inc. All Rights Reserved
+
+#pragma once
+#include "Runtime/Launch/Resources/Version.h"
+#include "Containers/Ticker.h"
+
+namespace ApiGear
+{
+#if (ENGINE_MAJOR_VERSION >= 5)
+using FDelegateHandle = FTSTicker::FDelegateHandle;
+#else
+using FDelegateHandle = ::FDelegateHandle;
+#endif
+} // namespace ApiGear
+
+class ApiGearTicker
+{
+public:
+#if (ENGINE_MAJOR_VERSION >= 5)
+	static FTSTicker& GetCoreTicker()
+	{
+		return FTSTicker::GetCoreTicker();
+	}
+#else
+	static FTicker& ApiGearTicker::GetCoreTicker()
+	{
+		return GetCoreTicker();
+	}
+#endif
+};

--- a/goldenmaster/Plugins/ApiGear/Source/ApiGearOLink/Private/OLinkHostPrivate.cpp
+++ b/goldenmaster/Plugins/ApiGear/Source/ApiGearOLink/Private/OLinkHostPrivate.cpp
@@ -75,11 +75,7 @@ bool OLinkHostPrivate::Start(uint32 InPort)
 		return false;
 	}
 
-#if (ENGINE_MAJOR_VERSION >= 5)
-	TickerHandle = FTSTicker::GetCoreTicker().AddTicker(FTickerDelegate::CreateRaw(this, &OLinkHostPrivate::Tick));
-#else
-	TickerHandle = FTicker::GetCoreTicker().AddTicker(FTickerDelegate::CreateRaw(this, &OLinkHostPrivate::Tick));
-#endif
+	TickerHandle = ApiGearTicker::GetCoreTicker().AddTicker(FTickerDelegate::CreateRaw(this, &OLinkHostPrivate::Tick));
 	return true;
 }
 
@@ -87,12 +83,7 @@ void OLinkHostPrivate::Stop()
 {
 	if (TickerHandle.IsValid())
 	{
-#if (ENGINE_MAJOR_VERSION >= 5)
-		FTSTicker::GetCoreTicker().RemoveTicker(TickerHandle);
-#else
-		FTicker::GetCoreTicker().RemoveTicker(TickerHandle);
-#endif
-
+		ApiGearTicker::GetCoreTicker().RemoveTicker(TickerHandle);
 		TickerHandle.Reset();
 	}
 	if (Server)

--- a/goldenmaster/Plugins/ApiGear/Source/ApiGearOLink/Private/OLinkHostPrivate.h
+++ b/goldenmaster/Plugins/ApiGear/Source/ApiGearOLink/Private/OLinkHostPrivate.h
@@ -11,6 +11,7 @@ THIRD_PARTY_INCLUDES_START
 THIRD_PARTY_INCLUDES_END
 #include "OLinkHostConnection.h"
 #include "IWebSocketServer.h"
+#include "ApiGearTicker.h"
 
 class INetworkingWebSocket;
 
@@ -63,13 +64,8 @@ private:
 	// olink registry stored here to hand it olink adapter classes
 	TSharedPtr<ApiGear::ObjectLink::RemoteRegistry> Registry;
 
-#if (ENGINE_MAJOR_VERSION >= 5)
 	/// @brief delegate which is connected to the tick function
-	FTSTicker::FDelegateHandle TickerHandle;
-#else
-	/// @brief delegate which is connected to the tick function
-	FDelegateHandle TickerHandle;
-#endif
+	ApiGear::FDelegateHandle TickerHandle;
 
 	/// @brief the port OLink server listen on
 	uint32 Port;

--- a/goldenmaster/Plugins/ApiGear/Source/ApiGearOLink/Private/unrealolink.cpp
+++ b/goldenmaster/Plugins/ApiGear/Source/ApiGearOLink/Private/unrealolink.cpp
@@ -60,8 +60,12 @@ UUnrealOLink::UUnrealOLink(const FObjectInitializer& ObjectInitializer)
 		// Schedule calling process message so they are sent from main thread. Throttling also improve sending during high load.
 		if (!m_processMessageTaskTimerHandle.IsValid())
 		{
-			m_processMessageTaskTimerHandle = ApiGearTicker::GetCoreTicker().AddTicker(*processMessageFunctionName, processMessageDelay, [this](float /*param*/)
-				{processMessages(); return true; });
+			m_processMessageTaskTimerHandle = ApiGearTicker::GetCoreTicker().AddTicker(*processMessageFunctionName, processMessageDelay,
+				[this](float /*param*/)
+				{
+					processMessages();
+					return true;
+				});
 		}
 	};
 	m_node->onWrite(func);
@@ -208,8 +212,12 @@ void UUnrealOLink::OnConnected_Implementation()
 	// Schedule calling process message so they are sent from main thread. Throttling also improve sending during high load.
 	if (!m_processMessageTaskTimerHandle.IsValid())
 	{
-		m_processMessageTaskTimerHandle = ApiGearTicker::GetCoreTicker().AddTicker(*processMessageFunctionName, processMessageDelay, [this](float /*param*/)
-			{processMessages(); return true; });
+		m_processMessageTaskTimerHandle = ApiGearTicker::GetCoreTicker().AddTicker(*processMessageFunctionName, processMessageDelay,
+			[this](float /*param*/)
+			{
+				processMessages();
+				return true;
+			});
 	}
 }
 

--- a/goldenmaster/Plugins/ApiGear/Source/ApiGearOLink/Public/unrealolink.h
+++ b/goldenmaster/Plugins/ApiGear/Source/ApiGearOLink/Public/unrealolink.h
@@ -9,6 +9,8 @@ THIRD_PARTY_INCLUDES_END
 #include "WebSocketsModule.h"
 #include "IWebSocket.h"
 #include "Containers/Queue.h"
+#include "HAL/CriticalSection.h"
+#include "ApiGearTicker.h"
 #include "unrealolink.generated.h"
 
 DECLARE_LOG_CATEGORY_EXTERN(LogApiGearOLink, Log, All);
@@ -62,13 +64,30 @@ public:
 private:
 	bool bInitialized = false;
 	void open(const FString& url);
+	/*
+	* Helper method for sending messages, should be used from one thread, here achieved with scheduling task to main thread.
+	* see m_processMessageTaskTimerHandle
+	*/
 	void processMessages();
+	/*
+	* Sends queued messages
+	* Uses m_flushMessagesMutex, to ensure it called only once at one time.
+	* It is not thread safe function - uses a m_socket and m_queue which are not guarded separately across the UUnrealOLink
+	*/
+	void flushMessages();
 
 	TArray<std::string> ListLinkedObjects;
+
+	DEFINE_LOG_CATEGORY(LogApiGearOLink);
+	
+	/// @brief delegate handle for scheduled process message task
+	ApiGear::FDelegateHandle m_processMessageTaskTimerHandle;
 
 	TSharedPtr<IWebSocket> m_socket;
 	FString m_serverURL;
 	ApiGear::ObjectLink::ClientRegistry m_registry;
 	std::shared_ptr<ApiGear::ObjectLink::ClientNode> m_node;
 	TQueue<std::string, EQueueMode::Mpsc> m_queue;
+	// Mutex for flushMessages().
+	FCriticalSection m_flushMessagesMutex;
 };

--- a/goldenmaster/Plugins/ApiGear/Source/ApiGearOLink/Public/unrealolink.h
+++ b/goldenmaster/Plugins/ApiGear/Source/ApiGearOLink/Public/unrealolink.h
@@ -79,8 +79,8 @@ private:
 	TArray<std::string> ListLinkedObjects;
 
 	DEFINE_LOG_CATEGORY(LogApiGearOLink);
-	
-	/// @brief delegate handle for scheduled process message task
+
+	// Delegate handle for scheduled process message task
 	ApiGear::FDelegateHandle m_processMessageTaskTimerHandle;
 
 	TSharedPtr<IWebSocket> m_socket;

--- a/goldenmaster/Plugins/TbEnum/Source/TbEnum/Private/Generated/OLink/TbEnumEnumInterfaceOLinkClient.cpp
+++ b/goldenmaster/Plugins/TbEnum/Source/TbEnum/Private/Generated/OLink/TbEnumEnumInterfaceOLinkClient.cpp
@@ -35,16 +35,17 @@ THIRD_PARTY_INCLUDES_START
 #include "olink/clientnode.h"
 #include "olink/iobjectsink.h"
 THIRD_PARTY_INCLUDES_END
+#include <atomic>
 
 /**
    \brief data structure to hold the last sent property values
 */
 struct TbEnumEnumInterfacePropertiesData
 {
-	ETbEnumEnum0 Prop0{ETbEnumEnum0::TEE_VALUE0};
-	ETbEnumEnum1 Prop1{ETbEnumEnum1::TEE_VALUE1};
-	ETbEnumEnum2 Prop2{ETbEnumEnum2::TEE_VALUE2};
-	ETbEnumEnum3 Prop3{ETbEnumEnum3::TEE_VALUE3};
+	std::atomic<ETbEnumEnum0> Prop0{ETbEnumEnum0::TEE_VALUE0};
+	std::atomic<ETbEnumEnum1> Prop1{ETbEnumEnum1::TEE_VALUE1};
+	std::atomic<ETbEnumEnum2> Prop2{ETbEnumEnum2::TEE_VALUE2};
+	std::atomic<ETbEnumEnum3> Prop3{ETbEnumEnum3::TEE_VALUE3};
 };
 DEFINE_LOG_CATEGORY(LogTbEnumEnumInterfaceOLinkClient);
 
@@ -168,9 +169,9 @@ void UTbEnumEnumInterfaceOLinkClient::SetProp0_Implementation(ETbEnumEnum0 InPro
 	if (_SentData->Prop0 == InProp0)
 	{
 		return;
-	}
+	}	
 	static const auto memberId = ApiGear::ObjectLink::Name::createMemberId(m_sink->olinkObjectName(), "prop0");
-	m_sink->GetNode()->setRemoteProperty(memberId, InProp0);
+	m_sink->GetNode()->setRemoteProperty(memberId, InProp0);	
 	_SentData->Prop0 = InProp0;
 }
 
@@ -197,9 +198,9 @@ void UTbEnumEnumInterfaceOLinkClient::SetProp1_Implementation(ETbEnumEnum1 InPro
 	if (_SentData->Prop1 == InProp1)
 	{
 		return;
-	}
+	}	
 	static const auto memberId = ApiGear::ObjectLink::Name::createMemberId(m_sink->olinkObjectName(), "prop1");
-	m_sink->GetNode()->setRemoteProperty(memberId, InProp1);
+	m_sink->GetNode()->setRemoteProperty(memberId, InProp1);	
 	_SentData->Prop1 = InProp1;
 }
 
@@ -226,9 +227,9 @@ void UTbEnumEnumInterfaceOLinkClient::SetProp2_Implementation(ETbEnumEnum2 InPro
 	if (_SentData->Prop2 == InProp2)
 	{
 		return;
-	}
+	}	
 	static const auto memberId = ApiGear::ObjectLink::Name::createMemberId(m_sink->olinkObjectName(), "prop2");
-	m_sink->GetNode()->setRemoteProperty(memberId, InProp2);
+	m_sink->GetNode()->setRemoteProperty(memberId, InProp2);	
 	_SentData->Prop2 = InProp2;
 }
 
@@ -255,9 +256,9 @@ void UTbEnumEnumInterfaceOLinkClient::SetProp3_Implementation(ETbEnumEnum3 InPro
 	if (_SentData->Prop3 == InProp3)
 	{
 		return;
-	}
+	}	
 	static const auto memberId = ApiGear::ObjectLink::Name::createMemberId(m_sink->olinkObjectName(), "prop3");
-	m_sink->GetNode()->setRemoteProperty(memberId, InProp3);
+	m_sink->GetNode()->setRemoteProperty(memberId, InProp3);	
 	_SentData->Prop3 = InProp3;
 }
 

--- a/goldenmaster/Plugins/TbEnum/Source/TbEnum/Private/Generated/OLink/TbEnumEnumInterfaceOLinkClient.cpp
+++ b/goldenmaster/Plugins/TbEnum/Source/TbEnum/Private/Generated/OLink/TbEnumEnumInterfaceOLinkClient.cpp
@@ -169,9 +169,9 @@ void UTbEnumEnumInterfaceOLinkClient::SetProp0_Implementation(ETbEnumEnum0 InPro
 	if (_SentData->Prop0 == InProp0)
 	{
 		return;
-	}	
+	}
 	static const auto memberId = ApiGear::ObjectLink::Name::createMemberId(m_sink->olinkObjectName(), "prop0");
-	m_sink->GetNode()->setRemoteProperty(memberId, InProp0);	
+	m_sink->GetNode()->setRemoteProperty(memberId, InProp0);
 	_SentData->Prop0 = InProp0;
 }
 
@@ -198,9 +198,9 @@ void UTbEnumEnumInterfaceOLinkClient::SetProp1_Implementation(ETbEnumEnum1 InPro
 	if (_SentData->Prop1 == InProp1)
 	{
 		return;
-	}	
+	}
 	static const auto memberId = ApiGear::ObjectLink::Name::createMemberId(m_sink->olinkObjectName(), "prop1");
-	m_sink->GetNode()->setRemoteProperty(memberId, InProp1);	
+	m_sink->GetNode()->setRemoteProperty(memberId, InProp1);
 	_SentData->Prop1 = InProp1;
 }
 
@@ -227,9 +227,9 @@ void UTbEnumEnumInterfaceOLinkClient::SetProp2_Implementation(ETbEnumEnum2 InPro
 	if (_SentData->Prop2 == InProp2)
 	{
 		return;
-	}	
+	}
 	static const auto memberId = ApiGear::ObjectLink::Name::createMemberId(m_sink->olinkObjectName(), "prop2");
-	m_sink->GetNode()->setRemoteProperty(memberId, InProp2);	
+	m_sink->GetNode()->setRemoteProperty(memberId, InProp2);
 	_SentData->Prop2 = InProp2;
 }
 
@@ -256,9 +256,9 @@ void UTbEnumEnumInterfaceOLinkClient::SetProp3_Implementation(ETbEnumEnum3 InPro
 	if (_SentData->Prop3 == InProp3)
 	{
 		return;
-	}	
+	}
 	static const auto memberId = ApiGear::ObjectLink::Name::createMemberId(m_sink->olinkObjectName(), "prop3");
-	m_sink->GetNode()->setRemoteProperty(memberId, InProp3);	
+	m_sink->GetNode()->setRemoteProperty(memberId, InProp3);
 	_SentData->Prop3 = InProp3;
 }
 

--- a/goldenmaster/Plugins/TbSame1/Source/TbSame1/Private/Generated/OLink/TbSame1SameEnum1InterfaceOLinkClient.cpp
+++ b/goldenmaster/Plugins/TbSame1/Source/TbSame1/Private/Generated/OLink/TbSame1SameEnum1InterfaceOLinkClient.cpp
@@ -166,9 +166,9 @@ void UTbSame1SameEnum1InterfaceOLinkClient::SetProp1_Implementation(ETbSame1Enum
 	if (_SentData->Prop1 == InProp1)
 	{
 		return;
-	}	
+	}
 	static const auto memberId = ApiGear::ObjectLink::Name::createMemberId(m_sink->olinkObjectName(), "prop1");
-	m_sink->GetNode()->setRemoteProperty(memberId, InProp1);	
+	m_sink->GetNode()->setRemoteProperty(memberId, InProp1);
 	_SentData->Prop1 = InProp1;
 }
 

--- a/goldenmaster/Plugins/TbSame1/Source/TbSame1/Private/Generated/OLink/TbSame1SameEnum1InterfaceOLinkClient.cpp
+++ b/goldenmaster/Plugins/TbSame1/Source/TbSame1/Private/Generated/OLink/TbSame1SameEnum1InterfaceOLinkClient.cpp
@@ -35,13 +35,14 @@ THIRD_PARTY_INCLUDES_START
 #include "olink/clientnode.h"
 #include "olink/iobjectsink.h"
 THIRD_PARTY_INCLUDES_END
+#include <atomic>
 
 /**
    \brief data structure to hold the last sent property values
 */
 struct TbSame1SameEnum1InterfacePropertiesData
 {
-	ETbSame1Enum1 Prop1{ETbSame1Enum1::TSE_VALUE1};
+	std::atomic<ETbSame1Enum1> Prop1{ETbSame1Enum1::TSE_VALUE1};
 };
 DEFINE_LOG_CATEGORY(LogTbSame1SameEnum1InterfaceOLinkClient);
 
@@ -165,9 +166,9 @@ void UTbSame1SameEnum1InterfaceOLinkClient::SetProp1_Implementation(ETbSame1Enum
 	if (_SentData->Prop1 == InProp1)
 	{
 		return;
-	}
+	}	
 	static const auto memberId = ApiGear::ObjectLink::Name::createMemberId(m_sink->olinkObjectName(), "prop1");
-	m_sink->GetNode()->setRemoteProperty(memberId, InProp1);
+	m_sink->GetNode()->setRemoteProperty(memberId, InProp1);	
 	_SentData->Prop1 = InProp1;
 }
 

--- a/goldenmaster/Plugins/TbSame1/Source/TbSame1/Private/Generated/OLink/TbSame1SameEnum2InterfaceOLinkClient.cpp
+++ b/goldenmaster/Plugins/TbSame1/Source/TbSame1/Private/Generated/OLink/TbSame1SameEnum2InterfaceOLinkClient.cpp
@@ -167,9 +167,9 @@ void UTbSame1SameEnum2InterfaceOLinkClient::SetProp1_Implementation(ETbSame1Enum
 	if (_SentData->Prop1 == InProp1)
 	{
 		return;
-	}	
+	}
 	static const auto memberId = ApiGear::ObjectLink::Name::createMemberId(m_sink->olinkObjectName(), "prop1");
-	m_sink->GetNode()->setRemoteProperty(memberId, InProp1);	
+	m_sink->GetNode()->setRemoteProperty(memberId, InProp1);
 	_SentData->Prop1 = InProp1;
 }
 
@@ -196,9 +196,9 @@ void UTbSame1SameEnum2InterfaceOLinkClient::SetProp2_Implementation(ETbSame1Enum
 	if (_SentData->Prop2 == InProp2)
 	{
 		return;
-	}	
+	}
 	static const auto memberId = ApiGear::ObjectLink::Name::createMemberId(m_sink->olinkObjectName(), "prop2");
-	m_sink->GetNode()->setRemoteProperty(memberId, InProp2);	
+	m_sink->GetNode()->setRemoteProperty(memberId, InProp2);
 	_SentData->Prop2 = InProp2;
 }
 

--- a/goldenmaster/Plugins/TbSame1/Source/TbSame1/Private/Generated/OLink/TbSame1SameEnum2InterfaceOLinkClient.cpp
+++ b/goldenmaster/Plugins/TbSame1/Source/TbSame1/Private/Generated/OLink/TbSame1SameEnum2InterfaceOLinkClient.cpp
@@ -35,14 +35,15 @@ THIRD_PARTY_INCLUDES_START
 #include "olink/clientnode.h"
 #include "olink/iobjectsink.h"
 THIRD_PARTY_INCLUDES_END
+#include <atomic>
 
 /**
    \brief data structure to hold the last sent property values
 */
 struct TbSame1SameEnum2InterfacePropertiesData
 {
-	ETbSame1Enum1 Prop1{ETbSame1Enum1::TSE_VALUE1};
-	ETbSame1Enum2 Prop2{ETbSame1Enum2::TSE_VALUE1};
+	std::atomic<ETbSame1Enum1> Prop1{ETbSame1Enum1::TSE_VALUE1};
+	std::atomic<ETbSame1Enum2> Prop2{ETbSame1Enum2::TSE_VALUE1};
 };
 DEFINE_LOG_CATEGORY(LogTbSame1SameEnum2InterfaceOLinkClient);
 
@@ -166,9 +167,9 @@ void UTbSame1SameEnum2InterfaceOLinkClient::SetProp1_Implementation(ETbSame1Enum
 	if (_SentData->Prop1 == InProp1)
 	{
 		return;
-	}
+	}	
 	static const auto memberId = ApiGear::ObjectLink::Name::createMemberId(m_sink->olinkObjectName(), "prop1");
-	m_sink->GetNode()->setRemoteProperty(memberId, InProp1);
+	m_sink->GetNode()->setRemoteProperty(memberId, InProp1);	
 	_SentData->Prop1 = InProp1;
 }
 
@@ -195,9 +196,9 @@ void UTbSame1SameEnum2InterfaceOLinkClient::SetProp2_Implementation(ETbSame1Enum
 	if (_SentData->Prop2 == InProp2)
 	{
 		return;
-	}
+	}	
 	static const auto memberId = ApiGear::ObjectLink::Name::createMemberId(m_sink->olinkObjectName(), "prop2");
-	m_sink->GetNode()->setRemoteProperty(memberId, InProp2);
+	m_sink->GetNode()->setRemoteProperty(memberId, InProp2);	
 	_SentData->Prop2 = InProp2;
 }
 

--- a/goldenmaster/Plugins/TbSame1/Source/TbSame1/Private/Generated/OLink/TbSame1SameStruct1InterfaceOLinkClient.cpp
+++ b/goldenmaster/Plugins/TbSame1/Source/TbSame1/Private/Generated/OLink/TbSame1SameStruct1InterfaceOLinkClient.cpp
@@ -170,10 +170,10 @@ void UTbSame1SameStruct1InterfaceOLinkClient::SetProp1_Implementation(const FTbS
 		{
 			return;
 		}
-	}	
+	}
 	static const auto memberId = ApiGear::ObjectLink::Name::createMemberId(m_sink->olinkObjectName(), "prop1");
 	m_sink->GetNode()->setRemoteProperty(memberId, InProp1);
-	FScopeLock Lock(&(_SentData->Prop1Mutex));	
+	FScopeLock Lock(&(_SentData->Prop1Mutex));
 	_SentData->Prop1 = InProp1;
 }
 

--- a/goldenmaster/Plugins/TbSame1/Source/TbSame1/Private/Generated/OLink/TbSame1SameStruct1InterfaceOLinkClient.cpp
+++ b/goldenmaster/Plugins/TbSame1/Source/TbSame1/Private/Generated/OLink/TbSame1SameStruct1InterfaceOLinkClient.cpp
@@ -35,12 +35,14 @@ THIRD_PARTY_INCLUDES_START
 #include "olink/clientnode.h"
 #include "olink/iobjectsink.h"
 THIRD_PARTY_INCLUDES_END
+#include "HAL/CriticalSection.h"
 
 /**
    \brief data structure to hold the last sent property values
 */
 struct TbSame1SameStruct1InterfacePropertiesData
 {
+	FCriticalSection Prop1Mutex;
 	FTbSame1Struct1 Prop1{FTbSame1Struct1()};
 };
 DEFINE_LOG_CATEGORY(LogTbSame1SameStruct1InterfaceOLinkClient);
@@ -162,12 +164,16 @@ void UTbSame1SameStruct1InterfaceOLinkClient::SetProp1_Implementation(const FTbS
 	}
 
 	// only send change requests if the value wasn't already sent -> reduce network load
-	if (_SentData->Prop1 == InProp1)
 	{
-		return;
-	}
+		FScopeLock Lock(&(_SentData->Prop1Mutex));
+		if (_SentData->Prop1 == InProp1)
+		{
+			return;
+		}
+	}	
 	static const auto memberId = ApiGear::ObjectLink::Name::createMemberId(m_sink->olinkObjectName(), "prop1");
 	m_sink->GetNode()->setRemoteProperty(memberId, InProp1);
+	FScopeLock Lock(&(_SentData->Prop1Mutex));	
 	_SentData->Prop1 = InProp1;
 }
 

--- a/goldenmaster/Plugins/TbSame1/Source/TbSame1/Private/Generated/OLink/TbSame1SameStruct2InterfaceOLinkClient.cpp
+++ b/goldenmaster/Plugins/TbSame1/Source/TbSame1/Private/Generated/OLink/TbSame1SameStruct2InterfaceOLinkClient.cpp
@@ -172,10 +172,10 @@ void UTbSame1SameStruct2InterfaceOLinkClient::SetProp1_Implementation(const FTbS
 		{
 			return;
 		}
-	}	
+	}
 	static const auto memberId = ApiGear::ObjectLink::Name::createMemberId(m_sink->olinkObjectName(), "prop1");
 	m_sink->GetNode()->setRemoteProperty(memberId, InProp1);
-	FScopeLock Lock(&(_SentData->Prop1Mutex));	
+	FScopeLock Lock(&(_SentData->Prop1Mutex));
 	_SentData->Prop1 = InProp1;
 }
 
@@ -205,10 +205,10 @@ void UTbSame1SameStruct2InterfaceOLinkClient::SetProp2_Implementation(const FTbS
 		{
 			return;
 		}
-	}	
+	}
 	static const auto memberId = ApiGear::ObjectLink::Name::createMemberId(m_sink->olinkObjectName(), "prop2");
 	m_sink->GetNode()->setRemoteProperty(memberId, InProp2);
-	FScopeLock Lock(&(_SentData->Prop2Mutex));	
+	FScopeLock Lock(&(_SentData->Prop2Mutex));
 	_SentData->Prop2 = InProp2;
 }
 

--- a/goldenmaster/Plugins/TbSame1/Source/TbSame1/Private/Generated/OLink/TbSame1SameStruct2InterfaceOLinkClient.cpp
+++ b/goldenmaster/Plugins/TbSame1/Source/TbSame1/Private/Generated/OLink/TbSame1SameStruct2InterfaceOLinkClient.cpp
@@ -35,13 +35,16 @@ THIRD_PARTY_INCLUDES_START
 #include "olink/clientnode.h"
 #include "olink/iobjectsink.h"
 THIRD_PARTY_INCLUDES_END
+#include "HAL/CriticalSection.h"
 
 /**
    \brief data structure to hold the last sent property values
 */
 struct TbSame1SameStruct2InterfacePropertiesData
 {
+	FCriticalSection Prop1Mutex;
 	FTbSame1Struct2 Prop1{FTbSame1Struct2()};
+	FCriticalSection Prop2Mutex;
 	FTbSame1Struct2 Prop2{FTbSame1Struct2()};
 };
 DEFINE_LOG_CATEGORY(LogTbSame1SameStruct2InterfaceOLinkClient);
@@ -163,12 +166,16 @@ void UTbSame1SameStruct2InterfaceOLinkClient::SetProp1_Implementation(const FTbS
 	}
 
 	// only send change requests if the value wasn't already sent -> reduce network load
-	if (_SentData->Prop1 == InProp1)
 	{
-		return;
-	}
+		FScopeLock Lock(&(_SentData->Prop1Mutex));
+		if (_SentData->Prop1 == InProp1)
+		{
+			return;
+		}
+	}	
 	static const auto memberId = ApiGear::ObjectLink::Name::createMemberId(m_sink->olinkObjectName(), "prop1");
 	m_sink->GetNode()->setRemoteProperty(memberId, InProp1);
+	FScopeLock Lock(&(_SentData->Prop1Mutex));	
 	_SentData->Prop1 = InProp1;
 }
 
@@ -192,12 +199,16 @@ void UTbSame1SameStruct2InterfaceOLinkClient::SetProp2_Implementation(const FTbS
 	}
 
 	// only send change requests if the value wasn't already sent -> reduce network load
-	if (_SentData->Prop2 == InProp2)
 	{
-		return;
-	}
+		FScopeLock Lock(&(_SentData->Prop2Mutex));
+		if (_SentData->Prop2 == InProp2)
+		{
+			return;
+		}
+	}	
 	static const auto memberId = ApiGear::ObjectLink::Name::createMemberId(m_sink->olinkObjectName(), "prop2");
 	m_sink->GetNode()->setRemoteProperty(memberId, InProp2);
+	FScopeLock Lock(&(_SentData->Prop2Mutex));	
 	_SentData->Prop2 = InProp2;
 }
 

--- a/goldenmaster/Plugins/TbSame2/Source/TbSame2/Private/Generated/OLink/TbSame2SameEnum1InterfaceOLinkClient.cpp
+++ b/goldenmaster/Plugins/TbSame2/Source/TbSame2/Private/Generated/OLink/TbSame2SameEnum1InterfaceOLinkClient.cpp
@@ -35,13 +35,14 @@ THIRD_PARTY_INCLUDES_START
 #include "olink/clientnode.h"
 #include "olink/iobjectsink.h"
 THIRD_PARTY_INCLUDES_END
+#include <atomic>
 
 /**
    \brief data structure to hold the last sent property values
 */
 struct TbSame2SameEnum1InterfacePropertiesData
 {
-	ETbSame2Enum1 Prop1{ETbSame2Enum1::TSE_VALUE1};
+	std::atomic<ETbSame2Enum1> Prop1{ETbSame2Enum1::TSE_VALUE1};
 };
 DEFINE_LOG_CATEGORY(LogTbSame2SameEnum1InterfaceOLinkClient);
 
@@ -165,9 +166,9 @@ void UTbSame2SameEnum1InterfaceOLinkClient::SetProp1_Implementation(ETbSame2Enum
 	if (_SentData->Prop1 == InProp1)
 	{
 		return;
-	}
+	}	
 	static const auto memberId = ApiGear::ObjectLink::Name::createMemberId(m_sink->olinkObjectName(), "prop1");
-	m_sink->GetNode()->setRemoteProperty(memberId, InProp1);
+	m_sink->GetNode()->setRemoteProperty(memberId, InProp1);	
 	_SentData->Prop1 = InProp1;
 }
 

--- a/goldenmaster/Plugins/TbSame2/Source/TbSame2/Private/Generated/OLink/TbSame2SameEnum1InterfaceOLinkClient.cpp
+++ b/goldenmaster/Plugins/TbSame2/Source/TbSame2/Private/Generated/OLink/TbSame2SameEnum1InterfaceOLinkClient.cpp
@@ -166,9 +166,9 @@ void UTbSame2SameEnum1InterfaceOLinkClient::SetProp1_Implementation(ETbSame2Enum
 	if (_SentData->Prop1 == InProp1)
 	{
 		return;
-	}	
+	}
 	static const auto memberId = ApiGear::ObjectLink::Name::createMemberId(m_sink->olinkObjectName(), "prop1");
-	m_sink->GetNode()->setRemoteProperty(memberId, InProp1);	
+	m_sink->GetNode()->setRemoteProperty(memberId, InProp1);
 	_SentData->Prop1 = InProp1;
 }
 

--- a/goldenmaster/Plugins/TbSame2/Source/TbSame2/Private/Generated/OLink/TbSame2SameEnum2InterfaceOLinkClient.cpp
+++ b/goldenmaster/Plugins/TbSame2/Source/TbSame2/Private/Generated/OLink/TbSame2SameEnum2InterfaceOLinkClient.cpp
@@ -167,9 +167,9 @@ void UTbSame2SameEnum2InterfaceOLinkClient::SetProp1_Implementation(ETbSame2Enum
 	if (_SentData->Prop1 == InProp1)
 	{
 		return;
-	}	
+	}
 	static const auto memberId = ApiGear::ObjectLink::Name::createMemberId(m_sink->olinkObjectName(), "prop1");
-	m_sink->GetNode()->setRemoteProperty(memberId, InProp1);	
+	m_sink->GetNode()->setRemoteProperty(memberId, InProp1);
 	_SentData->Prop1 = InProp1;
 }
 
@@ -196,9 +196,9 @@ void UTbSame2SameEnum2InterfaceOLinkClient::SetProp2_Implementation(ETbSame2Enum
 	if (_SentData->Prop2 == InProp2)
 	{
 		return;
-	}	
+	}
 	static const auto memberId = ApiGear::ObjectLink::Name::createMemberId(m_sink->olinkObjectName(), "prop2");
-	m_sink->GetNode()->setRemoteProperty(memberId, InProp2);	
+	m_sink->GetNode()->setRemoteProperty(memberId, InProp2);
 	_SentData->Prop2 = InProp2;
 }
 

--- a/goldenmaster/Plugins/TbSame2/Source/TbSame2/Private/Generated/OLink/TbSame2SameEnum2InterfaceOLinkClient.cpp
+++ b/goldenmaster/Plugins/TbSame2/Source/TbSame2/Private/Generated/OLink/TbSame2SameEnum2InterfaceOLinkClient.cpp
@@ -35,14 +35,15 @@ THIRD_PARTY_INCLUDES_START
 #include "olink/clientnode.h"
 #include "olink/iobjectsink.h"
 THIRD_PARTY_INCLUDES_END
+#include <atomic>
 
 /**
    \brief data structure to hold the last sent property values
 */
 struct TbSame2SameEnum2InterfacePropertiesData
 {
-	ETbSame2Enum1 Prop1{ETbSame2Enum1::TSE_VALUE1};
-	ETbSame2Enum2 Prop2{ETbSame2Enum2::TSE_VALUE1};
+	std::atomic<ETbSame2Enum1> Prop1{ETbSame2Enum1::TSE_VALUE1};
+	std::atomic<ETbSame2Enum2> Prop2{ETbSame2Enum2::TSE_VALUE1};
 };
 DEFINE_LOG_CATEGORY(LogTbSame2SameEnum2InterfaceOLinkClient);
 
@@ -166,9 +167,9 @@ void UTbSame2SameEnum2InterfaceOLinkClient::SetProp1_Implementation(ETbSame2Enum
 	if (_SentData->Prop1 == InProp1)
 	{
 		return;
-	}
+	}	
 	static const auto memberId = ApiGear::ObjectLink::Name::createMemberId(m_sink->olinkObjectName(), "prop1");
-	m_sink->GetNode()->setRemoteProperty(memberId, InProp1);
+	m_sink->GetNode()->setRemoteProperty(memberId, InProp1);	
 	_SentData->Prop1 = InProp1;
 }
 
@@ -195,9 +196,9 @@ void UTbSame2SameEnum2InterfaceOLinkClient::SetProp2_Implementation(ETbSame2Enum
 	if (_SentData->Prop2 == InProp2)
 	{
 		return;
-	}
+	}	
 	static const auto memberId = ApiGear::ObjectLink::Name::createMemberId(m_sink->olinkObjectName(), "prop2");
-	m_sink->GetNode()->setRemoteProperty(memberId, InProp2);
+	m_sink->GetNode()->setRemoteProperty(memberId, InProp2);	
 	_SentData->Prop2 = InProp2;
 }
 

--- a/goldenmaster/Plugins/TbSame2/Source/TbSame2/Private/Generated/OLink/TbSame2SameStruct1InterfaceOLinkClient.cpp
+++ b/goldenmaster/Plugins/TbSame2/Source/TbSame2/Private/Generated/OLink/TbSame2SameStruct1InterfaceOLinkClient.cpp
@@ -170,10 +170,10 @@ void UTbSame2SameStruct1InterfaceOLinkClient::SetProp1_Implementation(const FTbS
 		{
 			return;
 		}
-	}	
+	}
 	static const auto memberId = ApiGear::ObjectLink::Name::createMemberId(m_sink->olinkObjectName(), "prop1");
 	m_sink->GetNode()->setRemoteProperty(memberId, InProp1);
-	FScopeLock Lock(&(_SentData->Prop1Mutex));	
+	FScopeLock Lock(&(_SentData->Prop1Mutex));
 	_SentData->Prop1 = InProp1;
 }
 

--- a/goldenmaster/Plugins/TbSame2/Source/TbSame2/Private/Generated/OLink/TbSame2SameStruct2InterfaceOLinkClient.cpp
+++ b/goldenmaster/Plugins/TbSame2/Source/TbSame2/Private/Generated/OLink/TbSame2SameStruct2InterfaceOLinkClient.cpp
@@ -35,13 +35,16 @@ THIRD_PARTY_INCLUDES_START
 #include "olink/clientnode.h"
 #include "olink/iobjectsink.h"
 THIRD_PARTY_INCLUDES_END
+#include "HAL/CriticalSection.h"
 
 /**
    \brief data structure to hold the last sent property values
 */
 struct TbSame2SameStruct2InterfacePropertiesData
 {
+	FCriticalSection Prop1Mutex;
 	FTbSame2Struct2 Prop1{FTbSame2Struct2()};
+	FCriticalSection Prop2Mutex;
 	FTbSame2Struct2 Prop2{FTbSame2Struct2()};
 };
 DEFINE_LOG_CATEGORY(LogTbSame2SameStruct2InterfaceOLinkClient);
@@ -163,12 +166,16 @@ void UTbSame2SameStruct2InterfaceOLinkClient::SetProp1_Implementation(const FTbS
 	}
 
 	// only send change requests if the value wasn't already sent -> reduce network load
-	if (_SentData->Prop1 == InProp1)
 	{
-		return;
-	}
+		FScopeLock Lock(&(_SentData->Prop1Mutex));
+		if (_SentData->Prop1 == InProp1)
+		{
+			return;
+		}
+	}	
 	static const auto memberId = ApiGear::ObjectLink::Name::createMemberId(m_sink->olinkObjectName(), "prop1");
 	m_sink->GetNode()->setRemoteProperty(memberId, InProp1);
+	FScopeLock Lock(&(_SentData->Prop1Mutex));	
 	_SentData->Prop1 = InProp1;
 }
 
@@ -192,12 +199,16 @@ void UTbSame2SameStruct2InterfaceOLinkClient::SetProp2_Implementation(const FTbS
 	}
 
 	// only send change requests if the value wasn't already sent -> reduce network load
-	if (_SentData->Prop2 == InProp2)
 	{
-		return;
-	}
+		FScopeLock Lock(&(_SentData->Prop2Mutex));
+		if (_SentData->Prop2 == InProp2)
+		{
+			return;
+		}
+	}	
 	static const auto memberId = ApiGear::ObjectLink::Name::createMemberId(m_sink->olinkObjectName(), "prop2");
 	m_sink->GetNode()->setRemoteProperty(memberId, InProp2);
+	FScopeLock Lock(&(_SentData->Prop2Mutex));	
 	_SentData->Prop2 = InProp2;
 }
 

--- a/goldenmaster/Plugins/TbSame2/Source/TbSame2/Private/Generated/OLink/TbSame2SameStruct2InterfaceOLinkClient.cpp
+++ b/goldenmaster/Plugins/TbSame2/Source/TbSame2/Private/Generated/OLink/TbSame2SameStruct2InterfaceOLinkClient.cpp
@@ -172,10 +172,10 @@ void UTbSame2SameStruct2InterfaceOLinkClient::SetProp1_Implementation(const FTbS
 		{
 			return;
 		}
-	}	
+	}
 	static const auto memberId = ApiGear::ObjectLink::Name::createMemberId(m_sink->olinkObjectName(), "prop1");
 	m_sink->GetNode()->setRemoteProperty(memberId, InProp1);
-	FScopeLock Lock(&(_SentData->Prop1Mutex));	
+	FScopeLock Lock(&(_SentData->Prop1Mutex));
 	_SentData->Prop1 = InProp1;
 }
 
@@ -205,10 +205,10 @@ void UTbSame2SameStruct2InterfaceOLinkClient::SetProp2_Implementation(const FTbS
 		{
 			return;
 		}
-	}	
+	}
 	static const auto memberId = ApiGear::ObjectLink::Name::createMemberId(m_sink->olinkObjectName(), "prop2");
 	m_sink->GetNode()->setRemoteProperty(memberId, InProp2);
-	FScopeLock Lock(&(_SentData->Prop2Mutex));	
+	FScopeLock Lock(&(_SentData->Prop2Mutex));
 	_SentData->Prop2 = InProp2;
 }
 

--- a/goldenmaster/Plugins/TbSimple/Source/TbSimple/Private/Generated/OLink/TbSimpleNoOperationsInterfaceOLinkClient.cpp
+++ b/goldenmaster/Plugins/TbSimple/Source/TbSimple/Private/Generated/OLink/TbSimpleNoOperationsInterfaceOLinkClient.cpp
@@ -167,9 +167,9 @@ void UTbSimpleNoOperationsInterfaceOLinkClient::SetPropBool_Implementation(bool 
 	if (_SentData->bPropBool == bInPropBool)
 	{
 		return;
-	}	
+	}
 	static const auto memberId = ApiGear::ObjectLink::Name::createMemberId(m_sink->olinkObjectName(), "propBool");
-	m_sink->GetNode()->setRemoteProperty(memberId, bInPropBool);	
+	m_sink->GetNode()->setRemoteProperty(memberId, bInPropBool);
 	_SentData->bPropBool = bInPropBool;
 }
 
@@ -196,9 +196,9 @@ void UTbSimpleNoOperationsInterfaceOLinkClient::SetPropInt_Implementation(int32 
 	if (_SentData->PropInt == InPropInt)
 	{
 		return;
-	}	
+	}
 	static const auto memberId = ApiGear::ObjectLink::Name::createMemberId(m_sink->olinkObjectName(), "propInt");
-	m_sink->GetNode()->setRemoteProperty(memberId, InPropInt);	
+	m_sink->GetNode()->setRemoteProperty(memberId, InPropInt);
 	_SentData->PropInt = InPropInt;
 }
 

--- a/goldenmaster/Plugins/TbSimple/Source/TbSimple/Private/Generated/OLink/TbSimpleNoOperationsInterfaceOLinkClient.cpp
+++ b/goldenmaster/Plugins/TbSimple/Source/TbSimple/Private/Generated/OLink/TbSimpleNoOperationsInterfaceOLinkClient.cpp
@@ -35,14 +35,15 @@ THIRD_PARTY_INCLUDES_START
 #include "olink/clientnode.h"
 #include "olink/iobjectsink.h"
 THIRD_PARTY_INCLUDES_END
+#include <atomic>
 
 /**
    \brief data structure to hold the last sent property values
 */
 struct TbSimpleNoOperationsInterfacePropertiesData
 {
-	bool bPropBool{false};
-	int32 PropInt{0};
+	std::atomic<bool> bPropBool{false};
+	std::atomic<int32> PropInt{0};
 };
 DEFINE_LOG_CATEGORY(LogTbSimpleNoOperationsInterfaceOLinkClient);
 
@@ -166,9 +167,9 @@ void UTbSimpleNoOperationsInterfaceOLinkClient::SetPropBool_Implementation(bool 
 	if (_SentData->bPropBool == bInPropBool)
 	{
 		return;
-	}
+	}	
 	static const auto memberId = ApiGear::ObjectLink::Name::createMemberId(m_sink->olinkObjectName(), "propBool");
-	m_sink->GetNode()->setRemoteProperty(memberId, bInPropBool);
+	m_sink->GetNode()->setRemoteProperty(memberId, bInPropBool);	
 	_SentData->bPropBool = bInPropBool;
 }
 
@@ -195,9 +196,9 @@ void UTbSimpleNoOperationsInterfaceOLinkClient::SetPropInt_Implementation(int32 
 	if (_SentData->PropInt == InPropInt)
 	{
 		return;
-	}
+	}	
 	static const auto memberId = ApiGear::ObjectLink::Name::createMemberId(m_sink->olinkObjectName(), "propInt");
-	m_sink->GetNode()->setRemoteProperty(memberId, InPropInt);
+	m_sink->GetNode()->setRemoteProperty(memberId, InPropInt);	
 	_SentData->PropInt = InPropInt;
 }
 

--- a/goldenmaster/Plugins/TbSimple/Source/TbSimple/Private/Generated/OLink/TbSimpleNoSignalsInterfaceOLinkClient.cpp
+++ b/goldenmaster/Plugins/TbSimple/Source/TbSimple/Private/Generated/OLink/TbSimpleNoSignalsInterfaceOLinkClient.cpp
@@ -35,14 +35,15 @@ THIRD_PARTY_INCLUDES_START
 #include "olink/clientnode.h"
 #include "olink/iobjectsink.h"
 THIRD_PARTY_INCLUDES_END
+#include <atomic>
 
 /**
    \brief data structure to hold the last sent property values
 */
 struct TbSimpleNoSignalsInterfacePropertiesData
 {
-	bool bPropBool{false};
-	int32 PropInt{0};
+	std::atomic<bool> bPropBool{false};
+	std::atomic<int32> PropInt{0};
 };
 DEFINE_LOG_CATEGORY(LogTbSimpleNoSignalsInterfaceOLinkClient);
 
@@ -166,9 +167,9 @@ void UTbSimpleNoSignalsInterfaceOLinkClient::SetPropBool_Implementation(bool bIn
 	if (_SentData->bPropBool == bInPropBool)
 	{
 		return;
-	}
+	}	
 	static const auto memberId = ApiGear::ObjectLink::Name::createMemberId(m_sink->olinkObjectName(), "propBool");
-	m_sink->GetNode()->setRemoteProperty(memberId, bInPropBool);
+	m_sink->GetNode()->setRemoteProperty(memberId, bInPropBool);	
 	_SentData->bPropBool = bInPropBool;
 }
 
@@ -195,9 +196,9 @@ void UTbSimpleNoSignalsInterfaceOLinkClient::SetPropInt_Implementation(int32 InP
 	if (_SentData->PropInt == InPropInt)
 	{
 		return;
-	}
+	}	
 	static const auto memberId = ApiGear::ObjectLink::Name::createMemberId(m_sink->olinkObjectName(), "propInt");
-	m_sink->GetNode()->setRemoteProperty(memberId, InPropInt);
+	m_sink->GetNode()->setRemoteProperty(memberId, InPropInt);	
 	_SentData->PropInt = InPropInt;
 }
 

--- a/goldenmaster/Plugins/TbSimple/Source/TbSimple/Private/Generated/OLink/TbSimpleNoSignalsInterfaceOLinkClient.cpp
+++ b/goldenmaster/Plugins/TbSimple/Source/TbSimple/Private/Generated/OLink/TbSimpleNoSignalsInterfaceOLinkClient.cpp
@@ -167,9 +167,9 @@ void UTbSimpleNoSignalsInterfaceOLinkClient::SetPropBool_Implementation(bool bIn
 	if (_SentData->bPropBool == bInPropBool)
 	{
 		return;
-	}	
+	}
 	static const auto memberId = ApiGear::ObjectLink::Name::createMemberId(m_sink->olinkObjectName(), "propBool");
-	m_sink->GetNode()->setRemoteProperty(memberId, bInPropBool);	
+	m_sink->GetNode()->setRemoteProperty(memberId, bInPropBool);
 	_SentData->bPropBool = bInPropBool;
 }
 
@@ -196,9 +196,9 @@ void UTbSimpleNoSignalsInterfaceOLinkClient::SetPropInt_Implementation(int32 InP
 	if (_SentData->PropInt == InPropInt)
 	{
 		return;
-	}	
+	}
 	static const auto memberId = ApiGear::ObjectLink::Name::createMemberId(m_sink->olinkObjectName(), "propInt");
-	m_sink->GetNode()->setRemoteProperty(memberId, InPropInt);	
+	m_sink->GetNode()->setRemoteProperty(memberId, InPropInt);
 	_SentData->PropInt = InPropInt;
 }
 

--- a/goldenmaster/Plugins/TbSimple/Source/TbSimple/Private/Generated/OLink/TbSimpleSimpleArrayInterfaceOLinkClient.cpp
+++ b/goldenmaster/Plugins/TbSimple/Source/TbSimple/Private/Generated/OLink/TbSimpleSimpleArrayInterfaceOLinkClient.cpp
@@ -184,10 +184,10 @@ void UTbSimpleSimpleArrayInterfaceOLinkClient::SetPropBool_Implementation(const 
 		{
 			return;
 		}
-	}	
+	}
 	static const auto memberId = ApiGear::ObjectLink::Name::createMemberId(m_sink->olinkObjectName(), "propBool");
 	m_sink->GetNode()->setRemoteProperty(memberId, InPropBool);
-	FScopeLock Lock(&(_SentData->PropBoolMutex));	
+	FScopeLock Lock(&(_SentData->PropBoolMutex));
 	_SentData->PropBool = InPropBool;
 }
 
@@ -217,10 +217,10 @@ void UTbSimpleSimpleArrayInterfaceOLinkClient::SetPropInt_Implementation(const T
 		{
 			return;
 		}
-	}	
+	}
 	static const auto memberId = ApiGear::ObjectLink::Name::createMemberId(m_sink->olinkObjectName(), "propInt");
 	m_sink->GetNode()->setRemoteProperty(memberId, InPropInt);
-	FScopeLock Lock(&(_SentData->PropIntMutex));	
+	FScopeLock Lock(&(_SentData->PropIntMutex));
 	_SentData->PropInt = InPropInt;
 }
 
@@ -250,10 +250,10 @@ void UTbSimpleSimpleArrayInterfaceOLinkClient::SetPropInt32_Implementation(const
 		{
 			return;
 		}
-	}	
+	}
 	static const auto memberId = ApiGear::ObjectLink::Name::createMemberId(m_sink->olinkObjectName(), "propInt32");
 	m_sink->GetNode()->setRemoteProperty(memberId, InPropInt32);
-	FScopeLock Lock(&(_SentData->PropInt32Mutex));	
+	FScopeLock Lock(&(_SentData->PropInt32Mutex));
 	_SentData->PropInt32 = InPropInt32;
 }
 
@@ -283,10 +283,10 @@ void UTbSimpleSimpleArrayInterfaceOLinkClient::SetPropInt64_Implementation(const
 		{
 			return;
 		}
-	}	
+	}
 	static const auto memberId = ApiGear::ObjectLink::Name::createMemberId(m_sink->olinkObjectName(), "propInt64");
 	m_sink->GetNode()->setRemoteProperty(memberId, InPropInt64);
-	FScopeLock Lock(&(_SentData->PropInt64Mutex));	
+	FScopeLock Lock(&(_SentData->PropInt64Mutex));
 	_SentData->PropInt64 = InPropInt64;
 }
 
@@ -316,10 +316,10 @@ void UTbSimpleSimpleArrayInterfaceOLinkClient::SetPropFloat_Implementation(const
 		{
 			return;
 		}
-	}	
+	}
 	static const auto memberId = ApiGear::ObjectLink::Name::createMemberId(m_sink->olinkObjectName(), "propFloat");
 	m_sink->GetNode()->setRemoteProperty(memberId, InPropFloat);
-	FScopeLock Lock(&(_SentData->PropFloatMutex));	
+	FScopeLock Lock(&(_SentData->PropFloatMutex));
 	_SentData->PropFloat = InPropFloat;
 }
 
@@ -349,10 +349,10 @@ void UTbSimpleSimpleArrayInterfaceOLinkClient::SetPropFloat32_Implementation(con
 		{
 			return;
 		}
-	}	
+	}
 	static const auto memberId = ApiGear::ObjectLink::Name::createMemberId(m_sink->olinkObjectName(), "propFloat32");
 	m_sink->GetNode()->setRemoteProperty(memberId, InPropFloat32);
-	FScopeLock Lock(&(_SentData->PropFloat32Mutex));	
+	FScopeLock Lock(&(_SentData->PropFloat32Mutex));
 	_SentData->PropFloat32 = InPropFloat32;
 }
 
@@ -382,10 +382,10 @@ void UTbSimpleSimpleArrayInterfaceOLinkClient::SetPropFloat64_Implementation(con
 		{
 			return;
 		}
-	}	
+	}
 	static const auto memberId = ApiGear::ObjectLink::Name::createMemberId(m_sink->olinkObjectName(), "propFloat64");
 	m_sink->GetNode()->setRemoteProperty(memberId, InPropFloat64);
-	FScopeLock Lock(&(_SentData->PropFloat64Mutex));	
+	FScopeLock Lock(&(_SentData->PropFloat64Mutex));
 	_SentData->PropFloat64 = InPropFloat64;
 }
 
@@ -415,10 +415,10 @@ void UTbSimpleSimpleArrayInterfaceOLinkClient::SetPropString_Implementation(cons
 		{
 			return;
 		}
-	}	
+	}
 	static const auto memberId = ApiGear::ObjectLink::Name::createMemberId(m_sink->olinkObjectName(), "propString");
 	m_sink->GetNode()->setRemoteProperty(memberId, InPropString);
-	FScopeLock Lock(&(_SentData->PropStringMutex));	
+	FScopeLock Lock(&(_SentData->PropStringMutex));
 	_SentData->PropString = InPropString;
 }
 

--- a/goldenmaster/Plugins/TbSimple/Source/TbSimple/Private/Generated/OLink/TbSimpleSimpleArrayInterfaceOLinkClient.cpp
+++ b/goldenmaster/Plugins/TbSimple/Source/TbSimple/Private/Generated/OLink/TbSimpleSimpleArrayInterfaceOLinkClient.cpp
@@ -35,19 +35,28 @@ THIRD_PARTY_INCLUDES_START
 #include "olink/clientnode.h"
 #include "olink/iobjectsink.h"
 THIRD_PARTY_INCLUDES_END
+#include "HAL/CriticalSection.h"
 
 /**
    \brief data structure to hold the last sent property values
 */
 struct TbSimpleSimpleArrayInterfacePropertiesData
 {
+	FCriticalSection PropBoolMutex;
 	TArray<bool> PropBool{TArray<bool>()};
+	FCriticalSection PropIntMutex;
 	TArray<int32> PropInt{TArray<int32>()};
+	FCriticalSection PropInt32Mutex;
 	TArray<int32> PropInt32{TArray<int32>()};
+	FCriticalSection PropInt64Mutex;
 	TArray<int64> PropInt64{TArray<int64>()};
+	FCriticalSection PropFloatMutex;
 	TArray<float> PropFloat{TArray<float>()};
+	FCriticalSection PropFloat32Mutex;
 	TArray<float> PropFloat32{TArray<float>()};
+	FCriticalSection PropFloat64Mutex;
 	TArray<double> PropFloat64{TArray<double>()};
+	FCriticalSection PropStringMutex;
 	TArray<FString> PropString{TArray<FString>()};
 };
 DEFINE_LOG_CATEGORY(LogTbSimpleSimpleArrayInterfaceOLinkClient);
@@ -169,12 +178,16 @@ void UTbSimpleSimpleArrayInterfaceOLinkClient::SetPropBool_Implementation(const 
 	}
 
 	// only send change requests if the value wasn't already sent -> reduce network load
-	if (_SentData->PropBool == InPropBool)
 	{
-		return;
-	}
+		FScopeLock Lock(&(_SentData->PropBoolMutex));
+		if (_SentData->PropBool == InPropBool)
+		{
+			return;
+		}
+	}	
 	static const auto memberId = ApiGear::ObjectLink::Name::createMemberId(m_sink->olinkObjectName(), "propBool");
 	m_sink->GetNode()->setRemoteProperty(memberId, InPropBool);
+	FScopeLock Lock(&(_SentData->PropBoolMutex));	
 	_SentData->PropBool = InPropBool;
 }
 
@@ -198,12 +211,16 @@ void UTbSimpleSimpleArrayInterfaceOLinkClient::SetPropInt_Implementation(const T
 	}
 
 	// only send change requests if the value wasn't already sent -> reduce network load
-	if (_SentData->PropInt == InPropInt)
 	{
-		return;
-	}
+		FScopeLock Lock(&(_SentData->PropIntMutex));
+		if (_SentData->PropInt == InPropInt)
+		{
+			return;
+		}
+	}	
 	static const auto memberId = ApiGear::ObjectLink::Name::createMemberId(m_sink->olinkObjectName(), "propInt");
 	m_sink->GetNode()->setRemoteProperty(memberId, InPropInt);
+	FScopeLock Lock(&(_SentData->PropIntMutex));	
 	_SentData->PropInt = InPropInt;
 }
 
@@ -227,12 +244,16 @@ void UTbSimpleSimpleArrayInterfaceOLinkClient::SetPropInt32_Implementation(const
 	}
 
 	// only send change requests if the value wasn't already sent -> reduce network load
-	if (_SentData->PropInt32 == InPropInt32)
 	{
-		return;
-	}
+		FScopeLock Lock(&(_SentData->PropInt32Mutex));
+		if (_SentData->PropInt32 == InPropInt32)
+		{
+			return;
+		}
+	}	
 	static const auto memberId = ApiGear::ObjectLink::Name::createMemberId(m_sink->olinkObjectName(), "propInt32");
 	m_sink->GetNode()->setRemoteProperty(memberId, InPropInt32);
+	FScopeLock Lock(&(_SentData->PropInt32Mutex));	
 	_SentData->PropInt32 = InPropInt32;
 }
 
@@ -256,12 +277,16 @@ void UTbSimpleSimpleArrayInterfaceOLinkClient::SetPropInt64_Implementation(const
 	}
 
 	// only send change requests if the value wasn't already sent -> reduce network load
-	if (_SentData->PropInt64 == InPropInt64)
 	{
-		return;
-	}
+		FScopeLock Lock(&(_SentData->PropInt64Mutex));
+		if (_SentData->PropInt64 == InPropInt64)
+		{
+			return;
+		}
+	}	
 	static const auto memberId = ApiGear::ObjectLink::Name::createMemberId(m_sink->olinkObjectName(), "propInt64");
 	m_sink->GetNode()->setRemoteProperty(memberId, InPropInt64);
+	FScopeLock Lock(&(_SentData->PropInt64Mutex));	
 	_SentData->PropInt64 = InPropInt64;
 }
 
@@ -285,12 +310,16 @@ void UTbSimpleSimpleArrayInterfaceOLinkClient::SetPropFloat_Implementation(const
 	}
 
 	// only send change requests if the value wasn't already sent -> reduce network load
-	if (_SentData->PropFloat == InPropFloat)
 	{
-		return;
-	}
+		FScopeLock Lock(&(_SentData->PropFloatMutex));
+		if (_SentData->PropFloat == InPropFloat)
+		{
+			return;
+		}
+	}	
 	static const auto memberId = ApiGear::ObjectLink::Name::createMemberId(m_sink->olinkObjectName(), "propFloat");
 	m_sink->GetNode()->setRemoteProperty(memberId, InPropFloat);
+	FScopeLock Lock(&(_SentData->PropFloatMutex));	
 	_SentData->PropFloat = InPropFloat;
 }
 
@@ -314,12 +343,16 @@ void UTbSimpleSimpleArrayInterfaceOLinkClient::SetPropFloat32_Implementation(con
 	}
 
 	// only send change requests if the value wasn't already sent -> reduce network load
-	if (_SentData->PropFloat32 == InPropFloat32)
 	{
-		return;
-	}
+		FScopeLock Lock(&(_SentData->PropFloat32Mutex));
+		if (_SentData->PropFloat32 == InPropFloat32)
+		{
+			return;
+		}
+	}	
 	static const auto memberId = ApiGear::ObjectLink::Name::createMemberId(m_sink->olinkObjectName(), "propFloat32");
 	m_sink->GetNode()->setRemoteProperty(memberId, InPropFloat32);
+	FScopeLock Lock(&(_SentData->PropFloat32Mutex));	
 	_SentData->PropFloat32 = InPropFloat32;
 }
 
@@ -343,12 +376,16 @@ void UTbSimpleSimpleArrayInterfaceOLinkClient::SetPropFloat64_Implementation(con
 	}
 
 	// only send change requests if the value wasn't already sent -> reduce network load
-	if (_SentData->PropFloat64 == InPropFloat64)
 	{
-		return;
-	}
+		FScopeLock Lock(&(_SentData->PropFloat64Mutex));
+		if (_SentData->PropFloat64 == InPropFloat64)
+		{
+			return;
+		}
+	}	
 	static const auto memberId = ApiGear::ObjectLink::Name::createMemberId(m_sink->olinkObjectName(), "propFloat64");
 	m_sink->GetNode()->setRemoteProperty(memberId, InPropFloat64);
+	FScopeLock Lock(&(_SentData->PropFloat64Mutex));	
 	_SentData->PropFloat64 = InPropFloat64;
 }
 
@@ -372,12 +409,16 @@ void UTbSimpleSimpleArrayInterfaceOLinkClient::SetPropString_Implementation(cons
 	}
 
 	// only send change requests if the value wasn't already sent -> reduce network load
-	if (_SentData->PropString == InPropString)
 	{
-		return;
-	}
+		FScopeLock Lock(&(_SentData->PropStringMutex));
+		if (_SentData->PropString == InPropString)
+		{
+			return;
+		}
+	}	
 	static const auto memberId = ApiGear::ObjectLink::Name::createMemberId(m_sink->olinkObjectName(), "propString");
 	m_sink->GetNode()->setRemoteProperty(memberId, InPropString);
+	FScopeLock Lock(&(_SentData->PropStringMutex));	
 	_SentData->PropString = InPropString;
 }
 

--- a/goldenmaster/Plugins/TbSimple/Source/TbSimple/Private/Generated/OLink/TbSimpleSimpleInterfaceOLinkClient.cpp
+++ b/goldenmaster/Plugins/TbSimple/Source/TbSimple/Private/Generated/OLink/TbSimpleSimpleInterfaceOLinkClient.cpp
@@ -177,9 +177,9 @@ void UTbSimpleSimpleInterfaceOLinkClient::SetPropBool_Implementation(bool bInPro
 	if (_SentData->bPropBool == bInPropBool)
 	{
 		return;
-	}	
+	}
 	static const auto memberId = ApiGear::ObjectLink::Name::createMemberId(m_sink->olinkObjectName(), "propBool");
-	m_sink->GetNode()->setRemoteProperty(memberId, bInPropBool);	
+	m_sink->GetNode()->setRemoteProperty(memberId, bInPropBool);
 	_SentData->bPropBool = bInPropBool;
 }
 
@@ -206,9 +206,9 @@ void UTbSimpleSimpleInterfaceOLinkClient::SetPropInt_Implementation(int32 InProp
 	if (_SentData->PropInt == InPropInt)
 	{
 		return;
-	}	
+	}
 	static const auto memberId = ApiGear::ObjectLink::Name::createMemberId(m_sink->olinkObjectName(), "propInt");
-	m_sink->GetNode()->setRemoteProperty(memberId, InPropInt);	
+	m_sink->GetNode()->setRemoteProperty(memberId, InPropInt);
 	_SentData->PropInt = InPropInt;
 }
 
@@ -235,9 +235,9 @@ void UTbSimpleSimpleInterfaceOLinkClient::SetPropInt32_Implementation(int32 InPr
 	if (_SentData->PropInt32 == InPropInt32)
 	{
 		return;
-	}	
+	}
 	static const auto memberId = ApiGear::ObjectLink::Name::createMemberId(m_sink->olinkObjectName(), "propInt32");
-	m_sink->GetNode()->setRemoteProperty(memberId, InPropInt32);	
+	m_sink->GetNode()->setRemoteProperty(memberId, InPropInt32);
 	_SentData->PropInt32 = InPropInt32;
 }
 
@@ -264,9 +264,9 @@ void UTbSimpleSimpleInterfaceOLinkClient::SetPropInt64_Implementation(int64 InPr
 	if (_SentData->PropInt64 == InPropInt64)
 	{
 		return;
-	}	
+	}
 	static const auto memberId = ApiGear::ObjectLink::Name::createMemberId(m_sink->olinkObjectName(), "propInt64");
-	m_sink->GetNode()->setRemoteProperty(memberId, InPropInt64);	
+	m_sink->GetNode()->setRemoteProperty(memberId, InPropInt64);
 	_SentData->PropInt64 = InPropInt64;
 }
 
@@ -293,9 +293,9 @@ void UTbSimpleSimpleInterfaceOLinkClient::SetPropFloat_Implementation(float InPr
 	if (_SentData->PropFloat == InPropFloat)
 	{
 		return;
-	}	
+	}
 	static const auto memberId = ApiGear::ObjectLink::Name::createMemberId(m_sink->olinkObjectName(), "propFloat");
-	m_sink->GetNode()->setRemoteProperty(memberId, InPropFloat);	
+	m_sink->GetNode()->setRemoteProperty(memberId, InPropFloat);
 	_SentData->PropFloat = InPropFloat;
 }
 
@@ -322,9 +322,9 @@ void UTbSimpleSimpleInterfaceOLinkClient::SetPropFloat32_Implementation(float In
 	if (_SentData->PropFloat32 == InPropFloat32)
 	{
 		return;
-	}	
+	}
 	static const auto memberId = ApiGear::ObjectLink::Name::createMemberId(m_sink->olinkObjectName(), "propFloat32");
-	m_sink->GetNode()->setRemoteProperty(memberId, InPropFloat32);	
+	m_sink->GetNode()->setRemoteProperty(memberId, InPropFloat32);
 	_SentData->PropFloat32 = InPropFloat32;
 }
 
@@ -351,9 +351,9 @@ void UTbSimpleSimpleInterfaceOLinkClient::SetPropFloat64_Implementation(double I
 	if (_SentData->PropFloat64 == InPropFloat64)
 	{
 		return;
-	}	
+	}
 	static const auto memberId = ApiGear::ObjectLink::Name::createMemberId(m_sink->olinkObjectName(), "propFloat64");
-	m_sink->GetNode()->setRemoteProperty(memberId, InPropFloat64);	
+	m_sink->GetNode()->setRemoteProperty(memberId, InPropFloat64);
 	_SentData->PropFloat64 = InPropFloat64;
 }
 
@@ -383,10 +383,10 @@ void UTbSimpleSimpleInterfaceOLinkClient::SetPropString_Implementation(const FSt
 		{
 			return;
 		}
-	}	
+	}
 	static const auto memberId = ApiGear::ObjectLink::Name::createMemberId(m_sink->olinkObjectName(), "propString");
 	m_sink->GetNode()->setRemoteProperty(memberId, InPropString);
-	FScopeLock Lock(&(_SentData->PropStringMutex));	
+	FScopeLock Lock(&(_SentData->PropStringMutex));
 	_SentData->PropString = InPropString;
 }
 

--- a/goldenmaster/Plugins/Testbed1/Source/Testbed1/Private/Generated/OLink/Testbed1StructArrayInterfaceOLinkClient.cpp
+++ b/goldenmaster/Plugins/Testbed1/Source/Testbed1/Private/Generated/OLink/Testbed1StructArrayInterfaceOLinkClient.cpp
@@ -176,10 +176,10 @@ void UTestbed1StructArrayInterfaceOLinkClient::SetPropBool_Implementation(const 
 		{
 			return;
 		}
-	}	
+	}
 	static const auto memberId = ApiGear::ObjectLink::Name::createMemberId(m_sink->olinkObjectName(), "propBool");
 	m_sink->GetNode()->setRemoteProperty(memberId, InPropBool);
-	FScopeLock Lock(&(_SentData->PropBoolMutex));	
+	FScopeLock Lock(&(_SentData->PropBoolMutex));
 	_SentData->PropBool = InPropBool;
 }
 
@@ -209,10 +209,10 @@ void UTestbed1StructArrayInterfaceOLinkClient::SetPropInt_Implementation(const T
 		{
 			return;
 		}
-	}	
+	}
 	static const auto memberId = ApiGear::ObjectLink::Name::createMemberId(m_sink->olinkObjectName(), "propInt");
 	m_sink->GetNode()->setRemoteProperty(memberId, InPropInt);
-	FScopeLock Lock(&(_SentData->PropIntMutex));	
+	FScopeLock Lock(&(_SentData->PropIntMutex));
 	_SentData->PropInt = InPropInt;
 }
 
@@ -242,10 +242,10 @@ void UTestbed1StructArrayInterfaceOLinkClient::SetPropFloat_Implementation(const
 		{
 			return;
 		}
-	}	
+	}
 	static const auto memberId = ApiGear::ObjectLink::Name::createMemberId(m_sink->olinkObjectName(), "propFloat");
 	m_sink->GetNode()->setRemoteProperty(memberId, InPropFloat);
-	FScopeLock Lock(&(_SentData->PropFloatMutex));	
+	FScopeLock Lock(&(_SentData->PropFloatMutex));
 	_SentData->PropFloat = InPropFloat;
 }
 
@@ -275,10 +275,10 @@ void UTestbed1StructArrayInterfaceOLinkClient::SetPropString_Implementation(cons
 		{
 			return;
 		}
-	}	
+	}
 	static const auto memberId = ApiGear::ObjectLink::Name::createMemberId(m_sink->olinkObjectName(), "propString");
 	m_sink->GetNode()->setRemoteProperty(memberId, InPropString);
-	FScopeLock Lock(&(_SentData->PropStringMutex));	
+	FScopeLock Lock(&(_SentData->PropStringMutex));
 	_SentData->PropString = InPropString;
 }
 

--- a/goldenmaster/Plugins/Testbed1/Source/Testbed1/Private/Generated/OLink/Testbed1StructArrayInterfaceOLinkClient.cpp
+++ b/goldenmaster/Plugins/Testbed1/Source/Testbed1/Private/Generated/OLink/Testbed1StructArrayInterfaceOLinkClient.cpp
@@ -35,15 +35,20 @@ THIRD_PARTY_INCLUDES_START
 #include "olink/clientnode.h"
 #include "olink/iobjectsink.h"
 THIRD_PARTY_INCLUDES_END
+#include "HAL/CriticalSection.h"
 
 /**
    \brief data structure to hold the last sent property values
 */
 struct Testbed1StructArrayInterfacePropertiesData
 {
+	FCriticalSection PropBoolMutex;
 	TArray<FTestbed1StructBool> PropBool{TArray<FTestbed1StructBool>()};
+	FCriticalSection PropIntMutex;
 	TArray<FTestbed1StructInt> PropInt{TArray<FTestbed1StructInt>()};
+	FCriticalSection PropFloatMutex;
 	TArray<FTestbed1StructFloat> PropFloat{TArray<FTestbed1StructFloat>()};
+	FCriticalSection PropStringMutex;
 	TArray<FTestbed1StructString> PropString{TArray<FTestbed1StructString>()};
 };
 DEFINE_LOG_CATEGORY(LogTestbed1StructArrayInterfaceOLinkClient);
@@ -165,12 +170,16 @@ void UTestbed1StructArrayInterfaceOLinkClient::SetPropBool_Implementation(const 
 	}
 
 	// only send change requests if the value wasn't already sent -> reduce network load
-	if (_SentData->PropBool == InPropBool)
 	{
-		return;
-	}
+		FScopeLock Lock(&(_SentData->PropBoolMutex));
+		if (_SentData->PropBool == InPropBool)
+		{
+			return;
+		}
+	}	
 	static const auto memberId = ApiGear::ObjectLink::Name::createMemberId(m_sink->olinkObjectName(), "propBool");
 	m_sink->GetNode()->setRemoteProperty(memberId, InPropBool);
+	FScopeLock Lock(&(_SentData->PropBoolMutex));	
 	_SentData->PropBool = InPropBool;
 }
 
@@ -194,12 +203,16 @@ void UTestbed1StructArrayInterfaceOLinkClient::SetPropInt_Implementation(const T
 	}
 
 	// only send change requests if the value wasn't already sent -> reduce network load
-	if (_SentData->PropInt == InPropInt)
 	{
-		return;
-	}
+		FScopeLock Lock(&(_SentData->PropIntMutex));
+		if (_SentData->PropInt == InPropInt)
+		{
+			return;
+		}
+	}	
 	static const auto memberId = ApiGear::ObjectLink::Name::createMemberId(m_sink->olinkObjectName(), "propInt");
 	m_sink->GetNode()->setRemoteProperty(memberId, InPropInt);
+	FScopeLock Lock(&(_SentData->PropIntMutex));	
 	_SentData->PropInt = InPropInt;
 }
 
@@ -223,12 +236,16 @@ void UTestbed1StructArrayInterfaceOLinkClient::SetPropFloat_Implementation(const
 	}
 
 	// only send change requests if the value wasn't already sent -> reduce network load
-	if (_SentData->PropFloat == InPropFloat)
 	{
-		return;
-	}
+		FScopeLock Lock(&(_SentData->PropFloatMutex));
+		if (_SentData->PropFloat == InPropFloat)
+		{
+			return;
+		}
+	}	
 	static const auto memberId = ApiGear::ObjectLink::Name::createMemberId(m_sink->olinkObjectName(), "propFloat");
 	m_sink->GetNode()->setRemoteProperty(memberId, InPropFloat);
+	FScopeLock Lock(&(_SentData->PropFloatMutex));	
 	_SentData->PropFloat = InPropFloat;
 }
 
@@ -252,12 +269,16 @@ void UTestbed1StructArrayInterfaceOLinkClient::SetPropString_Implementation(cons
 	}
 
 	// only send change requests if the value wasn't already sent -> reduce network load
-	if (_SentData->PropString == InPropString)
 	{
-		return;
-	}
+		FScopeLock Lock(&(_SentData->PropStringMutex));
+		if (_SentData->PropString == InPropString)
+		{
+			return;
+		}
+	}	
 	static const auto memberId = ApiGear::ObjectLink::Name::createMemberId(m_sink->olinkObjectName(), "propString");
 	m_sink->GetNode()->setRemoteProperty(memberId, InPropString);
+	FScopeLock Lock(&(_SentData->PropStringMutex));	
 	_SentData->PropString = InPropString;
 }
 

--- a/goldenmaster/Plugins/Testbed1/Source/Testbed1/Private/Generated/OLink/Testbed1StructInterfaceOLinkClient.cpp
+++ b/goldenmaster/Plugins/Testbed1/Source/Testbed1/Private/Generated/OLink/Testbed1StructInterfaceOLinkClient.cpp
@@ -176,10 +176,10 @@ void UTestbed1StructInterfaceOLinkClient::SetPropBool_Implementation(const FTest
 		{
 			return;
 		}
-	}	
+	}
 	static const auto memberId = ApiGear::ObjectLink::Name::createMemberId(m_sink->olinkObjectName(), "propBool");
 	m_sink->GetNode()->setRemoteProperty(memberId, InPropBool);
-	FScopeLock Lock(&(_SentData->PropBoolMutex));	
+	FScopeLock Lock(&(_SentData->PropBoolMutex));
 	_SentData->PropBool = InPropBool;
 }
 
@@ -209,10 +209,10 @@ void UTestbed1StructInterfaceOLinkClient::SetPropInt_Implementation(const FTestb
 		{
 			return;
 		}
-	}	
+	}
 	static const auto memberId = ApiGear::ObjectLink::Name::createMemberId(m_sink->olinkObjectName(), "propInt");
 	m_sink->GetNode()->setRemoteProperty(memberId, InPropInt);
-	FScopeLock Lock(&(_SentData->PropIntMutex));	
+	FScopeLock Lock(&(_SentData->PropIntMutex));
 	_SentData->PropInt = InPropInt;
 }
 
@@ -242,10 +242,10 @@ void UTestbed1StructInterfaceOLinkClient::SetPropFloat_Implementation(const FTes
 		{
 			return;
 		}
-	}	
+	}
 	static const auto memberId = ApiGear::ObjectLink::Name::createMemberId(m_sink->olinkObjectName(), "propFloat");
 	m_sink->GetNode()->setRemoteProperty(memberId, InPropFloat);
-	FScopeLock Lock(&(_SentData->PropFloatMutex));	
+	FScopeLock Lock(&(_SentData->PropFloatMutex));
 	_SentData->PropFloat = InPropFloat;
 }
 
@@ -275,10 +275,10 @@ void UTestbed1StructInterfaceOLinkClient::SetPropString_Implementation(const FTe
 		{
 			return;
 		}
-	}	
+	}
 	static const auto memberId = ApiGear::ObjectLink::Name::createMemberId(m_sink->olinkObjectName(), "propString");
 	m_sink->GetNode()->setRemoteProperty(memberId, InPropString);
-	FScopeLock Lock(&(_SentData->PropStringMutex));	
+	FScopeLock Lock(&(_SentData->PropStringMutex));
 	_SentData->PropString = InPropString;
 }
 

--- a/goldenmaster/Plugins/Testbed1/Source/Testbed1/Private/Generated/OLink/Testbed1StructInterfaceOLinkClient.cpp
+++ b/goldenmaster/Plugins/Testbed1/Source/Testbed1/Private/Generated/OLink/Testbed1StructInterfaceOLinkClient.cpp
@@ -35,15 +35,20 @@ THIRD_PARTY_INCLUDES_START
 #include "olink/clientnode.h"
 #include "olink/iobjectsink.h"
 THIRD_PARTY_INCLUDES_END
+#include "HAL/CriticalSection.h"
 
 /**
    \brief data structure to hold the last sent property values
 */
 struct Testbed1StructInterfacePropertiesData
 {
+	FCriticalSection PropBoolMutex;
 	FTestbed1StructBool PropBool{FTestbed1StructBool()};
+	FCriticalSection PropIntMutex;
 	FTestbed1StructInt PropInt{FTestbed1StructInt()};
+	FCriticalSection PropFloatMutex;
 	FTestbed1StructFloat PropFloat{FTestbed1StructFloat()};
+	FCriticalSection PropStringMutex;
 	FTestbed1StructString PropString{FTestbed1StructString()};
 };
 DEFINE_LOG_CATEGORY(LogTestbed1StructInterfaceOLinkClient);
@@ -165,12 +170,16 @@ void UTestbed1StructInterfaceOLinkClient::SetPropBool_Implementation(const FTest
 	}
 
 	// only send change requests if the value wasn't already sent -> reduce network load
-	if (_SentData->PropBool == InPropBool)
 	{
-		return;
-	}
+		FScopeLock Lock(&(_SentData->PropBoolMutex));
+		if (_SentData->PropBool == InPropBool)
+		{
+			return;
+		}
+	}	
 	static const auto memberId = ApiGear::ObjectLink::Name::createMemberId(m_sink->olinkObjectName(), "propBool");
 	m_sink->GetNode()->setRemoteProperty(memberId, InPropBool);
+	FScopeLock Lock(&(_SentData->PropBoolMutex));	
 	_SentData->PropBool = InPropBool;
 }
 
@@ -194,12 +203,16 @@ void UTestbed1StructInterfaceOLinkClient::SetPropInt_Implementation(const FTestb
 	}
 
 	// only send change requests if the value wasn't already sent -> reduce network load
-	if (_SentData->PropInt == InPropInt)
 	{
-		return;
-	}
+		FScopeLock Lock(&(_SentData->PropIntMutex));
+		if (_SentData->PropInt == InPropInt)
+		{
+			return;
+		}
+	}	
 	static const auto memberId = ApiGear::ObjectLink::Name::createMemberId(m_sink->olinkObjectName(), "propInt");
 	m_sink->GetNode()->setRemoteProperty(memberId, InPropInt);
+	FScopeLock Lock(&(_SentData->PropIntMutex));	
 	_SentData->PropInt = InPropInt;
 }
 
@@ -223,12 +236,16 @@ void UTestbed1StructInterfaceOLinkClient::SetPropFloat_Implementation(const FTes
 	}
 
 	// only send change requests if the value wasn't already sent -> reduce network load
-	if (_SentData->PropFloat == InPropFloat)
 	{
-		return;
-	}
+		FScopeLock Lock(&(_SentData->PropFloatMutex));
+		if (_SentData->PropFloat == InPropFloat)
+		{
+			return;
+		}
+	}	
 	static const auto memberId = ApiGear::ObjectLink::Name::createMemberId(m_sink->olinkObjectName(), "propFloat");
 	m_sink->GetNode()->setRemoteProperty(memberId, InPropFloat);
+	FScopeLock Lock(&(_SentData->PropFloatMutex));	
 	_SentData->PropFloat = InPropFloat;
 }
 
@@ -252,12 +269,16 @@ void UTestbed1StructInterfaceOLinkClient::SetPropString_Implementation(const FTe
 	}
 
 	// only send change requests if the value wasn't already sent -> reduce network load
-	if (_SentData->PropString == InPropString)
 	{
-		return;
-	}
+		FScopeLock Lock(&(_SentData->PropStringMutex));
+		if (_SentData->PropString == InPropString)
+		{
+			return;
+		}
+	}	
 	static const auto memberId = ApiGear::ObjectLink::Name::createMemberId(m_sink->olinkObjectName(), "propString");
 	m_sink->GetNode()->setRemoteProperty(memberId, InPropString);
+	FScopeLock Lock(&(_SentData->PropStringMutex));	
 	_SentData->PropString = InPropString;
 }
 

--- a/goldenmaster/Plugins/Testbed2/Source/Testbed2/Private/Generated/OLink/Testbed2ManyParamInterfaceOLinkClient.cpp
+++ b/goldenmaster/Plugins/Testbed2/Source/Testbed2/Private/Generated/OLink/Testbed2ManyParamInterfaceOLinkClient.cpp
@@ -35,16 +35,17 @@ THIRD_PARTY_INCLUDES_START
 #include "olink/clientnode.h"
 #include "olink/iobjectsink.h"
 THIRD_PARTY_INCLUDES_END
+#include <atomic>
 
 /**
    \brief data structure to hold the last sent property values
 */
 struct Testbed2ManyParamInterfacePropertiesData
 {
-	int32 Prop1{0};
-	int32 Prop2{0};
-	int32 Prop3{0};
-	int32 Prop4{0};
+	std::atomic<int32> Prop1{0};
+	std::atomic<int32> Prop2{0};
+	std::atomic<int32> Prop3{0};
+	std::atomic<int32> Prop4{0};
 };
 DEFINE_LOG_CATEGORY(LogTestbed2ManyParamInterfaceOLinkClient);
 
@@ -168,9 +169,9 @@ void UTestbed2ManyParamInterfaceOLinkClient::SetProp1_Implementation(int32 InPro
 	if (_SentData->Prop1 == InProp1)
 	{
 		return;
-	}
+	}	
 	static const auto memberId = ApiGear::ObjectLink::Name::createMemberId(m_sink->olinkObjectName(), "prop1");
-	m_sink->GetNode()->setRemoteProperty(memberId, InProp1);
+	m_sink->GetNode()->setRemoteProperty(memberId, InProp1);	
 	_SentData->Prop1 = InProp1;
 }
 
@@ -197,9 +198,9 @@ void UTestbed2ManyParamInterfaceOLinkClient::SetProp2_Implementation(int32 InPro
 	if (_SentData->Prop2 == InProp2)
 	{
 		return;
-	}
+	}	
 	static const auto memberId = ApiGear::ObjectLink::Name::createMemberId(m_sink->olinkObjectName(), "prop2");
-	m_sink->GetNode()->setRemoteProperty(memberId, InProp2);
+	m_sink->GetNode()->setRemoteProperty(memberId, InProp2);	
 	_SentData->Prop2 = InProp2;
 }
 
@@ -226,9 +227,9 @@ void UTestbed2ManyParamInterfaceOLinkClient::SetProp3_Implementation(int32 InPro
 	if (_SentData->Prop3 == InProp3)
 	{
 		return;
-	}
+	}	
 	static const auto memberId = ApiGear::ObjectLink::Name::createMemberId(m_sink->olinkObjectName(), "prop3");
-	m_sink->GetNode()->setRemoteProperty(memberId, InProp3);
+	m_sink->GetNode()->setRemoteProperty(memberId, InProp3);	
 	_SentData->Prop3 = InProp3;
 }
 
@@ -255,9 +256,9 @@ void UTestbed2ManyParamInterfaceOLinkClient::SetProp4_Implementation(int32 InPro
 	if (_SentData->Prop4 == InProp4)
 	{
 		return;
-	}
+	}	
 	static const auto memberId = ApiGear::ObjectLink::Name::createMemberId(m_sink->olinkObjectName(), "prop4");
-	m_sink->GetNode()->setRemoteProperty(memberId, InProp4);
+	m_sink->GetNode()->setRemoteProperty(memberId, InProp4);	
 	_SentData->Prop4 = InProp4;
 }
 

--- a/goldenmaster/Plugins/Testbed2/Source/Testbed2/Private/Generated/OLink/Testbed2ManyParamInterfaceOLinkClient.cpp
+++ b/goldenmaster/Plugins/Testbed2/Source/Testbed2/Private/Generated/OLink/Testbed2ManyParamInterfaceOLinkClient.cpp
@@ -169,9 +169,9 @@ void UTestbed2ManyParamInterfaceOLinkClient::SetProp1_Implementation(int32 InPro
 	if (_SentData->Prop1 == InProp1)
 	{
 		return;
-	}	
+	}
 	static const auto memberId = ApiGear::ObjectLink::Name::createMemberId(m_sink->olinkObjectName(), "prop1");
-	m_sink->GetNode()->setRemoteProperty(memberId, InProp1);	
+	m_sink->GetNode()->setRemoteProperty(memberId, InProp1);
 	_SentData->Prop1 = InProp1;
 }
 
@@ -198,9 +198,9 @@ void UTestbed2ManyParamInterfaceOLinkClient::SetProp2_Implementation(int32 InPro
 	if (_SentData->Prop2 == InProp2)
 	{
 		return;
-	}	
+	}
 	static const auto memberId = ApiGear::ObjectLink::Name::createMemberId(m_sink->olinkObjectName(), "prop2");
-	m_sink->GetNode()->setRemoteProperty(memberId, InProp2);	
+	m_sink->GetNode()->setRemoteProperty(memberId, InProp2);
 	_SentData->Prop2 = InProp2;
 }
 
@@ -227,9 +227,9 @@ void UTestbed2ManyParamInterfaceOLinkClient::SetProp3_Implementation(int32 InPro
 	if (_SentData->Prop3 == InProp3)
 	{
 		return;
-	}	
+	}
 	static const auto memberId = ApiGear::ObjectLink::Name::createMemberId(m_sink->olinkObjectName(), "prop3");
-	m_sink->GetNode()->setRemoteProperty(memberId, InProp3);	
+	m_sink->GetNode()->setRemoteProperty(memberId, InProp3);
 	_SentData->Prop3 = InProp3;
 }
 
@@ -256,9 +256,9 @@ void UTestbed2ManyParamInterfaceOLinkClient::SetProp4_Implementation(int32 InPro
 	if (_SentData->Prop4 == InProp4)
 	{
 		return;
-	}	
+	}
 	static const auto memberId = ApiGear::ObjectLink::Name::createMemberId(m_sink->olinkObjectName(), "prop4");
-	m_sink->GetNode()->setRemoteProperty(memberId, InProp4);	
+	m_sink->GetNode()->setRemoteProperty(memberId, InProp4);
 	_SentData->Prop4 = InProp4;
 }
 

--- a/goldenmaster/Plugins/Testbed2/Source/Testbed2/Private/Generated/OLink/Testbed2NestedStruct1InterfaceOLinkClient.cpp
+++ b/goldenmaster/Plugins/Testbed2/Source/Testbed2/Private/Generated/OLink/Testbed2NestedStruct1InterfaceOLinkClient.cpp
@@ -170,10 +170,10 @@ void UTestbed2NestedStruct1InterfaceOLinkClient::SetProp1_Implementation(const F
 		{
 			return;
 		}
-	}	
+	}
 	static const auto memberId = ApiGear::ObjectLink::Name::createMemberId(m_sink->olinkObjectName(), "prop1");
 	m_sink->GetNode()->setRemoteProperty(memberId, InProp1);
-	FScopeLock Lock(&(_SentData->Prop1Mutex));	
+	FScopeLock Lock(&(_SentData->Prop1Mutex));
 	_SentData->Prop1 = InProp1;
 }
 

--- a/goldenmaster/Plugins/Testbed2/Source/Testbed2/Private/Generated/OLink/Testbed2NestedStruct2InterfaceOLinkClient.cpp
+++ b/goldenmaster/Plugins/Testbed2/Source/Testbed2/Private/Generated/OLink/Testbed2NestedStruct2InterfaceOLinkClient.cpp
@@ -172,10 +172,10 @@ void UTestbed2NestedStruct2InterfaceOLinkClient::SetProp1_Implementation(const F
 		{
 			return;
 		}
-	}	
+	}
 	static const auto memberId = ApiGear::ObjectLink::Name::createMemberId(m_sink->olinkObjectName(), "prop1");
 	m_sink->GetNode()->setRemoteProperty(memberId, InProp1);
-	FScopeLock Lock(&(_SentData->Prop1Mutex));	
+	FScopeLock Lock(&(_SentData->Prop1Mutex));
 	_SentData->Prop1 = InProp1;
 }
 
@@ -205,10 +205,10 @@ void UTestbed2NestedStruct2InterfaceOLinkClient::SetProp2_Implementation(const F
 		{
 			return;
 		}
-	}	
+	}
 	static const auto memberId = ApiGear::ObjectLink::Name::createMemberId(m_sink->olinkObjectName(), "prop2");
 	m_sink->GetNode()->setRemoteProperty(memberId, InProp2);
-	FScopeLock Lock(&(_SentData->Prop2Mutex));	
+	FScopeLock Lock(&(_SentData->Prop2Mutex));
 	_SentData->Prop2 = InProp2;
 }
 

--- a/goldenmaster/Plugins/Testbed2/Source/Testbed2/Private/Generated/OLink/Testbed2NestedStruct3InterfaceOLinkClient.cpp
+++ b/goldenmaster/Plugins/Testbed2/Source/Testbed2/Private/Generated/OLink/Testbed2NestedStruct3InterfaceOLinkClient.cpp
@@ -35,14 +35,18 @@ THIRD_PARTY_INCLUDES_START
 #include "olink/clientnode.h"
 #include "olink/iobjectsink.h"
 THIRD_PARTY_INCLUDES_END
+#include "HAL/CriticalSection.h"
 
 /**
    \brief data structure to hold the last sent property values
 */
 struct Testbed2NestedStruct3InterfacePropertiesData
 {
+	FCriticalSection Prop1Mutex;
 	FTestbed2NestedStruct1 Prop1{FTestbed2NestedStruct1()};
+	FCriticalSection Prop2Mutex;
 	FTestbed2NestedStruct2 Prop2{FTestbed2NestedStruct2()};
+	FCriticalSection Prop3Mutex;
 	FTestbed2NestedStruct3 Prop3{FTestbed2NestedStruct3()};
 };
 DEFINE_LOG_CATEGORY(LogTestbed2NestedStruct3InterfaceOLinkClient);
@@ -164,12 +168,16 @@ void UTestbed2NestedStruct3InterfaceOLinkClient::SetProp1_Implementation(const F
 	}
 
 	// only send change requests if the value wasn't already sent -> reduce network load
-	if (_SentData->Prop1 == InProp1)
 	{
-		return;
-	}
+		FScopeLock Lock(&(_SentData->Prop1Mutex));
+		if (_SentData->Prop1 == InProp1)
+		{
+			return;
+		}
+	}	
 	static const auto memberId = ApiGear::ObjectLink::Name::createMemberId(m_sink->olinkObjectName(), "prop1");
 	m_sink->GetNode()->setRemoteProperty(memberId, InProp1);
+	FScopeLock Lock(&(_SentData->Prop1Mutex));	
 	_SentData->Prop1 = InProp1;
 }
 
@@ -193,12 +201,16 @@ void UTestbed2NestedStruct3InterfaceOLinkClient::SetProp2_Implementation(const F
 	}
 
 	// only send change requests if the value wasn't already sent -> reduce network load
-	if (_SentData->Prop2 == InProp2)
 	{
-		return;
-	}
+		FScopeLock Lock(&(_SentData->Prop2Mutex));
+		if (_SentData->Prop2 == InProp2)
+		{
+			return;
+		}
+	}	
 	static const auto memberId = ApiGear::ObjectLink::Name::createMemberId(m_sink->olinkObjectName(), "prop2");
 	m_sink->GetNode()->setRemoteProperty(memberId, InProp2);
+	FScopeLock Lock(&(_SentData->Prop2Mutex));	
 	_SentData->Prop2 = InProp2;
 }
 
@@ -222,12 +234,16 @@ void UTestbed2NestedStruct3InterfaceOLinkClient::SetProp3_Implementation(const F
 	}
 
 	// only send change requests if the value wasn't already sent -> reduce network load
-	if (_SentData->Prop3 == InProp3)
 	{
-		return;
-	}
+		FScopeLock Lock(&(_SentData->Prop3Mutex));
+		if (_SentData->Prop3 == InProp3)
+		{
+			return;
+		}
+	}	
 	static const auto memberId = ApiGear::ObjectLink::Name::createMemberId(m_sink->olinkObjectName(), "prop3");
 	m_sink->GetNode()->setRemoteProperty(memberId, InProp3);
+	FScopeLock Lock(&(_SentData->Prop3Mutex));	
 	_SentData->Prop3 = InProp3;
 }
 

--- a/goldenmaster/Plugins/Testbed2/Source/Testbed2/Private/Generated/OLink/Testbed2NestedStruct3InterfaceOLinkClient.cpp
+++ b/goldenmaster/Plugins/Testbed2/Source/Testbed2/Private/Generated/OLink/Testbed2NestedStruct3InterfaceOLinkClient.cpp
@@ -174,10 +174,10 @@ void UTestbed2NestedStruct3InterfaceOLinkClient::SetProp1_Implementation(const F
 		{
 			return;
 		}
-	}	
+	}
 	static const auto memberId = ApiGear::ObjectLink::Name::createMemberId(m_sink->olinkObjectName(), "prop1");
 	m_sink->GetNode()->setRemoteProperty(memberId, InProp1);
-	FScopeLock Lock(&(_SentData->Prop1Mutex));	
+	FScopeLock Lock(&(_SentData->Prop1Mutex));
 	_SentData->Prop1 = InProp1;
 }
 
@@ -207,10 +207,10 @@ void UTestbed2NestedStruct3InterfaceOLinkClient::SetProp2_Implementation(const F
 		{
 			return;
 		}
-	}	
+	}
 	static const auto memberId = ApiGear::ObjectLink::Name::createMemberId(m_sink->olinkObjectName(), "prop2");
 	m_sink->GetNode()->setRemoteProperty(memberId, InProp2);
-	FScopeLock Lock(&(_SentData->Prop2Mutex));	
+	FScopeLock Lock(&(_SentData->Prop2Mutex));
 	_SentData->Prop2 = InProp2;
 }
 
@@ -240,10 +240,10 @@ void UTestbed2NestedStruct3InterfaceOLinkClient::SetProp3_Implementation(const F
 		{
 			return;
 		}
-	}	
+	}
 	static const auto memberId = ApiGear::ObjectLink::Name::createMemberId(m_sink->olinkObjectName(), "prop3");
 	m_sink->GetNode()->setRemoteProperty(memberId, InProp3);
-	FScopeLock Lock(&(_SentData->Prop3Mutex));	
+	FScopeLock Lock(&(_SentData->Prop3Mutex));
 	_SentData->Prop3 = InProp3;
 }
 

--- a/rules.yaml
+++ b/rules.yaml
@@ -175,6 +175,10 @@ features:
             target: "Source/ApiGear/Private/AbstractApiGearConnection.cpp"
             force: true
             raw: true
+          - source: "ApiGear/Source/ApiGear/Public/ApiGearTicker.h"
+            target: "Source/ApiGear/Public/ApiGearTicker.h"
+            force: true
+            raw: true
           - source: "ApiGear/Source/ApiGear/Public/ApiGearLogCategories.h"
             target: "Source/ApiGear/Public/ApiGearLogCategories.h"
             force: true

--- a/templates/ApiGear/Source/ApiGear/Private/AbstractApiGearConnection.cpp
+++ b/templates/ApiGear/Source/ApiGear/Private/AbstractApiGearConnection.cpp
@@ -2,18 +2,6 @@
 
 DEFINE_LOG_CATEGORY(LogApiGearConnection);
 
-#if (ENGINE_MAJOR_VERSION >= 5)
-FTSTicker& GetCoreTicker()
-{
-	return FTSTicker::GetCoreTicker();
-}
-#else
-FTicker& GetCoreTicker()
-{
-	return FTicker::GetCoreTicker();
-}
-#endif
-
 UAbstractApiGearConnection::UAbstractApiGearConnection(const FObjectInitializer& ObjectInitializer)
 	: Super(ObjectInitializer)
 	, bIsAutoReconnectEnabled(true)
@@ -37,7 +25,7 @@ void UAbstractApiGearConnection::OnConnected()
 	SetConnectionState(EApiGearConnectionState::Connected);
 
 	// disable reconnect ticker
-	GetCoreTicker().RemoveTicker(RetryTickerHandle);
+	ApiGearTicker::GetCoreTicker().RemoveTicker(RetryTickerHandle);
 
 	OnConnected_Implementation();
 }
@@ -50,7 +38,7 @@ void UAbstractApiGearConnection::OnDisconnected(bool bReconnect)
 
 	if (bIsAutoReconnectEnabled && bReconnect && !bStopReconnectingRequested)
 	{
-		RetryTickerHandle = GetCoreTicker().AddTicker(RetryTickerDelegate, 1.0f);
+		RetryTickerHandle = ApiGearTicker::GetCoreTicker().AddTicker(RetryTickerDelegate, 1.0f);
 	}
 
 	if (bStopReconnectingRequested)
@@ -85,7 +73,7 @@ void UAbstractApiGearConnection::StopReconnecting()
 {
 	bStopReconnectingRequested = true;
 	// disable reconnect ticker
-	GetCoreTicker().RemoveTicker(RetryTickerHandle);
+	ApiGearTicker::GetCoreTicker().RemoveTicker(RetryTickerHandle);
 }
 
 void UAbstractApiGearConnection::SetAutoReconnectEnabled(bool enabled)
@@ -93,7 +81,7 @@ void UAbstractApiGearConnection::SetAutoReconnectEnabled(bool enabled)
 	if (bIsAutoReconnectEnabled == true && enabled == false)
 	{
 		// disable reconnect ticker
-		GetCoreTicker().RemoveTicker(RetryTickerHandle);
+		ApiGearTicker::GetCoreTicker().RemoveTicker(RetryTickerHandle);
 	}
 	bIsAutoReconnectEnabled = enabled;
 }

--- a/templates/ApiGear/Source/ApiGear/Public/AbstractApiGearConnection.h
+++ b/templates/ApiGear/Source/ApiGear/Public/AbstractApiGearConnection.h
@@ -3,11 +3,9 @@
 #include "ApiGearConnection.h"
 #include "ApiGearTicker.h"
 #include "CoreMinimal.h"
-#include "Containers/Ticker.h"
 #include "UObject/NoExportTypes.h"
 #include "Runtime/Launch/Resources/Version.h"
 #include "AbstractApiGearConnection.generated.h"
-
 
 /**
  * @brief Abstract base for IApiGearConnection implementation

--- a/templates/ApiGear/Source/ApiGear/Public/AbstractApiGearConnection.h
+++ b/templates/ApiGear/Source/ApiGear/Public/AbstractApiGearConnection.h
@@ -1,11 +1,13 @@
 #pragma once
 
 #include "ApiGearConnection.h"
+#include "ApiGearTicker.h"
 #include "CoreMinimal.h"
 #include "Containers/Ticker.h"
 #include "UObject/NoExportTypes.h"
 #include "Runtime/Launch/Resources/Version.h"
 #include "AbstractApiGearConnection.generated.h"
+
 
 /**
  * @brief Abstract base for IApiGearConnection implementation
@@ -54,11 +56,8 @@ private:
 	bool bIsAutoReconnectEnabled;
 	bool bStopReconnectingRequested;
 
-#if (ENGINE_MAJOR_VERSION >= 5)
-	FTSTicker::FDelegateHandle RetryTickerHandle;
-#else
-	FDelegateHandle RetryTickerHandle;
-#endif
+	ApiGear::FDelegateHandle RetryTickerHandle;
+
 	FTickerDelegate RetryTickerDelegate;
 
 	EApiGearConnectionState ConnectionState;

--- a/templates/ApiGear/Source/ApiGear/Public/ApiGearTicker.h
+++ b/templates/ApiGear/Source/ApiGear/Public/ApiGearTicker.h
@@ -1,0 +1,30 @@
+// Copyright Epic Games, Inc. All Rights Reserved
+
+#pragma once
+#include "Runtime/Launch/Resources/Version.h"
+#include "Containers/Ticker.h"
+
+namespace ApiGear
+{
+#if (ENGINE_MAJOR_VERSION >= 5)
+using FDelegateHandle = FTSTicker::FDelegateHandle;
+#else
+using FDelegateHandle = ::FDelegateHandle;
+#endif
+} // namespace ApiGear
+
+class ApiGearTicker
+{
+public:
+#if (ENGINE_MAJOR_VERSION >= 5)
+	static FTSTicker& GetCoreTicker()
+	{
+		return FTSTicker::GetCoreTicker();
+	}
+#else
+	static FTicker& ApiGearTicker::GetCoreTicker()
+	{
+		return GetCoreTicker();
+	}
+#endif
+};

--- a/templates/ApiGear/Source/ApiGearOLink/Private/OLinkHostPrivate.cpp
+++ b/templates/ApiGear/Source/ApiGearOLink/Private/OLinkHostPrivate.cpp
@@ -75,11 +75,7 @@ bool OLinkHostPrivate::Start(uint32 InPort)
 		return false;
 	}
 
-#if (ENGINE_MAJOR_VERSION >= 5)
-	TickerHandle = FTSTicker::GetCoreTicker().AddTicker(FTickerDelegate::CreateRaw(this, &OLinkHostPrivate::Tick));
-#else
-	TickerHandle = FTicker::GetCoreTicker().AddTicker(FTickerDelegate::CreateRaw(this, &OLinkHostPrivate::Tick));
-#endif
+	TickerHandle = ApiGearTicker::GetCoreTicker().AddTicker(FTickerDelegate::CreateRaw(this, &OLinkHostPrivate::Tick));
 	return true;
 }
 
@@ -87,12 +83,7 @@ void OLinkHostPrivate::Stop()
 {
 	if (TickerHandle.IsValid())
 	{
-#if (ENGINE_MAJOR_VERSION >= 5)
-		FTSTicker::GetCoreTicker().RemoveTicker(TickerHandle);
-#else
-		FTicker::GetCoreTicker().RemoveTicker(TickerHandle);
-#endif
-
+		ApiGearTicker::GetCoreTicker().RemoveTicker(TickerHandle);
 		TickerHandle.Reset();
 	}
 	if (Server)

--- a/templates/ApiGear/Source/ApiGearOLink/Private/OLinkHostPrivate.h
+++ b/templates/ApiGear/Source/ApiGearOLink/Private/OLinkHostPrivate.h
@@ -11,6 +11,7 @@ THIRD_PARTY_INCLUDES_START
 THIRD_PARTY_INCLUDES_END
 #include "OLinkHostConnection.h"
 #include "IWebSocketServer.h"
+#include "ApiGearTicker.h"
 
 class INetworkingWebSocket;
 
@@ -63,13 +64,8 @@ private:
 	// olink registry stored here to hand it olink adapter classes
 	TSharedPtr<ApiGear::ObjectLink::RemoteRegistry> Registry;
 
-#if (ENGINE_MAJOR_VERSION >= 5)
 	/// @brief delegate which is connected to the tick function
-	FTSTicker::FDelegateHandle TickerHandle;
-#else
-	/// @brief delegate which is connected to the tick function
-	FDelegateHandle TickerHandle;
-#endif
+	ApiGear::FDelegateHandle TickerHandle;
 
 	/// @brief the port OLink server listen on
 	uint32 Port;

--- a/templates/ApiGear/Source/ApiGearOLink/Private/unrealolink.cpp
+++ b/templates/ApiGear/Source/ApiGearOLink/Private/unrealolink.cpp
@@ -60,8 +60,12 @@ UUnrealOLink::UUnrealOLink(const FObjectInitializer& ObjectInitializer)
 		// Schedule calling process message so they are sent from main thread. Throttling also improve sending during high load.
 		if (!m_processMessageTaskTimerHandle.IsValid())
 		{
-			m_processMessageTaskTimerHandle = ApiGearTicker::GetCoreTicker().AddTicker(*processMessageFunctionName, processMessageDelay, [this](float /*param*/)
-				{processMessages(); return true; });
+			m_processMessageTaskTimerHandle = ApiGearTicker::GetCoreTicker().AddTicker(*processMessageFunctionName, processMessageDelay,
+				[this](float /*param*/)
+				{
+					processMessages();
+					return true;
+				});
 		}
 	};
 	m_node->onWrite(func);
@@ -208,8 +212,12 @@ void UUnrealOLink::OnConnected_Implementation()
 	// Schedule calling process message so they are sent from main thread. Throttling also improve sending during high load.
 	if (!m_processMessageTaskTimerHandle.IsValid())
 	{
-		m_processMessageTaskTimerHandle = ApiGearTicker::GetCoreTicker().AddTicker(*processMessageFunctionName, processMessageDelay, [this](float /*param*/)
-			{processMessages(); return true; });
+		m_processMessageTaskTimerHandle = ApiGearTicker::GetCoreTicker().AddTicker(*processMessageFunctionName, processMessageDelay,
+			[this](float /*param*/)
+			{
+				processMessages();
+				return true;
+			});
 	}
 }
 

--- a/templates/ApiGear/Source/ApiGearOLink/Public/unrealolink.h
+++ b/templates/ApiGear/Source/ApiGearOLink/Public/unrealolink.h
@@ -9,6 +9,8 @@ THIRD_PARTY_INCLUDES_END
 #include "WebSocketsModule.h"
 #include "IWebSocket.h"
 #include "Containers/Queue.h"
+#include "HAL/CriticalSection.h"
+#include "ApiGearTicker.h"
 #include "unrealolink.generated.h"
 
 DECLARE_LOG_CATEGORY_EXTERN(LogApiGearOLink, Log, All);
@@ -62,13 +64,30 @@ public:
 private:
 	bool bInitialized = false;
 	void open(const FString& url);
+	/*
+	* Helper method for sending messages, should be used from one thread, here achieved with scheduling task to main thread.
+	* see m_processMessageTaskTimerHandle
+	*/
 	void processMessages();
+	/*
+	* Sends queued messages
+	* Uses m_flushMessagesMutex, to ensure it called only once at one time.
+	* It is not thread safe function - uses a m_socket and m_queue which are not guarded separately across the UUnrealOLink
+	*/
+	void flushMessages();
 
 	TArray<std::string> ListLinkedObjects;
+
+	DEFINE_LOG_CATEGORY(LogApiGearOLink);
+	
+	/// @brief delegate handle for scheduled process message task
+	ApiGear::FDelegateHandle m_processMessageTaskTimerHandle;
 
 	TSharedPtr<IWebSocket> m_socket;
 	FString m_serverURL;
 	ApiGear::ObjectLink::ClientRegistry m_registry;
 	std::shared_ptr<ApiGear::ObjectLink::ClientNode> m_node;
 	TQueue<std::string, EQueueMode::Mpsc> m_queue;
+	// Mutex for flushMessages().
+	FCriticalSection m_flushMessagesMutex;
 };

--- a/templates/ApiGear/Source/ApiGearOLink/Public/unrealolink.h
+++ b/templates/ApiGear/Source/ApiGearOLink/Public/unrealolink.h
@@ -79,8 +79,8 @@ private:
 	TArray<std::string> ListLinkedObjects;
 
 	DEFINE_LOG_CATEGORY(LogApiGearOLink);
-	
-	/// @brief delegate handle for scheduled process message task
+
+	// Delegate handle for scheduled process message task
 	ApiGear::FDelegateHandle m_processMessageTaskTimerHandle;
 
 	TSharedPtr<IWebSocket> m_socket;

--- a/templates/module/Source/module/Private/Generated/OLink/olinkclient.cpp.tpl
+++ b/templates/module/Source/module/Private/Generated/OLink/olinkclient.cpp.tpl
@@ -204,12 +204,12 @@ void {{$Class}}::Set{{Camel .Name}}_Implementation({{ueParam "In" .}})
 	{
 		return;
 	}
-{{- end }}	
+{{- end }}
 	static const auto memberId = ApiGear::ObjectLink::Name::createMemberId(m_sink->olinkObjectName(), "{{.Name}}");
 	m_sink->GetNode()->setRemoteProperty(memberId, {{ueVar "In" .}});
 {{- if not ( ueIsStdSimpleType . ) }}
 	FScopeLock Lock(&(_SentData->{{ueVar "" .}}Mutex));
-{{- end }}	
+{{- end }}
 	_SentData->{{ueVar "" .}} = {{ueVar "In" .}};
 }
 {{- end }}


### PR DESCRIPTION
Adds safe-thread synchronization for the olink client. The _SendData is now used safely between threads
Changes the way the websocket works for the olink. Now messages are sent with every next frame, and messages are queued between frames. It assures sending messages happens from only one thread (and it is only called once at one time)


<!-- 
Thanks for creating this pull request 🤗

Please make sure that the pull request is limited to one type (docs, feature, etc.) and keep it as small as possible. You can open multiple prs instead of opening a huge one.
-->

<!-- If this pull request closes an issue, please mention the issue number below -->
Closes # <!-- Issue # here -->

## 📑 Description
<!-- Add a brief description of the pr -->

<!-- You can also choose to add a list of changes and if they have been completed or not by using the markdown to-do list syntax
- [ ] Not Completed
- [x] Completed
-->

## ✅ Checks
<!-- Make sure your pr passes the CI checks and do check the following fields as needed - -->
- [ ] My pull request adheres to the code style of this project
- [ ] My code requires changes to the documentation
- [ ] I have updated the documentation as required
- [ ] All the tests have passed

## ℹ Additional Information
<!-- Any additional information like breaking changes, dependencies added, screenshots, comparisons between new and old behavior, etc. -->