### PR TITLE
fix(olink): do not pull the ws service lib on QNX

### DIFF
--- a/goldenmaster/Plugins/ApiGear/Source/ApiGearOLink/apigearolink.Build.cs
+++ b/goldenmaster/Plugins/ApiGear/Source/ApiGearOLink/apigearolink.Build.cs
@@ -41,7 +41,8 @@ public class ApiGearOLink : ModuleRules
 			);
 
 		// the WebSocketNetworking lib does not work on mobile
-		if (Target.Platform != UnrealTargetPlatform.Android && Target.Platform != UnrealTargetPlatform.IOS)
+		// QNX is only defined in certain UE versions so we use this workaround
+		if (Target.Platform != UnrealTargetPlatform.Android && Target.Platform != UnrealTargetPlatform.IOS && !Target.Platform.ToString().Equals("QNX", System.StringComparison.Ordinal))
 		{
 			PrivateDependencyModuleNames.Add("WebSocketNetworking");
 		}

--- a/templates/ApiGear/Source/ApiGearOLink/apigearolink.Build.cs
+++ b/templates/ApiGear/Source/ApiGearOLink/apigearolink.Build.cs
@@ -41,7 +41,8 @@ public class ApiGearOLink : ModuleRules
 			);
 
 		// the WebSocketNetworking lib does not work on mobile
-		if (Target.Platform != UnrealTargetPlatform.Android && Target.Platform != UnrealTargetPlatform.IOS)
+		// QNX is only defined in certain UE versions so we use this workaround
+		if (Target.Platform != UnrealTargetPlatform.Android && Target.Platform != UnrealTargetPlatform.IOS && !Target.Platform.ToString().Equals("QNX", System.StringComparison.Ordinal))
 		{
 			PrivateDependencyModuleNames.Add("WebSocketNetworking");
 		}


### PR DESCRIPTION
## 📑 Description
When building for QNX we cannot use the websocket service library. And thus should not try to link against it.
This was missing from the previous fix for 3.5.1

## ✅ Checks
<!-- Make sure your pr passes the CI checks and do check the following fields as needed - -->
- [ ] My pull request adheres to the code style of this project
- [ ] My code requires changes to the documentation
- [ ] I have updated the documentation as required
- [ ] All the tests have passed

## ℹ Additional Information
<!-- Any additional information like breaking changes, dependencies added, screenshots, comparisons between new and old behavior, etc. -->