### PR TITLE
Fix/linker warnings for o link library

### DIFF
--- a/goldenmaster/Plugins/ApiGear/Source/ApiGearOLink/apigearolink.Build.cs
+++ b/goldenmaster/Plugins/ApiGear/Source/ApiGearOLink/apigearolink.Build.cs
@@ -16,7 +16,6 @@ public class ApiGearOLink : ModuleRules
 
 		// Disable nlohmann::json exception handling
 		PublicDefinitions.Add("JSON_NOEXCEPTION=1");
-		PublicDefinitions.Add("OLINK_EXPORT=DLLIMPORT");
 
 		PublicIncludePaths.Add(Path.Combine(ModuleDirectory, "Public"));
 		PrivateIncludePaths.Add(Path.Combine(ModuleDirectory, "Private"));

--- a/goldenmaster/Plugins/ApiGear/Source/ThirdParty/OLinkProtocolLibrary/OLinkProtocolLibrary.Build.cs
+++ b/goldenmaster/Plugins/ApiGear/Source/ThirdParty/OLinkProtocolLibrary/OLinkProtocolLibrary.Build.cs
@@ -20,6 +20,9 @@ public class OLinkProtocolLibrary : ModuleRules
 		// Disable nlohmann::json exception handling
 		PublicDefinitions.Add("JSON_NOEXCEPTION=1");
 
+		// OLink library build to export symbols
+		PrivateDefinitions.Add("OLINK_LIBRARY_BUILD=1");
+
 		PublicIncludePaths.Add(Path.Combine(ModuleDirectory, "Public"));
 		PublicIncludePaths.Add(Path.Combine(ModuleDirectory, "Public", "olink", "core"));
 		PrivateIncludePaths.Add(Path.Combine(ModuleDirectory, "Private"));

--- a/goldenmaster/Plugins/ApiGear/Source/ThirdParty/OLinkProtocolLibrary/Public/olink/core/olink_common.h
+++ b/goldenmaster/Plugins/ApiGear/Source/ThirdParty/OLinkProtocolLibrary/Public/olink/core/olink_common.h
@@ -24,18 +24,28 @@
 */
 #pragma once
 
-#ifndef OLINK_EXPORT
-#if defined _WIN32 || defined __CYGWIN__
-#ifdef __GNUC__
-#define OLINK_EXPORT __attribute__ ((dllexport))
-#else
-#define OLINK_EXPORT __declspec(dllexport)
-#endif
-#else
-#if __GNUC__ >= 4
-    #define OLINK_EXPORT __attribute__ ((visibility ("default")))
+#ifdef OLINK_LIBRARY_BUILD
+  #if defined _WIN32 || defined __CYGWIN__
+    #ifdef __GNUC__
+      #define OLINK_EXPORT __attribute__ ((dllexport))
+    #else
+      #define OLINK_EXPORT __declspec(dllexport)
+    #endif
+  #else
+    #if __GNUC__ >= 4
+      #define OLINK_EXPORT __attribute__ ((visibility ("default")))
+    #else
+      #define OLINK_EXPORT
+    #endif
+  #endif
+#else // OLINK_LIBRARY_BUILD
+  #if defined _WIN32 || defined __CYGWIN__
+    #ifdef __GNUC__
+      #define OLINK_EXPORT __attribute__ ((dllimport))
+    #else
+      #define OLINK_EXPORT __declspec(dllimport)
+    #endif
   #else
     #define OLINK_EXPORT
   #endif
-#endif
-#endif // OLINK_EXPORT
+#endif // OLINK_LIBRARY_BUILD

--- a/templates/ApiGear/Source/ApiGearOLink/apigearolink.Build.cs
+++ b/templates/ApiGear/Source/ApiGearOLink/apigearolink.Build.cs
@@ -16,7 +16,6 @@ public class ApiGearOLink : ModuleRules
 
 		// Disable nlohmann::json exception handling
 		PublicDefinitions.Add("JSON_NOEXCEPTION=1");
-		PublicDefinitions.Add("OLINK_EXPORT=DLLIMPORT");
 
 		PublicIncludePaths.Add(Path.Combine(ModuleDirectory, "Public"));
 		PrivateIncludePaths.Add(Path.Combine(ModuleDirectory, "Private"));

--- a/templates/ApiGear/Source/ThirdParty/OLinkProtocolLibrary/OLinkProtocolLibrary.Build.cs
+++ b/templates/ApiGear/Source/ThirdParty/OLinkProtocolLibrary/OLinkProtocolLibrary.Build.cs
@@ -20,6 +20,9 @@ public class OLinkProtocolLibrary : ModuleRules
 		// Disable nlohmann::json exception handling
 		PublicDefinitions.Add("JSON_NOEXCEPTION=1");
 
+		// OLink library build to export symbols
+		PrivateDefinitions.Add("OLINK_LIBRARY_BUILD=1");
+
 		PublicIncludePaths.Add(Path.Combine(ModuleDirectory, "Public"));
 		PublicIncludePaths.Add(Path.Combine(ModuleDirectory, "Public", "olink", "core"));
 		PrivateIncludePaths.Add(Path.Combine(ModuleDirectory, "Private"));

--- a/templates/ApiGear/Source/ThirdParty/OLinkProtocolLibrary/Public/olink/core/olink_common.h
+++ b/templates/ApiGear/Source/ThirdParty/OLinkProtocolLibrary/Public/olink/core/olink_common.h
@@ -24,18 +24,28 @@
 */
 #pragma once
 
-#ifndef OLINK_EXPORT
-#if defined _WIN32 || defined __CYGWIN__
-#ifdef __GNUC__
-#define OLINK_EXPORT __attribute__ ((dllexport))
-#else
-#define OLINK_EXPORT __declspec(dllexport)
-#endif
-#else
-#if __GNUC__ >= 4
-    #define OLINK_EXPORT __attribute__ ((visibility ("default")))
+#ifdef OLINK_LIBRARY_BUILD
+  #if defined _WIN32 || defined __CYGWIN__
+    #ifdef __GNUC__
+      #define OLINK_EXPORT __attribute__ ((dllexport))
+    #else
+      #define OLINK_EXPORT __declspec(dllexport)
+    #endif
+  #else
+    #if __GNUC__ >= 4
+      #define OLINK_EXPORT __attribute__ ((visibility ("default")))
+    #else
+      #define OLINK_EXPORT
+    #endif
+  #endif
+#else // OLINK_LIBRARY_BUILD
+  #if defined _WIN32 || defined __CYGWIN__
+    #ifdef __GNUC__
+      #define OLINK_EXPORT __attribute__ ((dllimport))
+    #else
+      #define OLINK_EXPORT __declspec(dllimport)
+    #endif
   #else
     #define OLINK_EXPORT
   #endif
-#endif
-#endif // OLINK_EXPORT
+#endif // OLINK_LIBRARY_BUILD


### PR DESCRIPTION
## 📑 Description
- the olink library was using the wrong symbol export macros, this fixes it

## ✅ Checks
<!-- Make sure your pr passes the CI checks and do check the following fields as needed - -->
- [ ] My pull request adheres to the code style of this project
- [ ] My code requires changes to the documentation
- [ ] I have updated the documentation as required
- [x] All the tests have passed

## ℹ Additional Information
<!-- Any additional information like breaking changes, dependencies added, screenshots, comparisons between new and old behavior, etc. -->