### PR TITLE
fix(apigear): reset removed ticker task

### DIFF
--- a/goldenmaster/Plugins/ApiGear/Source/ApiGearOLink/Private/unrealolink.cpp
+++ b/goldenmaster/Plugins/ApiGear/Source/ApiGearOLink/Private/unrealolink.cpp
@@ -64,7 +64,7 @@ UUnrealOLink::UUnrealOLink(const FObjectInitializer& ObjectInitializer)
 				[this](float /*param*/)
 				{
 					processMessages();
-					return true;
+					return false;
 				});
 		}
 	};
@@ -90,6 +90,7 @@ void UUnrealOLink::Configure(FString InServerURL, bool bInAutoReconnectEnabled)
 UUnrealOLink::~UUnrealOLink()
 {
 	ApiGearTicker::GetCoreTicker().RemoveTicker(m_processMessageTaskTimerHandle);
+	m_processMessageTaskTimerHandle.Reset();
 }
 
 void UUnrealOLink::log(const FString& logMessage)
@@ -113,6 +114,7 @@ void UUnrealOLink::Disconnect_Implementation()
 	if (m_processMessageTaskTimerHandle.IsValid())
 	{
 		ApiGearTicker::GetCoreTicker().RemoveTicker(m_processMessageTaskTimerHandle);
+		m_processMessageTaskTimerHandle.Reset();
 	}
 	if (m_socket && m_socket->IsConnected())
 	{
@@ -216,7 +218,7 @@ void UUnrealOLink::OnConnected_Implementation()
 			[this](float /*param*/)
 			{
 				processMessages();
-				return true;
+				return false;
 			});
 	}
 }
@@ -267,6 +269,7 @@ void UUnrealOLink::unlinkObjectSource(const std::string& name)
 void UUnrealOLink::processMessages()
 {
 	ApiGearTicker::GetCoreTicker().RemoveTicker(m_processMessageTaskTimerHandle);
+	m_processMessageTaskTimerHandle.Reset();
 	if (m_queue.IsEmpty())
 	{
 		// no data to be sent

--- a/templates/ApiGear/Source/ApiGearOLink/Private/unrealolink.cpp
+++ b/templates/ApiGear/Source/ApiGearOLink/Private/unrealolink.cpp
@@ -64,7 +64,7 @@ UUnrealOLink::UUnrealOLink(const FObjectInitializer& ObjectInitializer)
 				[this](float /*param*/)
 				{
 					processMessages();
-					return true;
+					return false;
 				});
 		}
 	};
@@ -90,6 +90,7 @@ void UUnrealOLink::Configure(FString InServerURL, bool bInAutoReconnectEnabled)
 UUnrealOLink::~UUnrealOLink()
 {
 	ApiGearTicker::GetCoreTicker().RemoveTicker(m_processMessageTaskTimerHandle);
+	m_processMessageTaskTimerHandle.Reset();
 }
 
 void UUnrealOLink::log(const FString& logMessage)
@@ -113,6 +114,7 @@ void UUnrealOLink::Disconnect_Implementation()
 	if (m_processMessageTaskTimerHandle.IsValid())
 	{
 		ApiGearTicker::GetCoreTicker().RemoveTicker(m_processMessageTaskTimerHandle);
+		m_processMessageTaskTimerHandle.Reset();
 	}
 	if (m_socket && m_socket->IsConnected())
 	{
@@ -216,7 +218,7 @@ void UUnrealOLink::OnConnected_Implementation()
 			[this](float /*param*/)
 			{
 				processMessages();
-				return true;
+				return false;
 			});
 	}
 }
@@ -267,6 +269,7 @@ void UUnrealOLink::unlinkObjectSource(const std::string& name)
 void UUnrealOLink::processMessages()
 {
 	ApiGearTicker::GetCoreTicker().RemoveTicker(m_processMessageTaskTimerHandle);
+	m_processMessageTaskTimerHandle.Reset();
 	if (m_queue.IsEmpty())
 	{
 		// no data to be sent


### PR DESCRIPTION
In UE4 scheduling messages didn't work due to the task was not invalidated, only removed from timer. New task was never added. Now task is added.


Tested with setting async properties and async method call for UE4 and UE5. Used many threads (properties 100, methods 10), send 1000per thread for setting properties and 100 for methods.
<!-- 
Thanks for creating this pull request 🤗

Please make sure that the pull request is limited to one type (docs, feature, etc.) and keep it as small as possible. You can open multiple prs instead of opening a huge one.
-->

<!-- If this pull request closes an issue, please mention the issue number below -->
Closes # (https://github.com/apigear-io/template-unreal/issues/87)



## 📑 Description
<!-- Add a brief description of the pr -->


<!-- You can also choose to add a list of changes and if they have been completed or not by using the markdown to-do list syntax
- [ ] Not Completed
- [x] Completed
-->

## ✅ Checks
<!-- Make sure your pr passes the CI checks and do check the following fields as needed - -->
- [ ] My pull request adheres to the code style of this project
- [ ] My code requires changes to the documentation
- [ ] I have updated the documentation as required
- [ ] All the tests have passed

## ℹ Additional Information
<!-- Any additional information like breaking changes, dependencies added, screenshots, comparisons between new and old behavior, etc. -->