### PR TITLE
Feat/make msg bus heartbeat adjustable and use ticker

### DIFF
--- a/goldenmaster/Plugins/ApiGear/apigear.uplugin
+++ b/goldenmaster/Plugins/ApiGear/apigear.uplugin
@@ -1,7 +1,7 @@
 {
 	"FileVersion": 3,
 	"Version": 1,
-	"VersionName": "3.5.1",
+	"VersionName": "3.5.2",
 	"FriendlyName": "ApiGear",
 	"Description": "ApiGear ThirdParty libraries for tracing, simulation and IPC support",
 	"Category": "Other",

--- a/goldenmaster/Plugins/Counter/Counter.uplugin
+++ b/goldenmaster/Plugins/Counter/Counter.uplugin
@@ -2,7 +2,7 @@
 {
 	"FileVersion": 3,
 	"Version": 1,
-	"VersionName": "1.0.0",
+	"VersionName": "1.0.0+tpl.3.5.2",
 	"FriendlyName": "Counter",
 	"Description": "",
 	"Category": "Other",

--- a/goldenmaster/Plugins/Counter/Source/Counter/Private/Generated/MsgBus/CounterCounterMsgBusAdapter.cpp
+++ b/goldenmaster/Plugins/Counter/Source/Counter/Private/Generated/MsgBus/CounterCounterMsgBusAdapter.cpp
@@ -24,12 +24,12 @@ limitations under the License.
 #include "Generated/MsgBus/CounterCounterMsgBusMessages.h"
 #include "Async/Future.h"
 #include "Async/Async.h"
-#include "Async/Async.h"
-#include "Engine/Engine.h"
+#include "Engine/World.h"
 #include "TimerManager.h"
 #include "MessageEndpoint.h"
 #include "MessageEndpointBuilder.h"
 #include "Misc/DateTime.h"
+#include "CounterSettings.h"
 
 DEFINE_LOG_CATEGORY(LogCounterCounterMsgBusAdapter);
 UCounterCounterMsgBusAdapter::UCounterCounterMsgBusAdapter()
@@ -53,6 +53,10 @@ void UCounterCounterMsgBusAdapter::_StartListening()
 
 	if (!_HeartbeatTimerHandle.IsValid() && GetWorld())
 	{
+		UCounterSettings* settings = GetMutableDefault<UCounterSettings>();
+		check(settings);
+		_HeartbeatIntervalMS = settings->MsgBusHeartbeatIntervalMS;
+
 		GetWorld()->GetTimerManager().SetTimer(_HeartbeatTimerHandle, this, &UCounterCounterMsgBusAdapter::_CheckClientTimeouts, _HeartbeatIntervalMS / 1000.0f, true);
 	}
 

--- a/goldenmaster/Plugins/Counter/Source/Counter/Private/Generated/MsgBus/CounterCounterMsgBusAdapter.cpp
+++ b/goldenmaster/Plugins/Counter/Source/Counter/Private/Generated/MsgBus/CounterCounterMsgBusAdapter.cpp
@@ -25,7 +25,6 @@ limitations under the License.
 #include "Async/Future.h"
 #include "Async/Async.h"
 #include "Engine/World.h"
-#include "TimerManager.h"
 #include "MessageEndpoint.h"
 #include "MessageEndpointBuilder.h"
 #include "Misc/DateTime.h"
@@ -51,13 +50,17 @@ void UCounterCounterMsgBusAdapter::Deinitialize()
 void UCounterCounterMsgBusAdapter::_StartListening()
 {
 
-	if (!_HeartbeatTimerHandle.IsValid() && GetWorld())
+	if (!_HeartbeatTickerHandle.IsValid())
 	{
 		UCounterSettings* settings = GetMutableDefault<UCounterSettings>();
 		check(settings);
 		_HeartbeatIntervalMS = settings->MsgBusHeartbeatIntervalMS;
 
-		GetWorld()->GetTimerManager().SetTimer(_HeartbeatTimerHandle, this, &UCounterCounterMsgBusAdapter::_CheckClientTimeouts, _HeartbeatIntervalMS / 1000.0f, true);
+#if (ENGINE_MAJOR_VERSION < 5)
+		_HeartbeatTickerHandle = FTicker::GetCoreTicker().AddTicker(FTickerDelegate::CreateUObject(this, &UCounterCounterMsgBusAdapter::_CheckClientTimeoutsTick), _HeartbeatIntervalMS / 1000.0f);
+#else
+		_HeartbeatTickerHandle = FTSTicker::GetCoreTicker().AddTicker(FTickerDelegate::CreateUObject(this, &UCounterCounterMsgBusAdapter::_CheckClientTimeoutsTick), _HeartbeatIntervalMS / 1000.0f);
+#endif
 	}
 
 	if (CounterCounterMsgBusEndpoint.IsValid())
@@ -103,9 +106,13 @@ void UCounterCounterMsgBusAdapter::_AnnounceService()
 
 void UCounterCounterMsgBusAdapter::_StopListening()
 {
-	if (_HeartbeatTimerHandle.IsValid() && GetWorld())
+	if (_HeartbeatTickerHandle.IsValid())
 	{
-		GetWorld()->GetTimerManager().ClearTimer(_HeartbeatTimerHandle);
+#if (ENGINE_MAJOR_VERSION < 5)
+		FTicker::GetCoreTicker().RemoveTicker(_HeartbeatTickerHandle);
+#else
+		FTSTicker::GetCoreTicker().RemoveTicker(_HeartbeatTickerHandle);
+#endif
 	}
 
 	auto msg = new FCounterCounterServiceDisconnectMessage();
@@ -256,6 +263,12 @@ void UCounterCounterMsgBusAdapter::OnClientDisconnected(const FCounterCounterCli
 	ConnectedClientsTimestamps.Remove(Context->GetSender());
 	_OnClientDisconnected.Broadcast(Context->GetSender().ToString());
 	_UpdateClientsConnected();
+}
+
+bool UCounterCounterMsgBusAdapter::_CheckClientTimeoutsTick(float /*DeltaTime*/)
+{
+	_CheckClientTimeouts();
+	return true;
 }
 
 void UCounterCounterMsgBusAdapter::_CheckClientTimeouts()

--- a/goldenmaster/Plugins/Counter/Source/Counter/Private/Generated/MsgBus/CounterCounterMsgBusClient.cpp
+++ b/goldenmaster/Plugins/Counter/Source/Counter/Private/Generated/MsgBus/CounterCounterMsgBusClient.cpp
@@ -23,13 +23,14 @@ limitations under the License.
 #include "Generated/MsgBus/CounterCounterMsgBusClient.h"
 #include "Generated/MsgBus/CounterCounterMsgBusMessages.h"
 #include "Async/Async.h"
-#include "Engine/Engine.h"
+#include "Engine/World.h"
 #include "TimerManager.h"
 #include "Misc/DateTime.h"
 #include "GenericPlatform/GenericPlatformMath.h"
 #include "GenericPlatform/GenericPlatformTime.h"
 #include "MessageEndpointBuilder.h"
 #include "MessageEndpoint.h"
+#include "CounterSettings.h"
 #include "HAL/CriticalSection.h"
 
 /**
@@ -73,6 +74,10 @@ void UCounterCounterMsgBusClient::_Connect()
 {
 	if (!_HeartbeatTimerHandle.IsValid() && GetWorld())
 	{
+		UCounterSettings* settings = GetMutableDefault<UCounterSettings>();
+		check(settings);
+		_HeartbeatIntervalMS = settings->MsgBusHeartbeatIntervalMS;
+
 		GetWorld()->GetTimerManager().SetTimer(_HeartbeatTimerHandle, this, &UCounterCounterMsgBusClient::_OnHeartbeat, _HeartbeatIntervalMS / 1000.0f, true);
 	}
 

--- a/goldenmaster/Plugins/Counter/Source/Counter/Private/Generated/MsgBus/CounterCounterMsgBusClient.cpp
+++ b/goldenmaster/Plugins/Counter/Source/Counter/Private/Generated/MsgBus/CounterCounterMsgBusClient.cpp
@@ -24,7 +24,6 @@ limitations under the License.
 #include "Generated/MsgBus/CounterCounterMsgBusMessages.h"
 #include "Async/Async.h"
 #include "Engine/World.h"
-#include "TimerManager.h"
 #include "Misc/DateTime.h"
 #include "GenericPlatform/GenericPlatformMath.h"
 #include "GenericPlatform/GenericPlatformTime.h"
@@ -72,19 +71,25 @@ void UCounterCounterMsgBusClient::Deinitialize()
 
 void UCounterCounterMsgBusClient::_Connect()
 {
-	if (!_HeartbeatTimerHandle.IsValid() && GetWorld())
+	if (_IsConnected())
+	{
+		UE_LOG(LogCounterCounterMsgBusClient, Log, TEXT("Already connected, cannot connect again."));
+		return;
+	}
+
+	if (!_HeartbeatTickerHandle.IsValid())
 	{
 		UCounterSettings* settings = GetMutableDefault<UCounterSettings>();
 		check(settings);
 		_HeartbeatIntervalMS = settings->MsgBusHeartbeatIntervalMS;
 
-		GetWorld()->GetTimerManager().SetTimer(_HeartbeatTimerHandle, this, &UCounterCounterMsgBusClient::_OnHeartbeat, _HeartbeatIntervalMS / 1000.0f, true);
-	}
-
-	if (_IsConnected())
-	{
-		UE_LOG(LogCounterCounterMsgBusClient, Log, TEXT("Already connected, cannot connect again."));
-		return;
+#if (ENGINE_MAJOR_VERSION < 5)
+		FTicker::GetCoreTicker().RemoveTicker(_HeartbeatTickerHandle);
+		_HeartbeatTickerHandle = FTicker::GetCoreTicker().AddTicker(FTickerDelegate::CreateUObject(this, &UCounterCounterMsgBusClient::_OnHeartbeatTick), _HeartbeatIntervalMS / 1000.0f);
+#else
+		FTSTicker::GetCoreTicker().RemoveTicker(_HeartbeatTickerHandle);
+		_HeartbeatTickerHandle = FTSTicker::GetCoreTicker().AddTicker(FTickerDelegate::CreateUObject(this, &UCounterCounterMsgBusClient::_OnHeartbeatTick), _HeartbeatIntervalMS / 1000.0f);
+#endif
 	}
 
 	if (CounterCounterMsgBusEndpoint.IsValid() && !ServiceAddress.IsValid())
@@ -116,10 +121,12 @@ void UCounterCounterMsgBusClient::_Connect()
 void UCounterCounterMsgBusClient::_Disconnect()
 {
 	_LastHbTimestamp = 0.0f;
-	if (_HeartbeatTimerHandle.IsValid() && GetWorld())
-	{
-		GetWorld()->GetTimerManager().ClearTimer(_HeartbeatTimerHandle);
-	}
+
+#if (ENGINE_MAJOR_VERSION < 5)
+	FTicker::GetCoreTicker().RemoveTicker(_HeartbeatTickerHandle);
+#else
+	FTSTicker::GetCoreTicker().RemoveTicker(_HeartbeatTickerHandle);
+#endif
 
 	if (!_IsConnected())
 	{
@@ -180,15 +187,13 @@ void UCounterCounterMsgBusClient::OnConnectionInit(const FCounterCounterInitMess
 	{
 		_HeartbeatIntervalMS = InMessage._ClientPingIntervalMS;
 
-		if (_HeartbeatTimerHandle.IsValid() && GetWorld())
-		{
-			GetWorld()->GetTimerManager().ClearTimer(_HeartbeatTimerHandle);
-		}
-
-		if (!_HeartbeatTimerHandle.IsValid() && GetWorld())
-		{
-			GetWorld()->GetTimerManager().SetTimer(_HeartbeatTimerHandle, this, &UCounterCounterMsgBusClient::_OnHeartbeat, _HeartbeatIntervalMS / 1000.0f, true);
-		}
+#if (ENGINE_MAJOR_VERSION < 5)
+		FTicker::GetCoreTicker().RemoveTicker(_HeartbeatTickerHandle);
+		_HeartbeatTickerHandle = FTicker::GetCoreTicker().AddTicker(FTickerDelegate::CreateUObject(this, &UCounterCounterMsgBusClient::_OnHeartbeatTick), _HeartbeatIntervalMS / 1000.0f);
+#else
+		FTSTicker::GetCoreTicker().RemoveTicker(_HeartbeatTickerHandle);
+		_HeartbeatTickerHandle = FTSTicker::GetCoreTicker().AddTicker(FTickerDelegate::CreateUObject(this, &UCounterCounterMsgBusClient::_OnHeartbeatTick), _HeartbeatIntervalMS / 1000.0f);
+#endif
 	}
 	const bool bVectorChanged = InMessage.Vector != Vector;
 	if (bVectorChanged)
@@ -219,6 +224,12 @@ void UCounterCounterMsgBusClient::OnConnectionInit(const FCounterCounterInitMess
 	}
 
 	_ConnectionStatusChanged.Broadcast(true);
+}
+
+bool UCounterCounterMsgBusClient::_OnHeartbeatTick(float /*DeltaTime*/)
+{
+	_OnHeartbeat();
+	return true;
 }
 
 void UCounterCounterMsgBusClient::_OnHeartbeat()

--- a/goldenmaster/Plugins/Counter/Source/Counter/Public/CounterSettings.h
+++ b/goldenmaster/Plugins/Counter/Source/Counter/Public/CounterSettings.h
@@ -45,4 +45,11 @@ public:
 	/** Choose the olink connection to use */
 	UPROPERTY(EditAnywhere, config, Category = OLinkConnectionSetup)
 	FString OLinkConnectionIdentifier;
+
+	/** Choose the heartbeat interval in milliseconds for the msgbus connection on the service side.
+	 * On the service side this adjusts the heartbeat between client and service. The clients will receive the value from service.
+	 * On the client side this adjusts how often discovery messages are sent until a service is connected.
+	 */
+	UPROPERTY(EditAnywhere, config, Category = MsgBusConnectionSetup, meta = (DisplayName = "Heartbeat interval (in milliseconds)"))
+	uint32 MsgBusHeartbeatIntervalMS = 200;
 };

--- a/goldenmaster/Plugins/Counter/Source/Counter/Public/Generated/MsgBus/CounterCounterMsgBusAdapter.h
+++ b/goldenmaster/Plugins/Counter/Source/Counter/Public/Generated/MsgBus/CounterCounterMsgBusAdapter.h
@@ -21,11 +21,7 @@ limitations under the License.
 #include "IMessageContext.h"
 #include "Templates/SharedPointer.h"
 #include "Runtime/Launch/Resources/Version.h"
-#if (ENGINE_MAJOR_VERSION < 5)
-#include "Engine/EngineTypes.h"
-#else
-#include "Engine/TimerHandle.h"
-#endif
+#include "Containers/Ticker.h"
 #include "CounterCounterMsgBusAdapter.generated.h"
 
 class FMessageEndpoint;
@@ -142,9 +138,14 @@ private:
 
 	// Heartbeat handling
 	void _CheckClientTimeouts();
+	bool _CheckClientTimeoutsTick(float DeltaTime);
 	void _UpdateClientsConnected();
 	TMap<FMessageAddress, double> ConnectedClientsTimestamps;
-	FTimerHandle _HeartbeatTimerHandle;
+#if (ENGINE_MAJOR_VERSION < 5)
+	::FDelegateHandle _HeartbeatTickerHandle;
+#else
+	FTSTicker::FDelegateHandle _HeartbeatTickerHandle;
+#endif
 	int32 _ClientsConnected = 0;
 	uint32 _HeartbeatIntervalMS = 100;
 };

--- a/goldenmaster/Plugins/Counter/Source/Counter/Public/Generated/MsgBus/CounterCounterMsgBusClient.h
+++ b/goldenmaster/Plugins/Counter/Source/Counter/Public/Generated/MsgBus/CounterCounterMsgBusClient.h
@@ -22,11 +22,7 @@ limitations under the License.
 #include "HAL/CriticalSection.h"
 #include "Async/Future.h"
 #include "Runtime/Launch/Resources/Version.h"
-#if (ENGINE_MAJOR_VERSION < 5)
-#include "Engine/EngineTypes.h"
-#else
-#include "Engine/TimerHandle.h"
-#endif
+#include "Containers/Ticker.h"
 #include "Templates/PimplPtr.h"
 #include "IMessageContext.h"
 #include "CounterCounterMsgBusClient.generated.h"
@@ -140,8 +136,13 @@ private:
 	size_t CurrentPingCounter = 0;
 	float _CalculateAverageRTT() const;
 	FCounterCounterStats Stats;
-	FTimerHandle _HeartbeatTimerHandle;
+#if (ENGINE_MAJOR_VERSION < 5)
+	::FDelegateHandle _HeartbeatTickerHandle;
+#else
+	FTSTicker::FDelegateHandle _HeartbeatTickerHandle;
+#endif
 	void _OnHeartbeat();
+	bool _OnHeartbeatTick(float DeltaTime);
 	uint32 _HeartbeatIntervalMS = 100;
 
 	// connection handling

--- a/goldenmaster/Plugins/CustomTypes/CustomTypes.uplugin
+++ b/goldenmaster/Plugins/CustomTypes/CustomTypes.uplugin
@@ -2,7 +2,7 @@
 {
 	"FileVersion": 3,
 	"Version": 1,
-	"VersionName": "1.0.0",
+	"VersionName": "1.0.0+tpl.3.5.2",
 	"FriendlyName": "CustomTypes",
 	"Description": "",
 	"Category": "Other",

--- a/goldenmaster/Plugins/CustomTypes/Source/CustomTypes/Public/CustomTypesSettings.h
+++ b/goldenmaster/Plugins/CustomTypes/Source/CustomTypes/Public/CustomTypesSettings.h
@@ -45,4 +45,11 @@ public:
 	/** Choose the olink connection to use */
 	UPROPERTY(EditAnywhere, config, Category = OLinkConnectionSetup)
 	FString OLinkConnectionIdentifier;
+
+	/** Choose the heartbeat interval in milliseconds for the msgbus connection on the service side.
+	 * On the service side this adjusts the heartbeat between client and service. The clients will receive the value from service.
+	 * On the client side this adjusts how often discovery messages are sent until a service is connected.
+	 */
+	UPROPERTY(EditAnywhere, config, Category = MsgBusConnectionSetup, meta = (DisplayName = "Heartbeat interval (in milliseconds)"))
+	uint32 MsgBusHeartbeatIntervalMS = 200;
 };

--- a/goldenmaster/Plugins/ExternTypes/ExternTypes.uplugin
+++ b/goldenmaster/Plugins/ExternTypes/ExternTypes.uplugin
@@ -2,7 +2,7 @@
 {
 	"FileVersion": 3,
 	"Version": 1,
-	"VersionName": "1.0.0",
+	"VersionName": "1.0.0+tpl.3.5.2",
 	"FriendlyName": "ExternTypes",
 	"Description": "",
 	"Category": "Other",

--- a/goldenmaster/Plugins/ExternTypes/Source/ExternTypes/Public/ExternTypesSettings.h
+++ b/goldenmaster/Plugins/ExternTypes/Source/ExternTypes/Public/ExternTypesSettings.h
@@ -45,4 +45,11 @@ public:
 	/** Choose the olink connection to use */
 	UPROPERTY(EditAnywhere, config, Category = OLinkConnectionSetup)
 	FString OLinkConnectionIdentifier;
+
+	/** Choose the heartbeat interval in milliseconds for the msgbus connection on the service side.
+	 * On the service side this adjusts the heartbeat between client and service. The clients will receive the value from service.
+	 * On the client side this adjusts how often discovery messages are sent until a service is connected.
+	 */
+	UPROPERTY(EditAnywhere, config, Category = MsgBusConnectionSetup, meta = (DisplayName = "Heartbeat interval (in milliseconds)"))
+	uint32 MsgBusHeartbeatIntervalMS = 200;
 };

--- a/goldenmaster/Plugins/TbEnum/Source/TbEnum/Private/Generated/MsgBus/TbEnumEnumInterfaceMsgBusAdapter.cpp
+++ b/goldenmaster/Plugins/TbEnum/Source/TbEnum/Private/Generated/MsgBus/TbEnumEnumInterfaceMsgBusAdapter.cpp
@@ -25,7 +25,6 @@ limitations under the License.
 #include "Async/Future.h"
 #include "Async/Async.h"
 #include "Engine/World.h"
-#include "TimerManager.h"
 #include "MessageEndpoint.h"
 #include "MessageEndpointBuilder.h"
 #include "Misc/DateTime.h"
@@ -51,13 +50,17 @@ void UTbEnumEnumInterfaceMsgBusAdapter::Deinitialize()
 void UTbEnumEnumInterfaceMsgBusAdapter::_StartListening()
 {
 
-	if (!_HeartbeatTimerHandle.IsValid() && GetWorld())
+	if (!_HeartbeatTickerHandle.IsValid())
 	{
 		UTbEnumSettings* settings = GetMutableDefault<UTbEnumSettings>();
 		check(settings);
 		_HeartbeatIntervalMS = settings->MsgBusHeartbeatIntervalMS;
 
-		GetWorld()->GetTimerManager().SetTimer(_HeartbeatTimerHandle, this, &UTbEnumEnumInterfaceMsgBusAdapter::_CheckClientTimeouts, _HeartbeatIntervalMS / 1000.0f, true);
+#if (ENGINE_MAJOR_VERSION < 5)
+		_HeartbeatTickerHandle = FTicker::GetCoreTicker().AddTicker(FTickerDelegate::CreateUObject(this, &UTbEnumEnumInterfaceMsgBusAdapter::_CheckClientTimeoutsTick), _HeartbeatIntervalMS / 1000.0f);
+#else
+		_HeartbeatTickerHandle = FTSTicker::GetCoreTicker().AddTicker(FTickerDelegate::CreateUObject(this, &UTbEnumEnumInterfaceMsgBusAdapter::_CheckClientTimeoutsTick), _HeartbeatIntervalMS / 1000.0f);
+#endif
 	}
 
 	if (TbEnumEnumInterfaceMsgBusEndpoint.IsValid())
@@ -103,9 +106,13 @@ void UTbEnumEnumInterfaceMsgBusAdapter::_AnnounceService()
 
 void UTbEnumEnumInterfaceMsgBusAdapter::_StopListening()
 {
-	if (_HeartbeatTimerHandle.IsValid() && GetWorld())
+	if (_HeartbeatTickerHandle.IsValid())
 	{
-		GetWorld()->GetTimerManager().ClearTimer(_HeartbeatTimerHandle);
+#if (ENGINE_MAJOR_VERSION < 5)
+		FTicker::GetCoreTicker().RemoveTicker(_HeartbeatTickerHandle);
+#else
+		FTSTicker::GetCoreTicker().RemoveTicker(_HeartbeatTickerHandle);
+#endif
 	}
 
 	auto msg = new FTbEnumEnumInterfaceServiceDisconnectMessage();
@@ -262,6 +269,12 @@ void UTbEnumEnumInterfaceMsgBusAdapter::OnClientDisconnected(const FTbEnumEnumIn
 	ConnectedClientsTimestamps.Remove(Context->GetSender());
 	_OnClientDisconnected.Broadcast(Context->GetSender().ToString());
 	_UpdateClientsConnected();
+}
+
+bool UTbEnumEnumInterfaceMsgBusAdapter::_CheckClientTimeoutsTick(float /*DeltaTime*/)
+{
+	_CheckClientTimeouts();
+	return true;
 }
 
 void UTbEnumEnumInterfaceMsgBusAdapter::_CheckClientTimeouts()

--- a/goldenmaster/Plugins/TbEnum/Source/TbEnum/Private/Generated/MsgBus/TbEnumEnumInterfaceMsgBusAdapter.cpp
+++ b/goldenmaster/Plugins/TbEnum/Source/TbEnum/Private/Generated/MsgBus/TbEnumEnumInterfaceMsgBusAdapter.cpp
@@ -24,12 +24,12 @@ limitations under the License.
 #include "Generated/MsgBus/TbEnumEnumInterfaceMsgBusMessages.h"
 #include "Async/Future.h"
 #include "Async/Async.h"
-#include "Async/Async.h"
-#include "Engine/Engine.h"
+#include "Engine/World.h"
 #include "TimerManager.h"
 #include "MessageEndpoint.h"
 #include "MessageEndpointBuilder.h"
 #include "Misc/DateTime.h"
+#include "TbEnumSettings.h"
 
 DEFINE_LOG_CATEGORY(LogTbEnumEnumInterfaceMsgBusAdapter);
 UTbEnumEnumInterfaceMsgBusAdapter::UTbEnumEnumInterfaceMsgBusAdapter()
@@ -53,6 +53,10 @@ void UTbEnumEnumInterfaceMsgBusAdapter::_StartListening()
 
 	if (!_HeartbeatTimerHandle.IsValid() && GetWorld())
 	{
+		UTbEnumSettings* settings = GetMutableDefault<UTbEnumSettings>();
+		check(settings);
+		_HeartbeatIntervalMS = settings->MsgBusHeartbeatIntervalMS;
+
 		GetWorld()->GetTimerManager().SetTimer(_HeartbeatTimerHandle, this, &UTbEnumEnumInterfaceMsgBusAdapter::_CheckClientTimeouts, _HeartbeatIntervalMS / 1000.0f, true);
 	}
 

--- a/goldenmaster/Plugins/TbEnum/Source/TbEnum/Private/Generated/MsgBus/TbEnumEnumInterfaceMsgBusClient.cpp
+++ b/goldenmaster/Plugins/TbEnum/Source/TbEnum/Private/Generated/MsgBus/TbEnumEnumInterfaceMsgBusClient.cpp
@@ -23,13 +23,14 @@ limitations under the License.
 #include "Generated/MsgBus/TbEnumEnumInterfaceMsgBusClient.h"
 #include "Generated/MsgBus/TbEnumEnumInterfaceMsgBusMessages.h"
 #include "Async/Async.h"
-#include "Engine/Engine.h"
+#include "Engine/World.h"
 #include "TimerManager.h"
 #include "Misc/DateTime.h"
 #include "GenericPlatform/GenericPlatformMath.h"
 #include "GenericPlatform/GenericPlatformTime.h"
 #include "MessageEndpointBuilder.h"
 #include "MessageEndpoint.h"
+#include "TbEnumSettings.h"
 #include <atomic>
 
 /**
@@ -69,6 +70,10 @@ void UTbEnumEnumInterfaceMsgBusClient::_Connect()
 {
 	if (!_HeartbeatTimerHandle.IsValid() && GetWorld())
 	{
+		UTbEnumSettings* settings = GetMutableDefault<UTbEnumSettings>();
+		check(settings);
+		_HeartbeatIntervalMS = settings->MsgBusHeartbeatIntervalMS;
+
 		GetWorld()->GetTimerManager().SetTimer(_HeartbeatTimerHandle, this, &UTbEnumEnumInterfaceMsgBusClient::_OnHeartbeat, _HeartbeatIntervalMS / 1000.0f, true);
 	}
 

--- a/goldenmaster/Plugins/TbEnum/Source/TbEnum/Private/Generated/MsgBus/TbEnumEnumInterfaceMsgBusClient.cpp
+++ b/goldenmaster/Plugins/TbEnum/Source/TbEnum/Private/Generated/MsgBus/TbEnumEnumInterfaceMsgBusClient.cpp
@@ -24,7 +24,6 @@ limitations under the License.
 #include "Generated/MsgBus/TbEnumEnumInterfaceMsgBusMessages.h"
 #include "Async/Async.h"
 #include "Engine/World.h"
-#include "TimerManager.h"
 #include "Misc/DateTime.h"
 #include "GenericPlatform/GenericPlatformMath.h"
 #include "GenericPlatform/GenericPlatformTime.h"
@@ -68,19 +67,25 @@ void UTbEnumEnumInterfaceMsgBusClient::Deinitialize()
 
 void UTbEnumEnumInterfaceMsgBusClient::_Connect()
 {
-	if (!_HeartbeatTimerHandle.IsValid() && GetWorld())
+	if (_IsConnected())
+	{
+		UE_LOG(LogTbEnumEnumInterfaceMsgBusClient, Log, TEXT("Already connected, cannot connect again."));
+		return;
+	}
+
+	if (!_HeartbeatTickerHandle.IsValid())
 	{
 		UTbEnumSettings* settings = GetMutableDefault<UTbEnumSettings>();
 		check(settings);
 		_HeartbeatIntervalMS = settings->MsgBusHeartbeatIntervalMS;
 
-		GetWorld()->GetTimerManager().SetTimer(_HeartbeatTimerHandle, this, &UTbEnumEnumInterfaceMsgBusClient::_OnHeartbeat, _HeartbeatIntervalMS / 1000.0f, true);
-	}
-
-	if (_IsConnected())
-	{
-		UE_LOG(LogTbEnumEnumInterfaceMsgBusClient, Log, TEXT("Already connected, cannot connect again."));
-		return;
+#if (ENGINE_MAJOR_VERSION < 5)
+		FTicker::GetCoreTicker().RemoveTicker(_HeartbeatTickerHandle);
+		_HeartbeatTickerHandle = FTicker::GetCoreTicker().AddTicker(FTickerDelegate::CreateUObject(this, &UTbEnumEnumInterfaceMsgBusClient::_OnHeartbeatTick), _HeartbeatIntervalMS / 1000.0f);
+#else
+		FTSTicker::GetCoreTicker().RemoveTicker(_HeartbeatTickerHandle);
+		_HeartbeatTickerHandle = FTSTicker::GetCoreTicker().AddTicker(FTickerDelegate::CreateUObject(this, &UTbEnumEnumInterfaceMsgBusClient::_OnHeartbeatTick), _HeartbeatIntervalMS / 1000.0f);
+#endif
 	}
 
 	if (TbEnumEnumInterfaceMsgBusEndpoint.IsValid() && !ServiceAddress.IsValid())
@@ -115,10 +120,12 @@ void UTbEnumEnumInterfaceMsgBusClient::_Connect()
 void UTbEnumEnumInterfaceMsgBusClient::_Disconnect()
 {
 	_LastHbTimestamp = 0.0f;
-	if (_HeartbeatTimerHandle.IsValid() && GetWorld())
-	{
-		GetWorld()->GetTimerManager().ClearTimer(_HeartbeatTimerHandle);
-	}
+
+#if (ENGINE_MAJOR_VERSION < 5)
+	FTicker::GetCoreTicker().RemoveTicker(_HeartbeatTickerHandle);
+#else
+	FTSTicker::GetCoreTicker().RemoveTicker(_HeartbeatTickerHandle);
+#endif
 
 	if (!_IsConnected())
 	{
@@ -179,15 +186,13 @@ void UTbEnumEnumInterfaceMsgBusClient::OnConnectionInit(const FTbEnumEnumInterfa
 	{
 		_HeartbeatIntervalMS = InMessage._ClientPingIntervalMS;
 
-		if (_HeartbeatTimerHandle.IsValid() && GetWorld())
-		{
-			GetWorld()->GetTimerManager().ClearTimer(_HeartbeatTimerHandle);
-		}
-
-		if (!_HeartbeatTimerHandle.IsValid() && GetWorld())
-		{
-			GetWorld()->GetTimerManager().SetTimer(_HeartbeatTimerHandle, this, &UTbEnumEnumInterfaceMsgBusClient::_OnHeartbeat, _HeartbeatIntervalMS / 1000.0f, true);
-		}
+#if (ENGINE_MAJOR_VERSION < 5)
+		FTicker::GetCoreTicker().RemoveTicker(_HeartbeatTickerHandle);
+		_HeartbeatTickerHandle = FTicker::GetCoreTicker().AddTicker(FTickerDelegate::CreateUObject(this, &UTbEnumEnumInterfaceMsgBusClient::_OnHeartbeatTick), _HeartbeatIntervalMS / 1000.0f);
+#else
+		FTSTicker::GetCoreTicker().RemoveTicker(_HeartbeatTickerHandle);
+		_HeartbeatTickerHandle = FTSTicker::GetCoreTicker().AddTicker(FTickerDelegate::CreateUObject(this, &UTbEnumEnumInterfaceMsgBusClient::_OnHeartbeatTick), _HeartbeatIntervalMS / 1000.0f);
+#endif
 	}
 	const bool bProp0Changed = InMessage.Prop0 != Prop0;
 	if (bProp0Changed)
@@ -218,6 +223,12 @@ void UTbEnumEnumInterfaceMsgBusClient::OnConnectionInit(const FTbEnumEnumInterfa
 	}
 
 	_ConnectionStatusChanged.Broadcast(true);
+}
+
+bool UTbEnumEnumInterfaceMsgBusClient::_OnHeartbeatTick(float /*DeltaTime*/)
+{
+	_OnHeartbeat();
+	return true;
 }
 
 void UTbEnumEnumInterfaceMsgBusClient::_OnHeartbeat()

--- a/goldenmaster/Plugins/TbEnum/Source/TbEnum/Public/Generated/MsgBus/TbEnumEnumInterfaceMsgBusAdapter.h
+++ b/goldenmaster/Plugins/TbEnum/Source/TbEnum/Public/Generated/MsgBus/TbEnumEnumInterfaceMsgBusAdapter.h
@@ -21,11 +21,7 @@ limitations under the License.
 #include "IMessageContext.h"
 #include "Templates/SharedPointer.h"
 #include "Runtime/Launch/Resources/Version.h"
-#if (ENGINE_MAJOR_VERSION < 5)
-#include "Engine/EngineTypes.h"
-#else
-#include "Engine/TimerHandle.h"
-#endif
+#include "Containers/Ticker.h"
 #include "TbEnumEnumInterfaceMsgBusAdapter.generated.h"
 
 class FMessageEndpoint;
@@ -154,9 +150,14 @@ private:
 
 	// Heartbeat handling
 	void _CheckClientTimeouts();
+	bool _CheckClientTimeoutsTick(float DeltaTime);
 	void _UpdateClientsConnected();
 	TMap<FMessageAddress, double> ConnectedClientsTimestamps;
-	FTimerHandle _HeartbeatTimerHandle;
+#if (ENGINE_MAJOR_VERSION < 5)
+	::FDelegateHandle _HeartbeatTickerHandle;
+#else
+	FTSTicker::FDelegateHandle _HeartbeatTickerHandle;
+#endif
 	int32 _ClientsConnected = 0;
 	uint32 _HeartbeatIntervalMS = 100;
 };

--- a/goldenmaster/Plugins/TbEnum/Source/TbEnum/Public/Generated/MsgBus/TbEnumEnumInterfaceMsgBusClient.h
+++ b/goldenmaster/Plugins/TbEnum/Source/TbEnum/Public/Generated/MsgBus/TbEnumEnumInterfaceMsgBusClient.h
@@ -22,11 +22,7 @@ limitations under the License.
 #include "HAL/CriticalSection.h"
 #include "Async/Future.h"
 #include "Runtime/Launch/Resources/Version.h"
-#if (ENGINE_MAJOR_VERSION < 5)
-#include "Engine/EngineTypes.h"
-#else
-#include "Engine/TimerHandle.h"
-#endif
+#include "Containers/Ticker.h"
 #include "Templates/PimplPtr.h"
 #include "IMessageContext.h"
 #include "TbEnumEnumInterfaceMsgBusClient.generated.h"
@@ -143,8 +139,13 @@ private:
 	size_t CurrentPingCounter = 0;
 	float _CalculateAverageRTT() const;
 	FTbEnumEnumInterfaceStats Stats;
-	FTimerHandle _HeartbeatTimerHandle;
+#if (ENGINE_MAJOR_VERSION < 5)
+	::FDelegateHandle _HeartbeatTickerHandle;
+#else
+	FTSTicker::FDelegateHandle _HeartbeatTickerHandle;
+#endif
 	void _OnHeartbeat();
+	bool _OnHeartbeatTick(float DeltaTime);
 	uint32 _HeartbeatIntervalMS = 100;
 
 	// connection handling

--- a/goldenmaster/Plugins/TbEnum/Source/TbEnum/Public/TbEnumSettings.h
+++ b/goldenmaster/Plugins/TbEnum/Source/TbEnum/Public/TbEnumSettings.h
@@ -45,4 +45,11 @@ public:
 	/** Choose the olink connection to use */
 	UPROPERTY(EditAnywhere, config, Category = OLinkConnectionSetup)
 	FString OLinkConnectionIdentifier;
+
+	/** Choose the heartbeat interval in milliseconds for the msgbus connection on the service side.
+	 * On the service side this adjusts the heartbeat between client and service. The clients will receive the value from service.
+	 * On the client side this adjusts how often discovery messages are sent until a service is connected.
+	 */
+	UPROPERTY(EditAnywhere, config, Category = MsgBusConnectionSetup, meta = (DisplayName = "Heartbeat interval (in milliseconds)"))
+	uint32 MsgBusHeartbeatIntervalMS = 200;
 };

--- a/goldenmaster/Plugins/TbEnum/TbEnum.uplugin
+++ b/goldenmaster/Plugins/TbEnum/TbEnum.uplugin
@@ -2,7 +2,7 @@
 {
 	"FileVersion": 3,
 	"Version": 1,
-	"VersionName": "1.0.0",
+	"VersionName": "1.0.0+tpl.3.5.2",
 	"FriendlyName": "TbEnum",
 	"Description": "",
 	"Category": "Other",

--- a/goldenmaster/Plugins/TbNames/Source/TbNames/Private/Generated/MsgBus/TbNamesNamEsMsgBusAdapter.cpp
+++ b/goldenmaster/Plugins/TbNames/Source/TbNames/Private/Generated/MsgBus/TbNamesNamEsMsgBusAdapter.cpp
@@ -24,12 +24,12 @@ limitations under the License.
 #include "Generated/MsgBus/TbNamesNamEsMsgBusMessages.h"
 #include "Async/Future.h"
 #include "Async/Async.h"
-#include "Async/Async.h"
-#include "Engine/Engine.h"
+#include "Engine/World.h"
 #include "TimerManager.h"
 #include "MessageEndpoint.h"
 #include "MessageEndpointBuilder.h"
 #include "Misc/DateTime.h"
+#include "TbNamesSettings.h"
 
 DEFINE_LOG_CATEGORY(LogTbNamesNamEsMsgBusAdapter);
 UTbNamesNamEsMsgBusAdapter::UTbNamesNamEsMsgBusAdapter()
@@ -53,6 +53,10 @@ void UTbNamesNamEsMsgBusAdapter::_StartListening()
 
 	if (!_HeartbeatTimerHandle.IsValid() && GetWorld())
 	{
+		UTbNamesSettings* settings = GetMutableDefault<UTbNamesSettings>();
+		check(settings);
+		_HeartbeatIntervalMS = settings->MsgBusHeartbeatIntervalMS;
+
 		GetWorld()->GetTimerManager().SetTimer(_HeartbeatTimerHandle, this, &UTbNamesNamEsMsgBusAdapter::_CheckClientTimeouts, _HeartbeatIntervalMS / 1000.0f, true);
 	}
 

--- a/goldenmaster/Plugins/TbNames/Source/TbNames/Private/Generated/MsgBus/TbNamesNamEsMsgBusAdapter.cpp
+++ b/goldenmaster/Plugins/TbNames/Source/TbNames/Private/Generated/MsgBus/TbNamesNamEsMsgBusAdapter.cpp
@@ -25,7 +25,6 @@ limitations under the License.
 #include "Async/Future.h"
 #include "Async/Async.h"
 #include "Engine/World.h"
-#include "TimerManager.h"
 #include "MessageEndpoint.h"
 #include "MessageEndpointBuilder.h"
 #include "Misc/DateTime.h"
@@ -51,13 +50,17 @@ void UTbNamesNamEsMsgBusAdapter::Deinitialize()
 void UTbNamesNamEsMsgBusAdapter::_StartListening()
 {
 
-	if (!_HeartbeatTimerHandle.IsValid() && GetWorld())
+	if (!_HeartbeatTickerHandle.IsValid())
 	{
 		UTbNamesSettings* settings = GetMutableDefault<UTbNamesSettings>();
 		check(settings);
 		_HeartbeatIntervalMS = settings->MsgBusHeartbeatIntervalMS;
 
-		GetWorld()->GetTimerManager().SetTimer(_HeartbeatTimerHandle, this, &UTbNamesNamEsMsgBusAdapter::_CheckClientTimeouts, _HeartbeatIntervalMS / 1000.0f, true);
+#if (ENGINE_MAJOR_VERSION < 5)
+		_HeartbeatTickerHandle = FTicker::GetCoreTicker().AddTicker(FTickerDelegate::CreateUObject(this, &UTbNamesNamEsMsgBusAdapter::_CheckClientTimeoutsTick), _HeartbeatIntervalMS / 1000.0f);
+#else
+		_HeartbeatTickerHandle = FTSTicker::GetCoreTicker().AddTicker(FTickerDelegate::CreateUObject(this, &UTbNamesNamEsMsgBusAdapter::_CheckClientTimeoutsTick), _HeartbeatIntervalMS / 1000.0f);
+#endif
 	}
 
 	if (TbNamesNamEsMsgBusEndpoint.IsValid())
@@ -101,9 +104,13 @@ void UTbNamesNamEsMsgBusAdapter::_AnnounceService()
 
 void UTbNamesNamEsMsgBusAdapter::_StopListening()
 {
-	if (_HeartbeatTimerHandle.IsValid() && GetWorld())
+	if (_HeartbeatTickerHandle.IsValid())
 	{
-		GetWorld()->GetTimerManager().ClearTimer(_HeartbeatTimerHandle);
+#if (ENGINE_MAJOR_VERSION < 5)
+		FTicker::GetCoreTicker().RemoveTicker(_HeartbeatTickerHandle);
+#else
+		FTSTicker::GetCoreTicker().RemoveTicker(_HeartbeatTickerHandle);
+#endif
 	}
 
 	auto msg = new FTbNamesNamEsServiceDisconnectMessage();
@@ -256,6 +263,12 @@ void UTbNamesNamEsMsgBusAdapter::OnClientDisconnected(const FTbNamesNamEsClientD
 	ConnectedClientsTimestamps.Remove(Context->GetSender());
 	_OnClientDisconnected.Broadcast(Context->GetSender().ToString());
 	_UpdateClientsConnected();
+}
+
+bool UTbNamesNamEsMsgBusAdapter::_CheckClientTimeoutsTick(float /*DeltaTime*/)
+{
+	_CheckClientTimeouts();
+	return true;
 }
 
 void UTbNamesNamEsMsgBusAdapter::_CheckClientTimeouts()

--- a/goldenmaster/Plugins/TbNames/Source/TbNames/Private/Generated/MsgBus/TbNamesNamEsMsgBusClient.cpp
+++ b/goldenmaster/Plugins/TbNames/Source/TbNames/Private/Generated/MsgBus/TbNamesNamEsMsgBusClient.cpp
@@ -23,13 +23,14 @@ limitations under the License.
 #include "Generated/MsgBus/TbNamesNamEsMsgBusClient.h"
 #include "Generated/MsgBus/TbNamesNamEsMsgBusMessages.h"
 #include "Async/Async.h"
-#include "Engine/Engine.h"
+#include "Engine/World.h"
 #include "TimerManager.h"
 #include "Misc/DateTime.h"
 #include "GenericPlatform/GenericPlatformMath.h"
 #include "GenericPlatform/GenericPlatformTime.h"
 #include "MessageEndpointBuilder.h"
 #include "MessageEndpoint.h"
+#include "TbNamesSettings.h"
 #include <atomic>
 
 /**
@@ -69,6 +70,10 @@ void UTbNamesNamEsMsgBusClient::_Connect()
 {
 	if (!_HeartbeatTimerHandle.IsValid() && GetWorld())
 	{
+		UTbNamesSettings* settings = GetMutableDefault<UTbNamesSettings>();
+		check(settings);
+		_HeartbeatIntervalMS = settings->MsgBusHeartbeatIntervalMS;
+
 		GetWorld()->GetTimerManager().SetTimer(_HeartbeatTimerHandle, this, &UTbNamesNamEsMsgBusClient::_OnHeartbeat, _HeartbeatIntervalMS / 1000.0f, true);
 	}
 

--- a/goldenmaster/Plugins/TbNames/Source/TbNames/Private/Generated/MsgBus/TbNamesNamEsMsgBusClient.cpp
+++ b/goldenmaster/Plugins/TbNames/Source/TbNames/Private/Generated/MsgBus/TbNamesNamEsMsgBusClient.cpp
@@ -24,7 +24,6 @@ limitations under the License.
 #include "Generated/MsgBus/TbNamesNamEsMsgBusMessages.h"
 #include "Async/Async.h"
 #include "Engine/World.h"
-#include "TimerManager.h"
 #include "Misc/DateTime.h"
 #include "GenericPlatform/GenericPlatformMath.h"
 #include "GenericPlatform/GenericPlatformTime.h"
@@ -68,19 +67,25 @@ void UTbNamesNamEsMsgBusClient::Deinitialize()
 
 void UTbNamesNamEsMsgBusClient::_Connect()
 {
-	if (!_HeartbeatTimerHandle.IsValid() && GetWorld())
+	if (_IsConnected())
+	{
+		UE_LOG(LogTbNamesNamEsMsgBusClient, Log, TEXT("Already connected, cannot connect again."));
+		return;
+	}
+
+	if (!_HeartbeatTickerHandle.IsValid())
 	{
 		UTbNamesSettings* settings = GetMutableDefault<UTbNamesSettings>();
 		check(settings);
 		_HeartbeatIntervalMS = settings->MsgBusHeartbeatIntervalMS;
 
-		GetWorld()->GetTimerManager().SetTimer(_HeartbeatTimerHandle, this, &UTbNamesNamEsMsgBusClient::_OnHeartbeat, _HeartbeatIntervalMS / 1000.0f, true);
-	}
-
-	if (_IsConnected())
-	{
-		UE_LOG(LogTbNamesNamEsMsgBusClient, Log, TEXT("Already connected, cannot connect again."));
-		return;
+#if (ENGINE_MAJOR_VERSION < 5)
+		FTicker::GetCoreTicker().RemoveTicker(_HeartbeatTickerHandle);
+		_HeartbeatTickerHandle = FTicker::GetCoreTicker().AddTicker(FTickerDelegate::CreateUObject(this, &UTbNamesNamEsMsgBusClient::_OnHeartbeatTick), _HeartbeatIntervalMS / 1000.0f);
+#else
+		FTSTicker::GetCoreTicker().RemoveTicker(_HeartbeatTickerHandle);
+		_HeartbeatTickerHandle = FTSTicker::GetCoreTicker().AddTicker(FTickerDelegate::CreateUObject(this, &UTbNamesNamEsMsgBusClient::_OnHeartbeatTick), _HeartbeatIntervalMS / 1000.0f);
+#endif
 	}
 
 	if (TbNamesNamEsMsgBusEndpoint.IsValid() && !ServiceAddress.IsValid())
@@ -109,10 +114,12 @@ void UTbNamesNamEsMsgBusClient::_Connect()
 void UTbNamesNamEsMsgBusClient::_Disconnect()
 {
 	_LastHbTimestamp = 0.0f;
-	if (_HeartbeatTimerHandle.IsValid() && GetWorld())
-	{
-		GetWorld()->GetTimerManager().ClearTimer(_HeartbeatTimerHandle);
-	}
+
+#if (ENGINE_MAJOR_VERSION < 5)
+	FTicker::GetCoreTicker().RemoveTicker(_HeartbeatTickerHandle);
+#else
+	FTSTicker::GetCoreTicker().RemoveTicker(_HeartbeatTickerHandle);
+#endif
 
 	if (!_IsConnected())
 	{
@@ -173,15 +180,13 @@ void UTbNamesNamEsMsgBusClient::OnConnectionInit(const FTbNamesNamEsInitMessage&
 	{
 		_HeartbeatIntervalMS = InMessage._ClientPingIntervalMS;
 
-		if (_HeartbeatTimerHandle.IsValid() && GetWorld())
-		{
-			GetWorld()->GetTimerManager().ClearTimer(_HeartbeatTimerHandle);
-		}
-
-		if (!_HeartbeatTimerHandle.IsValid() && GetWorld())
-		{
-			GetWorld()->GetTimerManager().SetTimer(_HeartbeatTimerHandle, this, &UTbNamesNamEsMsgBusClient::_OnHeartbeat, _HeartbeatIntervalMS / 1000.0f, true);
-		}
+#if (ENGINE_MAJOR_VERSION < 5)
+		FTicker::GetCoreTicker().RemoveTicker(_HeartbeatTickerHandle);
+		_HeartbeatTickerHandle = FTicker::GetCoreTicker().AddTicker(FTickerDelegate::CreateUObject(this, &UTbNamesNamEsMsgBusClient::_OnHeartbeatTick), _HeartbeatIntervalMS / 1000.0f);
+#else
+		FTSTicker::GetCoreTicker().RemoveTicker(_HeartbeatTickerHandle);
+		_HeartbeatTickerHandle = FTSTicker::GetCoreTicker().AddTicker(FTickerDelegate::CreateUObject(this, &UTbNamesNamEsMsgBusClient::_OnHeartbeatTick), _HeartbeatIntervalMS / 1000.0f);
+#endif
 	}
 	const bool bbSwitchChanged = InMessage.bSwitch != bSwitch;
 	if (bbSwitchChanged)
@@ -212,6 +217,12 @@ void UTbNamesNamEsMsgBusClient::OnConnectionInit(const FTbNamesNamEsInitMessage&
 	}
 
 	_ConnectionStatusChanged.Broadcast(true);
+}
+
+bool UTbNamesNamEsMsgBusClient::_OnHeartbeatTick(float /*DeltaTime*/)
+{
+	_OnHeartbeat();
+	return true;
 }
 
 void UTbNamesNamEsMsgBusClient::_OnHeartbeat()

--- a/goldenmaster/Plugins/TbNames/Source/TbNames/Public/Generated/MsgBus/TbNamesNamEsMsgBusAdapter.h
+++ b/goldenmaster/Plugins/TbNames/Source/TbNames/Public/Generated/MsgBus/TbNamesNamEsMsgBusAdapter.h
@@ -21,11 +21,7 @@ limitations under the License.
 #include "IMessageContext.h"
 #include "Templates/SharedPointer.h"
 #include "Runtime/Launch/Resources/Version.h"
-#if (ENGINE_MAJOR_VERSION < 5)
-#include "Engine/EngineTypes.h"
-#else
-#include "Engine/TimerHandle.h"
-#endif
+#include "Containers/Ticker.h"
 #include "TbNamesNamEsMsgBusAdapter.generated.h"
 
 class FMessageEndpoint;
@@ -142,9 +138,14 @@ private:
 
 	// Heartbeat handling
 	void _CheckClientTimeouts();
+	bool _CheckClientTimeoutsTick(float DeltaTime);
 	void _UpdateClientsConnected();
 	TMap<FMessageAddress, double> ConnectedClientsTimestamps;
-	FTimerHandle _HeartbeatTimerHandle;
+#if (ENGINE_MAJOR_VERSION < 5)
+	::FDelegateHandle _HeartbeatTickerHandle;
+#else
+	FTSTicker::FDelegateHandle _HeartbeatTickerHandle;
+#endif
 	int32 _ClientsConnected = 0;
 	uint32 _HeartbeatIntervalMS = 100;
 };

--- a/goldenmaster/Plugins/TbNames/Source/TbNames/Public/Generated/MsgBus/TbNamesNamEsMsgBusClient.h
+++ b/goldenmaster/Plugins/TbNames/Source/TbNames/Public/Generated/MsgBus/TbNamesNamEsMsgBusClient.h
@@ -22,11 +22,7 @@ limitations under the License.
 #include "HAL/CriticalSection.h"
 #include "Async/Future.h"
 #include "Runtime/Launch/Resources/Version.h"
-#if (ENGINE_MAJOR_VERSION < 5)
-#include "Engine/EngineTypes.h"
-#else
-#include "Engine/TimerHandle.h"
-#endif
+#include "Containers/Ticker.h"
 #include "Templates/PimplPtr.h"
 #include "IMessageContext.h"
 #include "TbNamesNamEsMsgBusClient.generated.h"
@@ -133,8 +129,13 @@ private:
 	size_t CurrentPingCounter = 0;
 	float _CalculateAverageRTT() const;
 	FTbNamesNamEsStats Stats;
-	FTimerHandle _HeartbeatTimerHandle;
+#if (ENGINE_MAJOR_VERSION < 5)
+	::FDelegateHandle _HeartbeatTickerHandle;
+#else
+	FTSTicker::FDelegateHandle _HeartbeatTickerHandle;
+#endif
 	void _OnHeartbeat();
+	bool _OnHeartbeatTick(float DeltaTime);
 	uint32 _HeartbeatIntervalMS = 100;
 
 	// connection handling

--- a/goldenmaster/Plugins/TbNames/Source/TbNames/Public/TbNamesSettings.h
+++ b/goldenmaster/Plugins/TbNames/Source/TbNames/Public/TbNamesSettings.h
@@ -45,4 +45,11 @@ public:
 	/** Choose the olink connection to use */
 	UPROPERTY(EditAnywhere, config, Category = OLinkConnectionSetup)
 	FString OLinkConnectionIdentifier;
+
+	/** Choose the heartbeat interval in milliseconds for the msgbus connection on the service side.
+	 * On the service side this adjusts the heartbeat between client and service. The clients will receive the value from service.
+	 * On the client side this adjusts how often discovery messages are sent until a service is connected.
+	 */
+	UPROPERTY(EditAnywhere, config, Category = MsgBusConnectionSetup, meta = (DisplayName = "Heartbeat interval (in milliseconds)"))
+	uint32 MsgBusHeartbeatIntervalMS = 200;
 };

--- a/goldenmaster/Plugins/TbNames/TbNames.uplugin
+++ b/goldenmaster/Plugins/TbNames/TbNames.uplugin
@@ -2,7 +2,7 @@
 {
 	"FileVersion": 3,
 	"Version": 1,
-	"VersionName": "1.0.0",
+	"VersionName": "1.0.0+tpl.3.5.2",
 	"FriendlyName": "TbNames",
 	"Description": "",
 	"Category": "Other",

--- a/goldenmaster/Plugins/TbSame1/Source/TbSame1/Private/Generated/MsgBus/TbSame1SameEnum1InterfaceMsgBusAdapter.cpp
+++ b/goldenmaster/Plugins/TbSame1/Source/TbSame1/Private/Generated/MsgBus/TbSame1SameEnum1InterfaceMsgBusAdapter.cpp
@@ -25,7 +25,6 @@ limitations under the License.
 #include "Async/Future.h"
 #include "Async/Async.h"
 #include "Engine/World.h"
-#include "TimerManager.h"
 #include "MessageEndpoint.h"
 #include "MessageEndpointBuilder.h"
 #include "Misc/DateTime.h"
@@ -51,13 +50,17 @@ void UTbSame1SameEnum1InterfaceMsgBusAdapter::Deinitialize()
 void UTbSame1SameEnum1InterfaceMsgBusAdapter::_StartListening()
 {
 
-	if (!_HeartbeatTimerHandle.IsValid() && GetWorld())
+	if (!_HeartbeatTickerHandle.IsValid())
 	{
 		UTbSame1Settings* settings = GetMutableDefault<UTbSame1Settings>();
 		check(settings);
 		_HeartbeatIntervalMS = settings->MsgBusHeartbeatIntervalMS;
 
-		GetWorld()->GetTimerManager().SetTimer(_HeartbeatTimerHandle, this, &UTbSame1SameEnum1InterfaceMsgBusAdapter::_CheckClientTimeouts, _HeartbeatIntervalMS / 1000.0f, true);
+#if (ENGINE_MAJOR_VERSION < 5)
+		_HeartbeatTickerHandle = FTicker::GetCoreTicker().AddTicker(FTickerDelegate::CreateUObject(this, &UTbSame1SameEnum1InterfaceMsgBusAdapter::_CheckClientTimeoutsTick), _HeartbeatIntervalMS / 1000.0f);
+#else
+		_HeartbeatTickerHandle = FTSTicker::GetCoreTicker().AddTicker(FTickerDelegate::CreateUObject(this, &UTbSame1SameEnum1InterfaceMsgBusAdapter::_CheckClientTimeoutsTick), _HeartbeatIntervalMS / 1000.0f);
+#endif
 	}
 
 	if (TbSame1SameEnum1InterfaceMsgBusEndpoint.IsValid())
@@ -97,9 +100,13 @@ void UTbSame1SameEnum1InterfaceMsgBusAdapter::_AnnounceService()
 
 void UTbSame1SameEnum1InterfaceMsgBusAdapter::_StopListening()
 {
-	if (_HeartbeatTimerHandle.IsValid() && GetWorld())
+	if (_HeartbeatTickerHandle.IsValid())
 	{
-		GetWorld()->GetTimerManager().ClearTimer(_HeartbeatTimerHandle);
+#if (ENGINE_MAJOR_VERSION < 5)
+		FTicker::GetCoreTicker().RemoveTicker(_HeartbeatTickerHandle);
+#else
+		FTSTicker::GetCoreTicker().RemoveTicker(_HeartbeatTickerHandle);
+#endif
 	}
 
 	auto msg = new FTbSame1SameEnum1InterfaceServiceDisconnectMessage();
@@ -241,6 +248,12 @@ void UTbSame1SameEnum1InterfaceMsgBusAdapter::OnClientDisconnected(const FTbSame
 	ConnectedClientsTimestamps.Remove(Context->GetSender());
 	_OnClientDisconnected.Broadcast(Context->GetSender().ToString());
 	_UpdateClientsConnected();
+}
+
+bool UTbSame1SameEnum1InterfaceMsgBusAdapter::_CheckClientTimeoutsTick(float /*DeltaTime*/)
+{
+	_CheckClientTimeouts();
+	return true;
 }
 
 void UTbSame1SameEnum1InterfaceMsgBusAdapter::_CheckClientTimeouts()

--- a/goldenmaster/Plugins/TbSame1/Source/TbSame1/Private/Generated/MsgBus/TbSame1SameEnum1InterfaceMsgBusAdapter.cpp
+++ b/goldenmaster/Plugins/TbSame1/Source/TbSame1/Private/Generated/MsgBus/TbSame1SameEnum1InterfaceMsgBusAdapter.cpp
@@ -24,12 +24,12 @@ limitations under the License.
 #include "Generated/MsgBus/TbSame1SameEnum1InterfaceMsgBusMessages.h"
 #include "Async/Future.h"
 #include "Async/Async.h"
-#include "Async/Async.h"
-#include "Engine/Engine.h"
+#include "Engine/World.h"
 #include "TimerManager.h"
 #include "MessageEndpoint.h"
 #include "MessageEndpointBuilder.h"
 #include "Misc/DateTime.h"
+#include "TbSame1Settings.h"
 
 DEFINE_LOG_CATEGORY(LogTbSame1SameEnum1InterfaceMsgBusAdapter);
 UTbSame1SameEnum1InterfaceMsgBusAdapter::UTbSame1SameEnum1InterfaceMsgBusAdapter()
@@ -53,6 +53,10 @@ void UTbSame1SameEnum1InterfaceMsgBusAdapter::_StartListening()
 
 	if (!_HeartbeatTimerHandle.IsValid() && GetWorld())
 	{
+		UTbSame1Settings* settings = GetMutableDefault<UTbSame1Settings>();
+		check(settings);
+		_HeartbeatIntervalMS = settings->MsgBusHeartbeatIntervalMS;
+
 		GetWorld()->GetTimerManager().SetTimer(_HeartbeatTimerHandle, this, &UTbSame1SameEnum1InterfaceMsgBusAdapter::_CheckClientTimeouts, _HeartbeatIntervalMS / 1000.0f, true);
 	}
 

--- a/goldenmaster/Plugins/TbSame1/Source/TbSame1/Private/Generated/MsgBus/TbSame1SameEnum1InterfaceMsgBusClient.cpp
+++ b/goldenmaster/Plugins/TbSame1/Source/TbSame1/Private/Generated/MsgBus/TbSame1SameEnum1InterfaceMsgBusClient.cpp
@@ -23,13 +23,14 @@ limitations under the License.
 #include "Generated/MsgBus/TbSame1SameEnum1InterfaceMsgBusClient.h"
 #include "Generated/MsgBus/TbSame1SameEnum1InterfaceMsgBusMessages.h"
 #include "Async/Async.h"
-#include "Engine/Engine.h"
+#include "Engine/World.h"
 #include "TimerManager.h"
 #include "Misc/DateTime.h"
 #include "GenericPlatform/GenericPlatformMath.h"
 #include "GenericPlatform/GenericPlatformTime.h"
 #include "MessageEndpointBuilder.h"
 #include "MessageEndpoint.h"
+#include "TbSame1Settings.h"
 #include <atomic>
 
 /**
@@ -66,6 +67,10 @@ void UTbSame1SameEnum1InterfaceMsgBusClient::_Connect()
 {
 	if (!_HeartbeatTimerHandle.IsValid() && GetWorld())
 	{
+		UTbSame1Settings* settings = GetMutableDefault<UTbSame1Settings>();
+		check(settings);
+		_HeartbeatIntervalMS = settings->MsgBusHeartbeatIntervalMS;
+
 		GetWorld()->GetTimerManager().SetTimer(_HeartbeatTimerHandle, this, &UTbSame1SameEnum1InterfaceMsgBusClient::_OnHeartbeat, _HeartbeatIntervalMS / 1000.0f, true);
 	}
 

--- a/goldenmaster/Plugins/TbSame1/Source/TbSame1/Private/Generated/MsgBus/TbSame1SameEnum1InterfaceMsgBusClient.cpp
+++ b/goldenmaster/Plugins/TbSame1/Source/TbSame1/Private/Generated/MsgBus/TbSame1SameEnum1InterfaceMsgBusClient.cpp
@@ -24,7 +24,6 @@ limitations under the License.
 #include "Generated/MsgBus/TbSame1SameEnum1InterfaceMsgBusMessages.h"
 #include "Async/Async.h"
 #include "Engine/World.h"
-#include "TimerManager.h"
 #include "Misc/DateTime.h"
 #include "GenericPlatform/GenericPlatformMath.h"
 #include "GenericPlatform/GenericPlatformTime.h"
@@ -65,19 +64,25 @@ void UTbSame1SameEnum1InterfaceMsgBusClient::Deinitialize()
 
 void UTbSame1SameEnum1InterfaceMsgBusClient::_Connect()
 {
-	if (!_HeartbeatTimerHandle.IsValid() && GetWorld())
+	if (_IsConnected())
+	{
+		UE_LOG(LogTbSame1SameEnum1InterfaceMsgBusClient, Log, TEXT("Already connected, cannot connect again."));
+		return;
+	}
+
+	if (!_HeartbeatTickerHandle.IsValid())
 	{
 		UTbSame1Settings* settings = GetMutableDefault<UTbSame1Settings>();
 		check(settings);
 		_HeartbeatIntervalMS = settings->MsgBusHeartbeatIntervalMS;
 
-		GetWorld()->GetTimerManager().SetTimer(_HeartbeatTimerHandle, this, &UTbSame1SameEnum1InterfaceMsgBusClient::_OnHeartbeat, _HeartbeatIntervalMS / 1000.0f, true);
-	}
-
-	if (_IsConnected())
-	{
-		UE_LOG(LogTbSame1SameEnum1InterfaceMsgBusClient, Log, TEXT("Already connected, cannot connect again."));
-		return;
+#if (ENGINE_MAJOR_VERSION < 5)
+		FTicker::GetCoreTicker().RemoveTicker(_HeartbeatTickerHandle);
+		_HeartbeatTickerHandle = FTicker::GetCoreTicker().AddTicker(FTickerDelegate::CreateUObject(this, &UTbSame1SameEnum1InterfaceMsgBusClient::_OnHeartbeatTick), _HeartbeatIntervalMS / 1000.0f);
+#else
+		FTSTicker::GetCoreTicker().RemoveTicker(_HeartbeatTickerHandle);
+		_HeartbeatTickerHandle = FTSTicker::GetCoreTicker().AddTicker(FTickerDelegate::CreateUObject(this, &UTbSame1SameEnum1InterfaceMsgBusClient::_OnHeartbeatTick), _HeartbeatIntervalMS / 1000.0f);
+#endif
 	}
 
 	if (TbSame1SameEnum1InterfaceMsgBusEndpoint.IsValid() && !ServiceAddress.IsValid())
@@ -103,10 +108,12 @@ void UTbSame1SameEnum1InterfaceMsgBusClient::_Connect()
 void UTbSame1SameEnum1InterfaceMsgBusClient::_Disconnect()
 {
 	_LastHbTimestamp = 0.0f;
-	if (_HeartbeatTimerHandle.IsValid() && GetWorld())
-	{
-		GetWorld()->GetTimerManager().ClearTimer(_HeartbeatTimerHandle);
-	}
+
+#if (ENGINE_MAJOR_VERSION < 5)
+	FTicker::GetCoreTicker().RemoveTicker(_HeartbeatTickerHandle);
+#else
+	FTSTicker::GetCoreTicker().RemoveTicker(_HeartbeatTickerHandle);
+#endif
 
 	if (!_IsConnected())
 	{
@@ -167,15 +174,13 @@ void UTbSame1SameEnum1InterfaceMsgBusClient::OnConnectionInit(const FTbSame1Same
 	{
 		_HeartbeatIntervalMS = InMessage._ClientPingIntervalMS;
 
-		if (_HeartbeatTimerHandle.IsValid() && GetWorld())
-		{
-			GetWorld()->GetTimerManager().ClearTimer(_HeartbeatTimerHandle);
-		}
-
-		if (!_HeartbeatTimerHandle.IsValid() && GetWorld())
-		{
-			GetWorld()->GetTimerManager().SetTimer(_HeartbeatTimerHandle, this, &UTbSame1SameEnum1InterfaceMsgBusClient::_OnHeartbeat, _HeartbeatIntervalMS / 1000.0f, true);
-		}
+#if (ENGINE_MAJOR_VERSION < 5)
+		FTicker::GetCoreTicker().RemoveTicker(_HeartbeatTickerHandle);
+		_HeartbeatTickerHandle = FTicker::GetCoreTicker().AddTicker(FTickerDelegate::CreateUObject(this, &UTbSame1SameEnum1InterfaceMsgBusClient::_OnHeartbeatTick), _HeartbeatIntervalMS / 1000.0f);
+#else
+		FTSTicker::GetCoreTicker().RemoveTicker(_HeartbeatTickerHandle);
+		_HeartbeatTickerHandle = FTSTicker::GetCoreTicker().AddTicker(FTickerDelegate::CreateUObject(this, &UTbSame1SameEnum1InterfaceMsgBusClient::_OnHeartbeatTick), _HeartbeatIntervalMS / 1000.0f);
+#endif
 	}
 	const bool bProp1Changed = InMessage.Prop1 != Prop1;
 	if (bProp1Changed)
@@ -185,6 +190,12 @@ void UTbSame1SameEnum1InterfaceMsgBusClient::OnConnectionInit(const FTbSame1Same
 	}
 
 	_ConnectionStatusChanged.Broadcast(true);
+}
+
+bool UTbSame1SameEnum1InterfaceMsgBusClient::_OnHeartbeatTick(float /*DeltaTime*/)
+{
+	_OnHeartbeat();
+	return true;
 }
 
 void UTbSame1SameEnum1InterfaceMsgBusClient::_OnHeartbeat()

--- a/goldenmaster/Plugins/TbSame1/Source/TbSame1/Private/Generated/MsgBus/TbSame1SameEnum2InterfaceMsgBusAdapter.cpp
+++ b/goldenmaster/Plugins/TbSame1/Source/TbSame1/Private/Generated/MsgBus/TbSame1SameEnum2InterfaceMsgBusAdapter.cpp
@@ -24,12 +24,12 @@ limitations under the License.
 #include "Generated/MsgBus/TbSame1SameEnum2InterfaceMsgBusMessages.h"
 #include "Async/Future.h"
 #include "Async/Async.h"
-#include "Async/Async.h"
-#include "Engine/Engine.h"
+#include "Engine/World.h"
 #include "TimerManager.h"
 #include "MessageEndpoint.h"
 #include "MessageEndpointBuilder.h"
 #include "Misc/DateTime.h"
+#include "TbSame1Settings.h"
 
 DEFINE_LOG_CATEGORY(LogTbSame1SameEnum2InterfaceMsgBusAdapter);
 UTbSame1SameEnum2InterfaceMsgBusAdapter::UTbSame1SameEnum2InterfaceMsgBusAdapter()
@@ -53,6 +53,10 @@ void UTbSame1SameEnum2InterfaceMsgBusAdapter::_StartListening()
 
 	if (!_HeartbeatTimerHandle.IsValid() && GetWorld())
 	{
+		UTbSame1Settings* settings = GetMutableDefault<UTbSame1Settings>();
+		check(settings);
+		_HeartbeatIntervalMS = settings->MsgBusHeartbeatIntervalMS;
+
 		GetWorld()->GetTimerManager().SetTimer(_HeartbeatTimerHandle, this, &UTbSame1SameEnum2InterfaceMsgBusAdapter::_CheckClientTimeouts, _HeartbeatIntervalMS / 1000.0f, true);
 	}
 

--- a/goldenmaster/Plugins/TbSame1/Source/TbSame1/Private/Generated/MsgBus/TbSame1SameEnum2InterfaceMsgBusAdapter.cpp
+++ b/goldenmaster/Plugins/TbSame1/Source/TbSame1/Private/Generated/MsgBus/TbSame1SameEnum2InterfaceMsgBusAdapter.cpp
@@ -25,7 +25,6 @@ limitations under the License.
 #include "Async/Future.h"
 #include "Async/Async.h"
 #include "Engine/World.h"
-#include "TimerManager.h"
 #include "MessageEndpoint.h"
 #include "MessageEndpointBuilder.h"
 #include "Misc/DateTime.h"
@@ -51,13 +50,17 @@ void UTbSame1SameEnum2InterfaceMsgBusAdapter::Deinitialize()
 void UTbSame1SameEnum2InterfaceMsgBusAdapter::_StartListening()
 {
 
-	if (!_HeartbeatTimerHandle.IsValid() && GetWorld())
+	if (!_HeartbeatTickerHandle.IsValid())
 	{
 		UTbSame1Settings* settings = GetMutableDefault<UTbSame1Settings>();
 		check(settings);
 		_HeartbeatIntervalMS = settings->MsgBusHeartbeatIntervalMS;
 
-		GetWorld()->GetTimerManager().SetTimer(_HeartbeatTimerHandle, this, &UTbSame1SameEnum2InterfaceMsgBusAdapter::_CheckClientTimeouts, _HeartbeatIntervalMS / 1000.0f, true);
+#if (ENGINE_MAJOR_VERSION < 5)
+		_HeartbeatTickerHandle = FTicker::GetCoreTicker().AddTicker(FTickerDelegate::CreateUObject(this, &UTbSame1SameEnum2InterfaceMsgBusAdapter::_CheckClientTimeoutsTick), _HeartbeatIntervalMS / 1000.0f);
+#else
+		_HeartbeatTickerHandle = FTSTicker::GetCoreTicker().AddTicker(FTickerDelegate::CreateUObject(this, &UTbSame1SameEnum2InterfaceMsgBusAdapter::_CheckClientTimeoutsTick), _HeartbeatIntervalMS / 1000.0f);
+#endif
 	}
 
 	if (TbSame1SameEnum2InterfaceMsgBusEndpoint.IsValid())
@@ -99,9 +102,13 @@ void UTbSame1SameEnum2InterfaceMsgBusAdapter::_AnnounceService()
 
 void UTbSame1SameEnum2InterfaceMsgBusAdapter::_StopListening()
 {
-	if (_HeartbeatTimerHandle.IsValid() && GetWorld())
+	if (_HeartbeatTickerHandle.IsValid())
 	{
-		GetWorld()->GetTimerManager().ClearTimer(_HeartbeatTimerHandle);
+#if (ENGINE_MAJOR_VERSION < 5)
+		FTicker::GetCoreTicker().RemoveTicker(_HeartbeatTickerHandle);
+#else
+		FTSTicker::GetCoreTicker().RemoveTicker(_HeartbeatTickerHandle);
+#endif
 	}
 
 	auto msg = new FTbSame1SameEnum2InterfaceServiceDisconnectMessage();
@@ -248,6 +255,12 @@ void UTbSame1SameEnum2InterfaceMsgBusAdapter::OnClientDisconnected(const FTbSame
 	ConnectedClientsTimestamps.Remove(Context->GetSender());
 	_OnClientDisconnected.Broadcast(Context->GetSender().ToString());
 	_UpdateClientsConnected();
+}
+
+bool UTbSame1SameEnum2InterfaceMsgBusAdapter::_CheckClientTimeoutsTick(float /*DeltaTime*/)
+{
+	_CheckClientTimeouts();
+	return true;
 }
 
 void UTbSame1SameEnum2InterfaceMsgBusAdapter::_CheckClientTimeouts()

--- a/goldenmaster/Plugins/TbSame1/Source/TbSame1/Private/Generated/MsgBus/TbSame1SameEnum2InterfaceMsgBusClient.cpp
+++ b/goldenmaster/Plugins/TbSame1/Source/TbSame1/Private/Generated/MsgBus/TbSame1SameEnum2InterfaceMsgBusClient.cpp
@@ -23,13 +23,14 @@ limitations under the License.
 #include "Generated/MsgBus/TbSame1SameEnum2InterfaceMsgBusClient.h"
 #include "Generated/MsgBus/TbSame1SameEnum2InterfaceMsgBusMessages.h"
 #include "Async/Async.h"
-#include "Engine/Engine.h"
+#include "Engine/World.h"
 #include "TimerManager.h"
 #include "Misc/DateTime.h"
 #include "GenericPlatform/GenericPlatformMath.h"
 #include "GenericPlatform/GenericPlatformTime.h"
 #include "MessageEndpointBuilder.h"
 #include "MessageEndpoint.h"
+#include "TbSame1Settings.h"
 #include <atomic>
 
 /**
@@ -67,6 +68,10 @@ void UTbSame1SameEnum2InterfaceMsgBusClient::_Connect()
 {
 	if (!_HeartbeatTimerHandle.IsValid() && GetWorld())
 	{
+		UTbSame1Settings* settings = GetMutableDefault<UTbSame1Settings>();
+		check(settings);
+		_HeartbeatIntervalMS = settings->MsgBusHeartbeatIntervalMS;
+
 		GetWorld()->GetTimerManager().SetTimer(_HeartbeatTimerHandle, this, &UTbSame1SameEnum2InterfaceMsgBusClient::_OnHeartbeat, _HeartbeatIntervalMS / 1000.0f, true);
 	}
 

--- a/goldenmaster/Plugins/TbSame1/Source/TbSame1/Private/Generated/MsgBus/TbSame1SameEnum2InterfaceMsgBusClient.cpp
+++ b/goldenmaster/Plugins/TbSame1/Source/TbSame1/Private/Generated/MsgBus/TbSame1SameEnum2InterfaceMsgBusClient.cpp
@@ -24,7 +24,6 @@ limitations under the License.
 #include "Generated/MsgBus/TbSame1SameEnum2InterfaceMsgBusMessages.h"
 #include "Async/Async.h"
 #include "Engine/World.h"
-#include "TimerManager.h"
 #include "Misc/DateTime.h"
 #include "GenericPlatform/GenericPlatformMath.h"
 #include "GenericPlatform/GenericPlatformTime.h"
@@ -66,19 +65,25 @@ void UTbSame1SameEnum2InterfaceMsgBusClient::Deinitialize()
 
 void UTbSame1SameEnum2InterfaceMsgBusClient::_Connect()
 {
-	if (!_HeartbeatTimerHandle.IsValid() && GetWorld())
+	if (_IsConnected())
+	{
+		UE_LOG(LogTbSame1SameEnum2InterfaceMsgBusClient, Log, TEXT("Already connected, cannot connect again."));
+		return;
+	}
+
+	if (!_HeartbeatTickerHandle.IsValid())
 	{
 		UTbSame1Settings* settings = GetMutableDefault<UTbSame1Settings>();
 		check(settings);
 		_HeartbeatIntervalMS = settings->MsgBusHeartbeatIntervalMS;
 
-		GetWorld()->GetTimerManager().SetTimer(_HeartbeatTimerHandle, this, &UTbSame1SameEnum2InterfaceMsgBusClient::_OnHeartbeat, _HeartbeatIntervalMS / 1000.0f, true);
-	}
-
-	if (_IsConnected())
-	{
-		UE_LOG(LogTbSame1SameEnum2InterfaceMsgBusClient, Log, TEXT("Already connected, cannot connect again."));
-		return;
+#if (ENGINE_MAJOR_VERSION < 5)
+		FTicker::GetCoreTicker().RemoveTicker(_HeartbeatTickerHandle);
+		_HeartbeatTickerHandle = FTicker::GetCoreTicker().AddTicker(FTickerDelegate::CreateUObject(this, &UTbSame1SameEnum2InterfaceMsgBusClient::_OnHeartbeatTick), _HeartbeatIntervalMS / 1000.0f);
+#else
+		FTSTicker::GetCoreTicker().RemoveTicker(_HeartbeatTickerHandle);
+		_HeartbeatTickerHandle = FTSTicker::GetCoreTicker().AddTicker(FTickerDelegate::CreateUObject(this, &UTbSame1SameEnum2InterfaceMsgBusClient::_OnHeartbeatTick), _HeartbeatIntervalMS / 1000.0f);
+#endif
 	}
 
 	if (TbSame1SameEnum2InterfaceMsgBusEndpoint.IsValid() && !ServiceAddress.IsValid())
@@ -107,10 +112,12 @@ void UTbSame1SameEnum2InterfaceMsgBusClient::_Connect()
 void UTbSame1SameEnum2InterfaceMsgBusClient::_Disconnect()
 {
 	_LastHbTimestamp = 0.0f;
-	if (_HeartbeatTimerHandle.IsValid() && GetWorld())
-	{
-		GetWorld()->GetTimerManager().ClearTimer(_HeartbeatTimerHandle);
-	}
+
+#if (ENGINE_MAJOR_VERSION < 5)
+	FTicker::GetCoreTicker().RemoveTicker(_HeartbeatTickerHandle);
+#else
+	FTSTicker::GetCoreTicker().RemoveTicker(_HeartbeatTickerHandle);
+#endif
 
 	if (!_IsConnected())
 	{
@@ -171,15 +178,13 @@ void UTbSame1SameEnum2InterfaceMsgBusClient::OnConnectionInit(const FTbSame1Same
 	{
 		_HeartbeatIntervalMS = InMessage._ClientPingIntervalMS;
 
-		if (_HeartbeatTimerHandle.IsValid() && GetWorld())
-		{
-			GetWorld()->GetTimerManager().ClearTimer(_HeartbeatTimerHandle);
-		}
-
-		if (!_HeartbeatTimerHandle.IsValid() && GetWorld())
-		{
-			GetWorld()->GetTimerManager().SetTimer(_HeartbeatTimerHandle, this, &UTbSame1SameEnum2InterfaceMsgBusClient::_OnHeartbeat, _HeartbeatIntervalMS / 1000.0f, true);
-		}
+#if (ENGINE_MAJOR_VERSION < 5)
+		FTicker::GetCoreTicker().RemoveTicker(_HeartbeatTickerHandle);
+		_HeartbeatTickerHandle = FTicker::GetCoreTicker().AddTicker(FTickerDelegate::CreateUObject(this, &UTbSame1SameEnum2InterfaceMsgBusClient::_OnHeartbeatTick), _HeartbeatIntervalMS / 1000.0f);
+#else
+		FTSTicker::GetCoreTicker().RemoveTicker(_HeartbeatTickerHandle);
+		_HeartbeatTickerHandle = FTSTicker::GetCoreTicker().AddTicker(FTickerDelegate::CreateUObject(this, &UTbSame1SameEnum2InterfaceMsgBusClient::_OnHeartbeatTick), _HeartbeatIntervalMS / 1000.0f);
+#endif
 	}
 	const bool bProp1Changed = InMessage.Prop1 != Prop1;
 	if (bProp1Changed)
@@ -196,6 +201,12 @@ void UTbSame1SameEnum2InterfaceMsgBusClient::OnConnectionInit(const FTbSame1Same
 	}
 
 	_ConnectionStatusChanged.Broadcast(true);
+}
+
+bool UTbSame1SameEnum2InterfaceMsgBusClient::_OnHeartbeatTick(float /*DeltaTime*/)
+{
+	_OnHeartbeat();
+	return true;
 }
 
 void UTbSame1SameEnum2InterfaceMsgBusClient::_OnHeartbeat()

--- a/goldenmaster/Plugins/TbSame1/Source/TbSame1/Private/Generated/MsgBus/TbSame1SameStruct1InterfaceMsgBusAdapter.cpp
+++ b/goldenmaster/Plugins/TbSame1/Source/TbSame1/Private/Generated/MsgBus/TbSame1SameStruct1InterfaceMsgBusAdapter.cpp
@@ -25,7 +25,6 @@ limitations under the License.
 #include "Async/Future.h"
 #include "Async/Async.h"
 #include "Engine/World.h"
-#include "TimerManager.h"
 #include "MessageEndpoint.h"
 #include "MessageEndpointBuilder.h"
 #include "Misc/DateTime.h"
@@ -51,13 +50,17 @@ void UTbSame1SameStruct1InterfaceMsgBusAdapter::Deinitialize()
 void UTbSame1SameStruct1InterfaceMsgBusAdapter::_StartListening()
 {
 
-	if (!_HeartbeatTimerHandle.IsValid() && GetWorld())
+	if (!_HeartbeatTickerHandle.IsValid())
 	{
 		UTbSame1Settings* settings = GetMutableDefault<UTbSame1Settings>();
 		check(settings);
 		_HeartbeatIntervalMS = settings->MsgBusHeartbeatIntervalMS;
 
-		GetWorld()->GetTimerManager().SetTimer(_HeartbeatTimerHandle, this, &UTbSame1SameStruct1InterfaceMsgBusAdapter::_CheckClientTimeouts, _HeartbeatIntervalMS / 1000.0f, true);
+#if (ENGINE_MAJOR_VERSION < 5)
+		_HeartbeatTickerHandle = FTicker::GetCoreTicker().AddTicker(FTickerDelegate::CreateUObject(this, &UTbSame1SameStruct1InterfaceMsgBusAdapter::_CheckClientTimeoutsTick), _HeartbeatIntervalMS / 1000.0f);
+#else
+		_HeartbeatTickerHandle = FTSTicker::GetCoreTicker().AddTicker(FTickerDelegate::CreateUObject(this, &UTbSame1SameStruct1InterfaceMsgBusAdapter::_CheckClientTimeoutsTick), _HeartbeatIntervalMS / 1000.0f);
+#endif
 	}
 
 	if (TbSame1SameStruct1InterfaceMsgBusEndpoint.IsValid())
@@ -97,9 +100,13 @@ void UTbSame1SameStruct1InterfaceMsgBusAdapter::_AnnounceService()
 
 void UTbSame1SameStruct1InterfaceMsgBusAdapter::_StopListening()
 {
-	if (_HeartbeatTimerHandle.IsValid() && GetWorld())
+	if (_HeartbeatTickerHandle.IsValid())
 	{
-		GetWorld()->GetTimerManager().ClearTimer(_HeartbeatTimerHandle);
+#if (ENGINE_MAJOR_VERSION < 5)
+		FTicker::GetCoreTicker().RemoveTicker(_HeartbeatTickerHandle);
+#else
+		FTSTicker::GetCoreTicker().RemoveTicker(_HeartbeatTickerHandle);
+#endif
 	}
 
 	auto msg = new FTbSame1SameStruct1InterfaceServiceDisconnectMessage();
@@ -241,6 +248,12 @@ void UTbSame1SameStruct1InterfaceMsgBusAdapter::OnClientDisconnected(const FTbSa
 	ConnectedClientsTimestamps.Remove(Context->GetSender());
 	_OnClientDisconnected.Broadcast(Context->GetSender().ToString());
 	_UpdateClientsConnected();
+}
+
+bool UTbSame1SameStruct1InterfaceMsgBusAdapter::_CheckClientTimeoutsTick(float /*DeltaTime*/)
+{
+	_CheckClientTimeouts();
+	return true;
 }
 
 void UTbSame1SameStruct1InterfaceMsgBusAdapter::_CheckClientTimeouts()

--- a/goldenmaster/Plugins/TbSame1/Source/TbSame1/Private/Generated/MsgBus/TbSame1SameStruct1InterfaceMsgBusAdapter.cpp
+++ b/goldenmaster/Plugins/TbSame1/Source/TbSame1/Private/Generated/MsgBus/TbSame1SameStruct1InterfaceMsgBusAdapter.cpp
@@ -24,12 +24,12 @@ limitations under the License.
 #include "Generated/MsgBus/TbSame1SameStruct1InterfaceMsgBusMessages.h"
 #include "Async/Future.h"
 #include "Async/Async.h"
-#include "Async/Async.h"
-#include "Engine/Engine.h"
+#include "Engine/World.h"
 #include "TimerManager.h"
 #include "MessageEndpoint.h"
 #include "MessageEndpointBuilder.h"
 #include "Misc/DateTime.h"
+#include "TbSame1Settings.h"
 
 DEFINE_LOG_CATEGORY(LogTbSame1SameStruct1InterfaceMsgBusAdapter);
 UTbSame1SameStruct1InterfaceMsgBusAdapter::UTbSame1SameStruct1InterfaceMsgBusAdapter()
@@ -53,6 +53,10 @@ void UTbSame1SameStruct1InterfaceMsgBusAdapter::_StartListening()
 
 	if (!_HeartbeatTimerHandle.IsValid() && GetWorld())
 	{
+		UTbSame1Settings* settings = GetMutableDefault<UTbSame1Settings>();
+		check(settings);
+		_HeartbeatIntervalMS = settings->MsgBusHeartbeatIntervalMS;
+
 		GetWorld()->GetTimerManager().SetTimer(_HeartbeatTimerHandle, this, &UTbSame1SameStruct1InterfaceMsgBusAdapter::_CheckClientTimeouts, _HeartbeatIntervalMS / 1000.0f, true);
 	}
 

--- a/goldenmaster/Plugins/TbSame1/Source/TbSame1/Private/Generated/MsgBus/TbSame1SameStruct1InterfaceMsgBusClient.cpp
+++ b/goldenmaster/Plugins/TbSame1/Source/TbSame1/Private/Generated/MsgBus/TbSame1SameStruct1InterfaceMsgBusClient.cpp
@@ -23,13 +23,14 @@ limitations under the License.
 #include "Generated/MsgBus/TbSame1SameStruct1InterfaceMsgBusClient.h"
 #include "Generated/MsgBus/TbSame1SameStruct1InterfaceMsgBusMessages.h"
 #include "Async/Async.h"
-#include "Engine/Engine.h"
+#include "Engine/World.h"
 #include "TimerManager.h"
 #include "Misc/DateTime.h"
 #include "GenericPlatform/GenericPlatformMath.h"
 #include "GenericPlatform/GenericPlatformTime.h"
 #include "MessageEndpointBuilder.h"
 #include "MessageEndpoint.h"
+#include "TbSame1Settings.h"
 #include "HAL/CriticalSection.h"
 
 /**
@@ -67,6 +68,10 @@ void UTbSame1SameStruct1InterfaceMsgBusClient::_Connect()
 {
 	if (!_HeartbeatTimerHandle.IsValid() && GetWorld())
 	{
+		UTbSame1Settings* settings = GetMutableDefault<UTbSame1Settings>();
+		check(settings);
+		_HeartbeatIntervalMS = settings->MsgBusHeartbeatIntervalMS;
+
 		GetWorld()->GetTimerManager().SetTimer(_HeartbeatTimerHandle, this, &UTbSame1SameStruct1InterfaceMsgBusClient::_OnHeartbeat, _HeartbeatIntervalMS / 1000.0f, true);
 	}
 

--- a/goldenmaster/Plugins/TbSame1/Source/TbSame1/Private/Generated/MsgBus/TbSame1SameStruct1InterfaceMsgBusClient.cpp
+++ b/goldenmaster/Plugins/TbSame1/Source/TbSame1/Private/Generated/MsgBus/TbSame1SameStruct1InterfaceMsgBusClient.cpp
@@ -24,7 +24,6 @@ limitations under the License.
 #include "Generated/MsgBus/TbSame1SameStruct1InterfaceMsgBusMessages.h"
 #include "Async/Async.h"
 #include "Engine/World.h"
-#include "TimerManager.h"
 #include "Misc/DateTime.h"
 #include "GenericPlatform/GenericPlatformMath.h"
 #include "GenericPlatform/GenericPlatformTime.h"
@@ -66,19 +65,25 @@ void UTbSame1SameStruct1InterfaceMsgBusClient::Deinitialize()
 
 void UTbSame1SameStruct1InterfaceMsgBusClient::_Connect()
 {
-	if (!_HeartbeatTimerHandle.IsValid() && GetWorld())
+	if (_IsConnected())
+	{
+		UE_LOG(LogTbSame1SameStruct1InterfaceMsgBusClient, Log, TEXT("Already connected, cannot connect again."));
+		return;
+	}
+
+	if (!_HeartbeatTickerHandle.IsValid())
 	{
 		UTbSame1Settings* settings = GetMutableDefault<UTbSame1Settings>();
 		check(settings);
 		_HeartbeatIntervalMS = settings->MsgBusHeartbeatIntervalMS;
 
-		GetWorld()->GetTimerManager().SetTimer(_HeartbeatTimerHandle, this, &UTbSame1SameStruct1InterfaceMsgBusClient::_OnHeartbeat, _HeartbeatIntervalMS / 1000.0f, true);
-	}
-
-	if (_IsConnected())
-	{
-		UE_LOG(LogTbSame1SameStruct1InterfaceMsgBusClient, Log, TEXT("Already connected, cannot connect again."));
-		return;
+#if (ENGINE_MAJOR_VERSION < 5)
+		FTicker::GetCoreTicker().RemoveTicker(_HeartbeatTickerHandle);
+		_HeartbeatTickerHandle = FTicker::GetCoreTicker().AddTicker(FTickerDelegate::CreateUObject(this, &UTbSame1SameStruct1InterfaceMsgBusClient::_OnHeartbeatTick), _HeartbeatIntervalMS / 1000.0f);
+#else
+		FTSTicker::GetCoreTicker().RemoveTicker(_HeartbeatTickerHandle);
+		_HeartbeatTickerHandle = FTSTicker::GetCoreTicker().AddTicker(FTickerDelegate::CreateUObject(this, &UTbSame1SameStruct1InterfaceMsgBusClient::_OnHeartbeatTick), _HeartbeatIntervalMS / 1000.0f);
+#endif
 	}
 
 	if (TbSame1SameStruct1InterfaceMsgBusEndpoint.IsValid() && !ServiceAddress.IsValid())
@@ -104,10 +109,12 @@ void UTbSame1SameStruct1InterfaceMsgBusClient::_Connect()
 void UTbSame1SameStruct1InterfaceMsgBusClient::_Disconnect()
 {
 	_LastHbTimestamp = 0.0f;
-	if (_HeartbeatTimerHandle.IsValid() && GetWorld())
-	{
-		GetWorld()->GetTimerManager().ClearTimer(_HeartbeatTimerHandle);
-	}
+
+#if (ENGINE_MAJOR_VERSION < 5)
+	FTicker::GetCoreTicker().RemoveTicker(_HeartbeatTickerHandle);
+#else
+	FTSTicker::GetCoreTicker().RemoveTicker(_HeartbeatTickerHandle);
+#endif
 
 	if (!_IsConnected())
 	{
@@ -168,15 +175,13 @@ void UTbSame1SameStruct1InterfaceMsgBusClient::OnConnectionInit(const FTbSame1Sa
 	{
 		_HeartbeatIntervalMS = InMessage._ClientPingIntervalMS;
 
-		if (_HeartbeatTimerHandle.IsValid() && GetWorld())
-		{
-			GetWorld()->GetTimerManager().ClearTimer(_HeartbeatTimerHandle);
-		}
-
-		if (!_HeartbeatTimerHandle.IsValid() && GetWorld())
-		{
-			GetWorld()->GetTimerManager().SetTimer(_HeartbeatTimerHandle, this, &UTbSame1SameStruct1InterfaceMsgBusClient::_OnHeartbeat, _HeartbeatIntervalMS / 1000.0f, true);
-		}
+#if (ENGINE_MAJOR_VERSION < 5)
+		FTicker::GetCoreTicker().RemoveTicker(_HeartbeatTickerHandle);
+		_HeartbeatTickerHandle = FTicker::GetCoreTicker().AddTicker(FTickerDelegate::CreateUObject(this, &UTbSame1SameStruct1InterfaceMsgBusClient::_OnHeartbeatTick), _HeartbeatIntervalMS / 1000.0f);
+#else
+		FTSTicker::GetCoreTicker().RemoveTicker(_HeartbeatTickerHandle);
+		_HeartbeatTickerHandle = FTSTicker::GetCoreTicker().AddTicker(FTickerDelegate::CreateUObject(this, &UTbSame1SameStruct1InterfaceMsgBusClient::_OnHeartbeatTick), _HeartbeatIntervalMS / 1000.0f);
+#endif
 	}
 	const bool bProp1Changed = InMessage.Prop1 != Prop1;
 	if (bProp1Changed)
@@ -186,6 +191,12 @@ void UTbSame1SameStruct1InterfaceMsgBusClient::OnConnectionInit(const FTbSame1Sa
 	}
 
 	_ConnectionStatusChanged.Broadcast(true);
+}
+
+bool UTbSame1SameStruct1InterfaceMsgBusClient::_OnHeartbeatTick(float /*DeltaTime*/)
+{
+	_OnHeartbeat();
+	return true;
 }
 
 void UTbSame1SameStruct1InterfaceMsgBusClient::_OnHeartbeat()

--- a/goldenmaster/Plugins/TbSame1/Source/TbSame1/Private/Generated/MsgBus/TbSame1SameStruct2InterfaceMsgBusAdapter.cpp
+++ b/goldenmaster/Plugins/TbSame1/Source/TbSame1/Private/Generated/MsgBus/TbSame1SameStruct2InterfaceMsgBusAdapter.cpp
@@ -25,7 +25,6 @@ limitations under the License.
 #include "Async/Future.h"
 #include "Async/Async.h"
 #include "Engine/World.h"
-#include "TimerManager.h"
 #include "MessageEndpoint.h"
 #include "MessageEndpointBuilder.h"
 #include "Misc/DateTime.h"
@@ -51,13 +50,17 @@ void UTbSame1SameStruct2InterfaceMsgBusAdapter::Deinitialize()
 void UTbSame1SameStruct2InterfaceMsgBusAdapter::_StartListening()
 {
 
-	if (!_HeartbeatTimerHandle.IsValid() && GetWorld())
+	if (!_HeartbeatTickerHandle.IsValid())
 	{
 		UTbSame1Settings* settings = GetMutableDefault<UTbSame1Settings>();
 		check(settings);
 		_HeartbeatIntervalMS = settings->MsgBusHeartbeatIntervalMS;
 
-		GetWorld()->GetTimerManager().SetTimer(_HeartbeatTimerHandle, this, &UTbSame1SameStruct2InterfaceMsgBusAdapter::_CheckClientTimeouts, _HeartbeatIntervalMS / 1000.0f, true);
+#if (ENGINE_MAJOR_VERSION < 5)
+		_HeartbeatTickerHandle = FTicker::GetCoreTicker().AddTicker(FTickerDelegate::CreateUObject(this, &UTbSame1SameStruct2InterfaceMsgBusAdapter::_CheckClientTimeoutsTick), _HeartbeatIntervalMS / 1000.0f);
+#else
+		_HeartbeatTickerHandle = FTSTicker::GetCoreTicker().AddTicker(FTickerDelegate::CreateUObject(this, &UTbSame1SameStruct2InterfaceMsgBusAdapter::_CheckClientTimeoutsTick), _HeartbeatIntervalMS / 1000.0f);
+#endif
 	}
 
 	if (TbSame1SameStruct2InterfaceMsgBusEndpoint.IsValid())
@@ -99,9 +102,13 @@ void UTbSame1SameStruct2InterfaceMsgBusAdapter::_AnnounceService()
 
 void UTbSame1SameStruct2InterfaceMsgBusAdapter::_StopListening()
 {
-	if (_HeartbeatTimerHandle.IsValid() && GetWorld())
+	if (_HeartbeatTickerHandle.IsValid())
 	{
-		GetWorld()->GetTimerManager().ClearTimer(_HeartbeatTimerHandle);
+#if (ENGINE_MAJOR_VERSION < 5)
+		FTicker::GetCoreTicker().RemoveTicker(_HeartbeatTickerHandle);
+#else
+		FTSTicker::GetCoreTicker().RemoveTicker(_HeartbeatTickerHandle);
+#endif
 	}
 
 	auto msg = new FTbSame1SameStruct2InterfaceServiceDisconnectMessage();
@@ -248,6 +255,12 @@ void UTbSame1SameStruct2InterfaceMsgBusAdapter::OnClientDisconnected(const FTbSa
 	ConnectedClientsTimestamps.Remove(Context->GetSender());
 	_OnClientDisconnected.Broadcast(Context->GetSender().ToString());
 	_UpdateClientsConnected();
+}
+
+bool UTbSame1SameStruct2InterfaceMsgBusAdapter::_CheckClientTimeoutsTick(float /*DeltaTime*/)
+{
+	_CheckClientTimeouts();
+	return true;
 }
 
 void UTbSame1SameStruct2InterfaceMsgBusAdapter::_CheckClientTimeouts()

--- a/goldenmaster/Plugins/TbSame1/Source/TbSame1/Private/Generated/MsgBus/TbSame1SameStruct2InterfaceMsgBusAdapter.cpp
+++ b/goldenmaster/Plugins/TbSame1/Source/TbSame1/Private/Generated/MsgBus/TbSame1SameStruct2InterfaceMsgBusAdapter.cpp
@@ -24,12 +24,12 @@ limitations under the License.
 #include "Generated/MsgBus/TbSame1SameStruct2InterfaceMsgBusMessages.h"
 #include "Async/Future.h"
 #include "Async/Async.h"
-#include "Async/Async.h"
-#include "Engine/Engine.h"
+#include "Engine/World.h"
 #include "TimerManager.h"
 #include "MessageEndpoint.h"
 #include "MessageEndpointBuilder.h"
 #include "Misc/DateTime.h"
+#include "TbSame1Settings.h"
 
 DEFINE_LOG_CATEGORY(LogTbSame1SameStruct2InterfaceMsgBusAdapter);
 UTbSame1SameStruct2InterfaceMsgBusAdapter::UTbSame1SameStruct2InterfaceMsgBusAdapter()
@@ -53,6 +53,10 @@ void UTbSame1SameStruct2InterfaceMsgBusAdapter::_StartListening()
 
 	if (!_HeartbeatTimerHandle.IsValid() && GetWorld())
 	{
+		UTbSame1Settings* settings = GetMutableDefault<UTbSame1Settings>();
+		check(settings);
+		_HeartbeatIntervalMS = settings->MsgBusHeartbeatIntervalMS;
+
 		GetWorld()->GetTimerManager().SetTimer(_HeartbeatTimerHandle, this, &UTbSame1SameStruct2InterfaceMsgBusAdapter::_CheckClientTimeouts, _HeartbeatIntervalMS / 1000.0f, true);
 	}
 

--- a/goldenmaster/Plugins/TbSame1/Source/TbSame1/Private/Generated/MsgBus/TbSame1SameStruct2InterfaceMsgBusClient.cpp
+++ b/goldenmaster/Plugins/TbSame1/Source/TbSame1/Private/Generated/MsgBus/TbSame1SameStruct2InterfaceMsgBusClient.cpp
@@ -24,7 +24,6 @@ limitations under the License.
 #include "Generated/MsgBus/TbSame1SameStruct2InterfaceMsgBusMessages.h"
 #include "Async/Async.h"
 #include "Engine/World.h"
-#include "TimerManager.h"
 #include "Misc/DateTime.h"
 #include "GenericPlatform/GenericPlatformMath.h"
 #include "GenericPlatform/GenericPlatformTime.h"
@@ -68,19 +67,25 @@ void UTbSame1SameStruct2InterfaceMsgBusClient::Deinitialize()
 
 void UTbSame1SameStruct2InterfaceMsgBusClient::_Connect()
 {
-	if (!_HeartbeatTimerHandle.IsValid() && GetWorld())
+	if (_IsConnected())
+	{
+		UE_LOG(LogTbSame1SameStruct2InterfaceMsgBusClient, Log, TEXT("Already connected, cannot connect again."));
+		return;
+	}
+
+	if (!_HeartbeatTickerHandle.IsValid())
 	{
 		UTbSame1Settings* settings = GetMutableDefault<UTbSame1Settings>();
 		check(settings);
 		_HeartbeatIntervalMS = settings->MsgBusHeartbeatIntervalMS;
 
-		GetWorld()->GetTimerManager().SetTimer(_HeartbeatTimerHandle, this, &UTbSame1SameStruct2InterfaceMsgBusClient::_OnHeartbeat, _HeartbeatIntervalMS / 1000.0f, true);
-	}
-
-	if (_IsConnected())
-	{
-		UE_LOG(LogTbSame1SameStruct2InterfaceMsgBusClient, Log, TEXT("Already connected, cannot connect again."));
-		return;
+#if (ENGINE_MAJOR_VERSION < 5)
+		FTicker::GetCoreTicker().RemoveTicker(_HeartbeatTickerHandle);
+		_HeartbeatTickerHandle = FTicker::GetCoreTicker().AddTicker(FTickerDelegate::CreateUObject(this, &UTbSame1SameStruct2InterfaceMsgBusClient::_OnHeartbeatTick), _HeartbeatIntervalMS / 1000.0f);
+#else
+		FTSTicker::GetCoreTicker().RemoveTicker(_HeartbeatTickerHandle);
+		_HeartbeatTickerHandle = FTSTicker::GetCoreTicker().AddTicker(FTickerDelegate::CreateUObject(this, &UTbSame1SameStruct2InterfaceMsgBusClient::_OnHeartbeatTick), _HeartbeatIntervalMS / 1000.0f);
+#endif
 	}
 
 	if (TbSame1SameStruct2InterfaceMsgBusEndpoint.IsValid() && !ServiceAddress.IsValid())
@@ -109,10 +114,12 @@ void UTbSame1SameStruct2InterfaceMsgBusClient::_Connect()
 void UTbSame1SameStruct2InterfaceMsgBusClient::_Disconnect()
 {
 	_LastHbTimestamp = 0.0f;
-	if (_HeartbeatTimerHandle.IsValid() && GetWorld())
-	{
-		GetWorld()->GetTimerManager().ClearTimer(_HeartbeatTimerHandle);
-	}
+
+#if (ENGINE_MAJOR_VERSION < 5)
+	FTicker::GetCoreTicker().RemoveTicker(_HeartbeatTickerHandle);
+#else
+	FTSTicker::GetCoreTicker().RemoveTicker(_HeartbeatTickerHandle);
+#endif
 
 	if (!_IsConnected())
 	{
@@ -173,15 +180,13 @@ void UTbSame1SameStruct2InterfaceMsgBusClient::OnConnectionInit(const FTbSame1Sa
 	{
 		_HeartbeatIntervalMS = InMessage._ClientPingIntervalMS;
 
-		if (_HeartbeatTimerHandle.IsValid() && GetWorld())
-		{
-			GetWorld()->GetTimerManager().ClearTimer(_HeartbeatTimerHandle);
-		}
-
-		if (!_HeartbeatTimerHandle.IsValid() && GetWorld())
-		{
-			GetWorld()->GetTimerManager().SetTimer(_HeartbeatTimerHandle, this, &UTbSame1SameStruct2InterfaceMsgBusClient::_OnHeartbeat, _HeartbeatIntervalMS / 1000.0f, true);
-		}
+#if (ENGINE_MAJOR_VERSION < 5)
+		FTicker::GetCoreTicker().RemoveTicker(_HeartbeatTickerHandle);
+		_HeartbeatTickerHandle = FTicker::GetCoreTicker().AddTicker(FTickerDelegate::CreateUObject(this, &UTbSame1SameStruct2InterfaceMsgBusClient::_OnHeartbeatTick), _HeartbeatIntervalMS / 1000.0f);
+#else
+		FTSTicker::GetCoreTicker().RemoveTicker(_HeartbeatTickerHandle);
+		_HeartbeatTickerHandle = FTSTicker::GetCoreTicker().AddTicker(FTickerDelegate::CreateUObject(this, &UTbSame1SameStruct2InterfaceMsgBusClient::_OnHeartbeatTick), _HeartbeatIntervalMS / 1000.0f);
+#endif
 	}
 	const bool bProp1Changed = InMessage.Prop1 != Prop1;
 	if (bProp1Changed)
@@ -198,6 +203,12 @@ void UTbSame1SameStruct2InterfaceMsgBusClient::OnConnectionInit(const FTbSame1Sa
 	}
 
 	_ConnectionStatusChanged.Broadcast(true);
+}
+
+bool UTbSame1SameStruct2InterfaceMsgBusClient::_OnHeartbeatTick(float /*DeltaTime*/)
+{
+	_OnHeartbeat();
+	return true;
 }
 
 void UTbSame1SameStruct2InterfaceMsgBusClient::_OnHeartbeat()

--- a/goldenmaster/Plugins/TbSame1/Source/TbSame1/Private/Generated/MsgBus/TbSame1SameStruct2InterfaceMsgBusClient.cpp
+++ b/goldenmaster/Plugins/TbSame1/Source/TbSame1/Private/Generated/MsgBus/TbSame1SameStruct2InterfaceMsgBusClient.cpp
@@ -23,13 +23,14 @@ limitations under the License.
 #include "Generated/MsgBus/TbSame1SameStruct2InterfaceMsgBusClient.h"
 #include "Generated/MsgBus/TbSame1SameStruct2InterfaceMsgBusMessages.h"
 #include "Async/Async.h"
-#include "Engine/Engine.h"
+#include "Engine/World.h"
 #include "TimerManager.h"
 #include "Misc/DateTime.h"
 #include "GenericPlatform/GenericPlatformMath.h"
 #include "GenericPlatform/GenericPlatformTime.h"
 #include "MessageEndpointBuilder.h"
 #include "MessageEndpoint.h"
+#include "TbSame1Settings.h"
 #include "HAL/CriticalSection.h"
 
 /**
@@ -69,6 +70,10 @@ void UTbSame1SameStruct2InterfaceMsgBusClient::_Connect()
 {
 	if (!_HeartbeatTimerHandle.IsValid() && GetWorld())
 	{
+		UTbSame1Settings* settings = GetMutableDefault<UTbSame1Settings>();
+		check(settings);
+		_HeartbeatIntervalMS = settings->MsgBusHeartbeatIntervalMS;
+
 		GetWorld()->GetTimerManager().SetTimer(_HeartbeatTimerHandle, this, &UTbSame1SameStruct2InterfaceMsgBusClient::_OnHeartbeat, _HeartbeatIntervalMS / 1000.0f, true);
 	}
 

--- a/goldenmaster/Plugins/TbSame1/Source/TbSame1/Public/Generated/MsgBus/TbSame1SameEnum1InterfaceMsgBusAdapter.h
+++ b/goldenmaster/Plugins/TbSame1/Source/TbSame1/Public/Generated/MsgBus/TbSame1SameEnum1InterfaceMsgBusAdapter.h
@@ -21,11 +21,7 @@ limitations under the License.
 #include "IMessageContext.h"
 #include "Templates/SharedPointer.h"
 #include "Runtime/Launch/Resources/Version.h"
-#if (ENGINE_MAJOR_VERSION < 5)
-#include "Engine/EngineTypes.h"
-#else
-#include "Engine/TimerHandle.h"
-#endif
+#include "Containers/Ticker.h"
 #include "TbSame1SameEnum1InterfaceMsgBusAdapter.generated.h"
 
 class FMessageEndpoint;
@@ -118,9 +114,14 @@ private:
 
 	// Heartbeat handling
 	void _CheckClientTimeouts();
+	bool _CheckClientTimeoutsTick(float DeltaTime);
 	void _UpdateClientsConnected();
 	TMap<FMessageAddress, double> ConnectedClientsTimestamps;
-	FTimerHandle _HeartbeatTimerHandle;
+#if (ENGINE_MAJOR_VERSION < 5)
+	::FDelegateHandle _HeartbeatTickerHandle;
+#else
+	FTSTicker::FDelegateHandle _HeartbeatTickerHandle;
+#endif
 	int32 _ClientsConnected = 0;
 	uint32 _HeartbeatIntervalMS = 100;
 };

--- a/goldenmaster/Plugins/TbSame1/Source/TbSame1/Public/Generated/MsgBus/TbSame1SameEnum1InterfaceMsgBusClient.h
+++ b/goldenmaster/Plugins/TbSame1/Source/TbSame1/Public/Generated/MsgBus/TbSame1SameEnum1InterfaceMsgBusClient.h
@@ -22,11 +22,7 @@ limitations under the License.
 #include "HAL/CriticalSection.h"
 #include "Async/Future.h"
 #include "Runtime/Launch/Resources/Version.h"
-#if (ENGINE_MAJOR_VERSION < 5)
-#include "Engine/EngineTypes.h"
-#else
-#include "Engine/TimerHandle.h"
-#endif
+#include "Containers/Ticker.h"
 #include "Templates/PimplPtr.h"
 #include "IMessageContext.h"
 #include "TbSame1SameEnum1InterfaceMsgBusClient.generated.h"
@@ -119,8 +115,13 @@ private:
 	size_t CurrentPingCounter = 0;
 	float _CalculateAverageRTT() const;
 	FTbSame1SameEnum1InterfaceStats Stats;
-	FTimerHandle _HeartbeatTimerHandle;
+#if (ENGINE_MAJOR_VERSION < 5)
+	::FDelegateHandle _HeartbeatTickerHandle;
+#else
+	FTSTicker::FDelegateHandle _HeartbeatTickerHandle;
+#endif
 	void _OnHeartbeat();
+	bool _OnHeartbeatTick(float DeltaTime);
 	uint32 _HeartbeatIntervalMS = 100;
 
 	// connection handling

--- a/goldenmaster/Plugins/TbSame1/Source/TbSame1/Public/Generated/MsgBus/TbSame1SameEnum2InterfaceMsgBusAdapter.h
+++ b/goldenmaster/Plugins/TbSame1/Source/TbSame1/Public/Generated/MsgBus/TbSame1SameEnum2InterfaceMsgBusAdapter.h
@@ -21,11 +21,7 @@ limitations under the License.
 #include "IMessageContext.h"
 #include "Templates/SharedPointer.h"
 #include "Runtime/Launch/Resources/Version.h"
-#if (ENGINE_MAJOR_VERSION < 5)
-#include "Engine/EngineTypes.h"
-#else
-#include "Engine/TimerHandle.h"
-#endif
+#include "Containers/Ticker.h"
 #include "TbSame1SameEnum2InterfaceMsgBusAdapter.generated.h"
 
 class FMessageEndpoint;
@@ -130,9 +126,14 @@ private:
 
 	// Heartbeat handling
 	void _CheckClientTimeouts();
+	bool _CheckClientTimeoutsTick(float DeltaTime);
 	void _UpdateClientsConnected();
 	TMap<FMessageAddress, double> ConnectedClientsTimestamps;
-	FTimerHandle _HeartbeatTimerHandle;
+#if (ENGINE_MAJOR_VERSION < 5)
+	::FDelegateHandle _HeartbeatTickerHandle;
+#else
+	FTSTicker::FDelegateHandle _HeartbeatTickerHandle;
+#endif
 	int32 _ClientsConnected = 0;
 	uint32 _HeartbeatIntervalMS = 100;
 };

--- a/goldenmaster/Plugins/TbSame1/Source/TbSame1/Public/Generated/MsgBus/TbSame1SameEnum2InterfaceMsgBusClient.h
+++ b/goldenmaster/Plugins/TbSame1/Source/TbSame1/Public/Generated/MsgBus/TbSame1SameEnum2InterfaceMsgBusClient.h
@@ -22,11 +22,7 @@ limitations under the License.
 #include "HAL/CriticalSection.h"
 #include "Async/Future.h"
 #include "Runtime/Launch/Resources/Version.h"
-#if (ENGINE_MAJOR_VERSION < 5)
-#include "Engine/EngineTypes.h"
-#else
-#include "Engine/TimerHandle.h"
-#endif
+#include "Containers/Ticker.h"
 #include "Templates/PimplPtr.h"
 #include "IMessageContext.h"
 #include "TbSame1SameEnum2InterfaceMsgBusClient.generated.h"
@@ -127,8 +123,13 @@ private:
 	size_t CurrentPingCounter = 0;
 	float _CalculateAverageRTT() const;
 	FTbSame1SameEnum2InterfaceStats Stats;
-	FTimerHandle _HeartbeatTimerHandle;
+#if (ENGINE_MAJOR_VERSION < 5)
+	::FDelegateHandle _HeartbeatTickerHandle;
+#else
+	FTSTicker::FDelegateHandle _HeartbeatTickerHandle;
+#endif
 	void _OnHeartbeat();
+	bool _OnHeartbeatTick(float DeltaTime);
 	uint32 _HeartbeatIntervalMS = 100;
 
 	// connection handling

--- a/goldenmaster/Plugins/TbSame1/Source/TbSame1/Public/Generated/MsgBus/TbSame1SameStruct1InterfaceMsgBusAdapter.h
+++ b/goldenmaster/Plugins/TbSame1/Source/TbSame1/Public/Generated/MsgBus/TbSame1SameStruct1InterfaceMsgBusAdapter.h
@@ -21,11 +21,7 @@ limitations under the License.
 #include "IMessageContext.h"
 #include "Templates/SharedPointer.h"
 #include "Runtime/Launch/Resources/Version.h"
-#if (ENGINE_MAJOR_VERSION < 5)
-#include "Engine/EngineTypes.h"
-#else
-#include "Engine/TimerHandle.h"
-#endif
+#include "Containers/Ticker.h"
 #include "TbSame1SameStruct1InterfaceMsgBusAdapter.generated.h"
 
 class FMessageEndpoint;
@@ -118,9 +114,14 @@ private:
 
 	// Heartbeat handling
 	void _CheckClientTimeouts();
+	bool _CheckClientTimeoutsTick(float DeltaTime);
 	void _UpdateClientsConnected();
 	TMap<FMessageAddress, double> ConnectedClientsTimestamps;
-	FTimerHandle _HeartbeatTimerHandle;
+#if (ENGINE_MAJOR_VERSION < 5)
+	::FDelegateHandle _HeartbeatTickerHandle;
+#else
+	FTSTicker::FDelegateHandle _HeartbeatTickerHandle;
+#endif
 	int32 _ClientsConnected = 0;
 	uint32 _HeartbeatIntervalMS = 100;
 };

--- a/goldenmaster/Plugins/TbSame1/Source/TbSame1/Public/Generated/MsgBus/TbSame1SameStruct1InterfaceMsgBusClient.h
+++ b/goldenmaster/Plugins/TbSame1/Source/TbSame1/Public/Generated/MsgBus/TbSame1SameStruct1InterfaceMsgBusClient.h
@@ -22,11 +22,7 @@ limitations under the License.
 #include "HAL/CriticalSection.h"
 #include "Async/Future.h"
 #include "Runtime/Launch/Resources/Version.h"
-#if (ENGINE_MAJOR_VERSION < 5)
-#include "Engine/EngineTypes.h"
-#else
-#include "Engine/TimerHandle.h"
-#endif
+#include "Containers/Ticker.h"
 #include "Templates/PimplPtr.h"
 #include "IMessageContext.h"
 #include "TbSame1SameStruct1InterfaceMsgBusClient.generated.h"
@@ -119,8 +115,13 @@ private:
 	size_t CurrentPingCounter = 0;
 	float _CalculateAverageRTT() const;
 	FTbSame1SameStruct1InterfaceStats Stats;
-	FTimerHandle _HeartbeatTimerHandle;
+#if (ENGINE_MAJOR_VERSION < 5)
+	::FDelegateHandle _HeartbeatTickerHandle;
+#else
+	FTSTicker::FDelegateHandle _HeartbeatTickerHandle;
+#endif
 	void _OnHeartbeat();
+	bool _OnHeartbeatTick(float DeltaTime);
 	uint32 _HeartbeatIntervalMS = 100;
 
 	// connection handling

--- a/goldenmaster/Plugins/TbSame1/Source/TbSame1/Public/Generated/MsgBus/TbSame1SameStruct2InterfaceMsgBusAdapter.h
+++ b/goldenmaster/Plugins/TbSame1/Source/TbSame1/Public/Generated/MsgBus/TbSame1SameStruct2InterfaceMsgBusAdapter.h
@@ -21,11 +21,7 @@ limitations under the License.
 #include "IMessageContext.h"
 #include "Templates/SharedPointer.h"
 #include "Runtime/Launch/Resources/Version.h"
-#if (ENGINE_MAJOR_VERSION < 5)
-#include "Engine/EngineTypes.h"
-#else
-#include "Engine/TimerHandle.h"
-#endif
+#include "Containers/Ticker.h"
 #include "TbSame1SameStruct2InterfaceMsgBusAdapter.generated.h"
 
 class FMessageEndpoint;
@@ -130,9 +126,14 @@ private:
 
 	// Heartbeat handling
 	void _CheckClientTimeouts();
+	bool _CheckClientTimeoutsTick(float DeltaTime);
 	void _UpdateClientsConnected();
 	TMap<FMessageAddress, double> ConnectedClientsTimestamps;
-	FTimerHandle _HeartbeatTimerHandle;
+#if (ENGINE_MAJOR_VERSION < 5)
+	::FDelegateHandle _HeartbeatTickerHandle;
+#else
+	FTSTicker::FDelegateHandle _HeartbeatTickerHandle;
+#endif
 	int32 _ClientsConnected = 0;
 	uint32 _HeartbeatIntervalMS = 100;
 };

--- a/goldenmaster/Plugins/TbSame1/Source/TbSame1/Public/Generated/MsgBus/TbSame1SameStruct2InterfaceMsgBusClient.h
+++ b/goldenmaster/Plugins/TbSame1/Source/TbSame1/Public/Generated/MsgBus/TbSame1SameStruct2InterfaceMsgBusClient.h
@@ -22,11 +22,7 @@ limitations under the License.
 #include "HAL/CriticalSection.h"
 #include "Async/Future.h"
 #include "Runtime/Launch/Resources/Version.h"
-#if (ENGINE_MAJOR_VERSION < 5)
-#include "Engine/EngineTypes.h"
-#else
-#include "Engine/TimerHandle.h"
-#endif
+#include "Containers/Ticker.h"
 #include "Templates/PimplPtr.h"
 #include "IMessageContext.h"
 #include "TbSame1SameStruct2InterfaceMsgBusClient.generated.h"
@@ -127,8 +123,13 @@ private:
 	size_t CurrentPingCounter = 0;
 	float _CalculateAverageRTT() const;
 	FTbSame1SameStruct2InterfaceStats Stats;
-	FTimerHandle _HeartbeatTimerHandle;
+#if (ENGINE_MAJOR_VERSION < 5)
+	::FDelegateHandle _HeartbeatTickerHandle;
+#else
+	FTSTicker::FDelegateHandle _HeartbeatTickerHandle;
+#endif
 	void _OnHeartbeat();
+	bool _OnHeartbeatTick(float DeltaTime);
 	uint32 _HeartbeatIntervalMS = 100;
 
 	// connection handling

--- a/goldenmaster/Plugins/TbSame1/Source/TbSame1/Public/TbSame1Settings.h
+++ b/goldenmaster/Plugins/TbSame1/Source/TbSame1/Public/TbSame1Settings.h
@@ -45,4 +45,11 @@ public:
 	/** Choose the olink connection to use */
 	UPROPERTY(EditAnywhere, config, Category = OLinkConnectionSetup)
 	FString OLinkConnectionIdentifier;
+
+	/** Choose the heartbeat interval in milliseconds for the msgbus connection on the service side.
+	 * On the service side this adjusts the heartbeat between client and service. The clients will receive the value from service.
+	 * On the client side this adjusts how often discovery messages are sent until a service is connected.
+	 */
+	UPROPERTY(EditAnywhere, config, Category = MsgBusConnectionSetup, meta = (DisplayName = "Heartbeat interval (in milliseconds)"))
+	uint32 MsgBusHeartbeatIntervalMS = 200;
 };

--- a/goldenmaster/Plugins/TbSame1/TbSame1.uplugin
+++ b/goldenmaster/Plugins/TbSame1/TbSame1.uplugin
@@ -2,7 +2,7 @@
 {
 	"FileVersion": 3,
 	"Version": 1,
-	"VersionName": "1.0.0",
+	"VersionName": "1.0.0+tpl.3.5.2",
 	"FriendlyName": "TbSame1",
 	"Description": "",
 	"Category": "Other",

--- a/goldenmaster/Plugins/TbSame2/Source/TbSame2/Private/Generated/MsgBus/TbSame2SameEnum1InterfaceMsgBusAdapter.cpp
+++ b/goldenmaster/Plugins/TbSame2/Source/TbSame2/Private/Generated/MsgBus/TbSame2SameEnum1InterfaceMsgBusAdapter.cpp
@@ -24,12 +24,12 @@ limitations under the License.
 #include "Generated/MsgBus/TbSame2SameEnum1InterfaceMsgBusMessages.h"
 #include "Async/Future.h"
 #include "Async/Async.h"
-#include "Async/Async.h"
-#include "Engine/Engine.h"
+#include "Engine/World.h"
 #include "TimerManager.h"
 #include "MessageEndpoint.h"
 #include "MessageEndpointBuilder.h"
 #include "Misc/DateTime.h"
+#include "TbSame2Settings.h"
 
 DEFINE_LOG_CATEGORY(LogTbSame2SameEnum1InterfaceMsgBusAdapter);
 UTbSame2SameEnum1InterfaceMsgBusAdapter::UTbSame2SameEnum1InterfaceMsgBusAdapter()
@@ -53,6 +53,10 @@ void UTbSame2SameEnum1InterfaceMsgBusAdapter::_StartListening()
 
 	if (!_HeartbeatTimerHandle.IsValid() && GetWorld())
 	{
+		UTbSame2Settings* settings = GetMutableDefault<UTbSame2Settings>();
+		check(settings);
+		_HeartbeatIntervalMS = settings->MsgBusHeartbeatIntervalMS;
+
 		GetWorld()->GetTimerManager().SetTimer(_HeartbeatTimerHandle, this, &UTbSame2SameEnum1InterfaceMsgBusAdapter::_CheckClientTimeouts, _HeartbeatIntervalMS / 1000.0f, true);
 	}
 

--- a/goldenmaster/Plugins/TbSame2/Source/TbSame2/Private/Generated/MsgBus/TbSame2SameEnum1InterfaceMsgBusAdapter.cpp
+++ b/goldenmaster/Plugins/TbSame2/Source/TbSame2/Private/Generated/MsgBus/TbSame2SameEnum1InterfaceMsgBusAdapter.cpp
@@ -25,7 +25,6 @@ limitations under the License.
 #include "Async/Future.h"
 #include "Async/Async.h"
 #include "Engine/World.h"
-#include "TimerManager.h"
 #include "MessageEndpoint.h"
 #include "MessageEndpointBuilder.h"
 #include "Misc/DateTime.h"
@@ -51,13 +50,17 @@ void UTbSame2SameEnum1InterfaceMsgBusAdapter::Deinitialize()
 void UTbSame2SameEnum1InterfaceMsgBusAdapter::_StartListening()
 {
 
-	if (!_HeartbeatTimerHandle.IsValid() && GetWorld())
+	if (!_HeartbeatTickerHandle.IsValid())
 	{
 		UTbSame2Settings* settings = GetMutableDefault<UTbSame2Settings>();
 		check(settings);
 		_HeartbeatIntervalMS = settings->MsgBusHeartbeatIntervalMS;
 
-		GetWorld()->GetTimerManager().SetTimer(_HeartbeatTimerHandle, this, &UTbSame2SameEnum1InterfaceMsgBusAdapter::_CheckClientTimeouts, _HeartbeatIntervalMS / 1000.0f, true);
+#if (ENGINE_MAJOR_VERSION < 5)
+		_HeartbeatTickerHandle = FTicker::GetCoreTicker().AddTicker(FTickerDelegate::CreateUObject(this, &UTbSame2SameEnum1InterfaceMsgBusAdapter::_CheckClientTimeoutsTick), _HeartbeatIntervalMS / 1000.0f);
+#else
+		_HeartbeatTickerHandle = FTSTicker::GetCoreTicker().AddTicker(FTickerDelegate::CreateUObject(this, &UTbSame2SameEnum1InterfaceMsgBusAdapter::_CheckClientTimeoutsTick), _HeartbeatIntervalMS / 1000.0f);
+#endif
 	}
 
 	if (TbSame2SameEnum1InterfaceMsgBusEndpoint.IsValid())
@@ -97,9 +100,13 @@ void UTbSame2SameEnum1InterfaceMsgBusAdapter::_AnnounceService()
 
 void UTbSame2SameEnum1InterfaceMsgBusAdapter::_StopListening()
 {
-	if (_HeartbeatTimerHandle.IsValid() && GetWorld())
+	if (_HeartbeatTickerHandle.IsValid())
 	{
-		GetWorld()->GetTimerManager().ClearTimer(_HeartbeatTimerHandle);
+#if (ENGINE_MAJOR_VERSION < 5)
+		FTicker::GetCoreTicker().RemoveTicker(_HeartbeatTickerHandle);
+#else
+		FTSTicker::GetCoreTicker().RemoveTicker(_HeartbeatTickerHandle);
+#endif
 	}
 
 	auto msg = new FTbSame2SameEnum1InterfaceServiceDisconnectMessage();
@@ -241,6 +248,12 @@ void UTbSame2SameEnum1InterfaceMsgBusAdapter::OnClientDisconnected(const FTbSame
 	ConnectedClientsTimestamps.Remove(Context->GetSender());
 	_OnClientDisconnected.Broadcast(Context->GetSender().ToString());
 	_UpdateClientsConnected();
+}
+
+bool UTbSame2SameEnum1InterfaceMsgBusAdapter::_CheckClientTimeoutsTick(float /*DeltaTime*/)
+{
+	_CheckClientTimeouts();
+	return true;
 }
 
 void UTbSame2SameEnum1InterfaceMsgBusAdapter::_CheckClientTimeouts()

--- a/goldenmaster/Plugins/TbSame2/Source/TbSame2/Private/Generated/MsgBus/TbSame2SameEnum1InterfaceMsgBusClient.cpp
+++ b/goldenmaster/Plugins/TbSame2/Source/TbSame2/Private/Generated/MsgBus/TbSame2SameEnum1InterfaceMsgBusClient.cpp
@@ -23,13 +23,14 @@ limitations under the License.
 #include "Generated/MsgBus/TbSame2SameEnum1InterfaceMsgBusClient.h"
 #include "Generated/MsgBus/TbSame2SameEnum1InterfaceMsgBusMessages.h"
 #include "Async/Async.h"
-#include "Engine/Engine.h"
+#include "Engine/World.h"
 #include "TimerManager.h"
 #include "Misc/DateTime.h"
 #include "GenericPlatform/GenericPlatformMath.h"
 #include "GenericPlatform/GenericPlatformTime.h"
 #include "MessageEndpointBuilder.h"
 #include "MessageEndpoint.h"
+#include "TbSame2Settings.h"
 #include <atomic>
 
 /**
@@ -66,6 +67,10 @@ void UTbSame2SameEnum1InterfaceMsgBusClient::_Connect()
 {
 	if (!_HeartbeatTimerHandle.IsValid() && GetWorld())
 	{
+		UTbSame2Settings* settings = GetMutableDefault<UTbSame2Settings>();
+		check(settings);
+		_HeartbeatIntervalMS = settings->MsgBusHeartbeatIntervalMS;
+
 		GetWorld()->GetTimerManager().SetTimer(_HeartbeatTimerHandle, this, &UTbSame2SameEnum1InterfaceMsgBusClient::_OnHeartbeat, _HeartbeatIntervalMS / 1000.0f, true);
 	}
 

--- a/goldenmaster/Plugins/TbSame2/Source/TbSame2/Private/Generated/MsgBus/TbSame2SameEnum1InterfaceMsgBusClient.cpp
+++ b/goldenmaster/Plugins/TbSame2/Source/TbSame2/Private/Generated/MsgBus/TbSame2SameEnum1InterfaceMsgBusClient.cpp
@@ -24,7 +24,6 @@ limitations under the License.
 #include "Generated/MsgBus/TbSame2SameEnum1InterfaceMsgBusMessages.h"
 #include "Async/Async.h"
 #include "Engine/World.h"
-#include "TimerManager.h"
 #include "Misc/DateTime.h"
 #include "GenericPlatform/GenericPlatformMath.h"
 #include "GenericPlatform/GenericPlatformTime.h"
@@ -65,19 +64,25 @@ void UTbSame2SameEnum1InterfaceMsgBusClient::Deinitialize()
 
 void UTbSame2SameEnum1InterfaceMsgBusClient::_Connect()
 {
-	if (!_HeartbeatTimerHandle.IsValid() && GetWorld())
+	if (_IsConnected())
+	{
+		UE_LOG(LogTbSame2SameEnum1InterfaceMsgBusClient, Log, TEXT("Already connected, cannot connect again."));
+		return;
+	}
+
+	if (!_HeartbeatTickerHandle.IsValid())
 	{
 		UTbSame2Settings* settings = GetMutableDefault<UTbSame2Settings>();
 		check(settings);
 		_HeartbeatIntervalMS = settings->MsgBusHeartbeatIntervalMS;
 
-		GetWorld()->GetTimerManager().SetTimer(_HeartbeatTimerHandle, this, &UTbSame2SameEnum1InterfaceMsgBusClient::_OnHeartbeat, _HeartbeatIntervalMS / 1000.0f, true);
-	}
-
-	if (_IsConnected())
-	{
-		UE_LOG(LogTbSame2SameEnum1InterfaceMsgBusClient, Log, TEXT("Already connected, cannot connect again."));
-		return;
+#if (ENGINE_MAJOR_VERSION < 5)
+		FTicker::GetCoreTicker().RemoveTicker(_HeartbeatTickerHandle);
+		_HeartbeatTickerHandle = FTicker::GetCoreTicker().AddTicker(FTickerDelegate::CreateUObject(this, &UTbSame2SameEnum1InterfaceMsgBusClient::_OnHeartbeatTick), _HeartbeatIntervalMS / 1000.0f);
+#else
+		FTSTicker::GetCoreTicker().RemoveTicker(_HeartbeatTickerHandle);
+		_HeartbeatTickerHandle = FTSTicker::GetCoreTicker().AddTicker(FTickerDelegate::CreateUObject(this, &UTbSame2SameEnum1InterfaceMsgBusClient::_OnHeartbeatTick), _HeartbeatIntervalMS / 1000.0f);
+#endif
 	}
 
 	if (TbSame2SameEnum1InterfaceMsgBusEndpoint.IsValid() && !ServiceAddress.IsValid())
@@ -103,10 +108,12 @@ void UTbSame2SameEnum1InterfaceMsgBusClient::_Connect()
 void UTbSame2SameEnum1InterfaceMsgBusClient::_Disconnect()
 {
 	_LastHbTimestamp = 0.0f;
-	if (_HeartbeatTimerHandle.IsValid() && GetWorld())
-	{
-		GetWorld()->GetTimerManager().ClearTimer(_HeartbeatTimerHandle);
-	}
+
+#if (ENGINE_MAJOR_VERSION < 5)
+	FTicker::GetCoreTicker().RemoveTicker(_HeartbeatTickerHandle);
+#else
+	FTSTicker::GetCoreTicker().RemoveTicker(_HeartbeatTickerHandle);
+#endif
 
 	if (!_IsConnected())
 	{
@@ -167,15 +174,13 @@ void UTbSame2SameEnum1InterfaceMsgBusClient::OnConnectionInit(const FTbSame2Same
 	{
 		_HeartbeatIntervalMS = InMessage._ClientPingIntervalMS;
 
-		if (_HeartbeatTimerHandle.IsValid() && GetWorld())
-		{
-			GetWorld()->GetTimerManager().ClearTimer(_HeartbeatTimerHandle);
-		}
-
-		if (!_HeartbeatTimerHandle.IsValid() && GetWorld())
-		{
-			GetWorld()->GetTimerManager().SetTimer(_HeartbeatTimerHandle, this, &UTbSame2SameEnum1InterfaceMsgBusClient::_OnHeartbeat, _HeartbeatIntervalMS / 1000.0f, true);
-		}
+#if (ENGINE_MAJOR_VERSION < 5)
+		FTicker::GetCoreTicker().RemoveTicker(_HeartbeatTickerHandle);
+		_HeartbeatTickerHandle = FTicker::GetCoreTicker().AddTicker(FTickerDelegate::CreateUObject(this, &UTbSame2SameEnum1InterfaceMsgBusClient::_OnHeartbeatTick), _HeartbeatIntervalMS / 1000.0f);
+#else
+		FTSTicker::GetCoreTicker().RemoveTicker(_HeartbeatTickerHandle);
+		_HeartbeatTickerHandle = FTSTicker::GetCoreTicker().AddTicker(FTickerDelegate::CreateUObject(this, &UTbSame2SameEnum1InterfaceMsgBusClient::_OnHeartbeatTick), _HeartbeatIntervalMS / 1000.0f);
+#endif
 	}
 	const bool bProp1Changed = InMessage.Prop1 != Prop1;
 	if (bProp1Changed)
@@ -185,6 +190,12 @@ void UTbSame2SameEnum1InterfaceMsgBusClient::OnConnectionInit(const FTbSame2Same
 	}
 
 	_ConnectionStatusChanged.Broadcast(true);
+}
+
+bool UTbSame2SameEnum1InterfaceMsgBusClient::_OnHeartbeatTick(float /*DeltaTime*/)
+{
+	_OnHeartbeat();
+	return true;
 }
 
 void UTbSame2SameEnum1InterfaceMsgBusClient::_OnHeartbeat()

--- a/goldenmaster/Plugins/TbSame2/Source/TbSame2/Private/Generated/MsgBus/TbSame2SameEnum2InterfaceMsgBusAdapter.cpp
+++ b/goldenmaster/Plugins/TbSame2/Source/TbSame2/Private/Generated/MsgBus/TbSame2SameEnum2InterfaceMsgBusAdapter.cpp
@@ -25,7 +25,6 @@ limitations under the License.
 #include "Async/Future.h"
 #include "Async/Async.h"
 #include "Engine/World.h"
-#include "TimerManager.h"
 #include "MessageEndpoint.h"
 #include "MessageEndpointBuilder.h"
 #include "Misc/DateTime.h"
@@ -51,13 +50,17 @@ void UTbSame2SameEnum2InterfaceMsgBusAdapter::Deinitialize()
 void UTbSame2SameEnum2InterfaceMsgBusAdapter::_StartListening()
 {
 
-	if (!_HeartbeatTimerHandle.IsValid() && GetWorld())
+	if (!_HeartbeatTickerHandle.IsValid())
 	{
 		UTbSame2Settings* settings = GetMutableDefault<UTbSame2Settings>();
 		check(settings);
 		_HeartbeatIntervalMS = settings->MsgBusHeartbeatIntervalMS;
 
-		GetWorld()->GetTimerManager().SetTimer(_HeartbeatTimerHandle, this, &UTbSame2SameEnum2InterfaceMsgBusAdapter::_CheckClientTimeouts, _HeartbeatIntervalMS / 1000.0f, true);
+#if (ENGINE_MAJOR_VERSION < 5)
+		_HeartbeatTickerHandle = FTicker::GetCoreTicker().AddTicker(FTickerDelegate::CreateUObject(this, &UTbSame2SameEnum2InterfaceMsgBusAdapter::_CheckClientTimeoutsTick), _HeartbeatIntervalMS / 1000.0f);
+#else
+		_HeartbeatTickerHandle = FTSTicker::GetCoreTicker().AddTicker(FTickerDelegate::CreateUObject(this, &UTbSame2SameEnum2InterfaceMsgBusAdapter::_CheckClientTimeoutsTick), _HeartbeatIntervalMS / 1000.0f);
+#endif
 	}
 
 	if (TbSame2SameEnum2InterfaceMsgBusEndpoint.IsValid())
@@ -99,9 +102,13 @@ void UTbSame2SameEnum2InterfaceMsgBusAdapter::_AnnounceService()
 
 void UTbSame2SameEnum2InterfaceMsgBusAdapter::_StopListening()
 {
-	if (_HeartbeatTimerHandle.IsValid() && GetWorld())
+	if (_HeartbeatTickerHandle.IsValid())
 	{
-		GetWorld()->GetTimerManager().ClearTimer(_HeartbeatTimerHandle);
+#if (ENGINE_MAJOR_VERSION < 5)
+		FTicker::GetCoreTicker().RemoveTicker(_HeartbeatTickerHandle);
+#else
+		FTSTicker::GetCoreTicker().RemoveTicker(_HeartbeatTickerHandle);
+#endif
 	}
 
 	auto msg = new FTbSame2SameEnum2InterfaceServiceDisconnectMessage();
@@ -248,6 +255,12 @@ void UTbSame2SameEnum2InterfaceMsgBusAdapter::OnClientDisconnected(const FTbSame
 	ConnectedClientsTimestamps.Remove(Context->GetSender());
 	_OnClientDisconnected.Broadcast(Context->GetSender().ToString());
 	_UpdateClientsConnected();
+}
+
+bool UTbSame2SameEnum2InterfaceMsgBusAdapter::_CheckClientTimeoutsTick(float /*DeltaTime*/)
+{
+	_CheckClientTimeouts();
+	return true;
 }
 
 void UTbSame2SameEnum2InterfaceMsgBusAdapter::_CheckClientTimeouts()

--- a/goldenmaster/Plugins/TbSame2/Source/TbSame2/Private/Generated/MsgBus/TbSame2SameEnum2InterfaceMsgBusAdapter.cpp
+++ b/goldenmaster/Plugins/TbSame2/Source/TbSame2/Private/Generated/MsgBus/TbSame2SameEnum2InterfaceMsgBusAdapter.cpp
@@ -24,12 +24,12 @@ limitations under the License.
 #include "Generated/MsgBus/TbSame2SameEnum2InterfaceMsgBusMessages.h"
 #include "Async/Future.h"
 #include "Async/Async.h"
-#include "Async/Async.h"
-#include "Engine/Engine.h"
+#include "Engine/World.h"
 #include "TimerManager.h"
 #include "MessageEndpoint.h"
 #include "MessageEndpointBuilder.h"
 #include "Misc/DateTime.h"
+#include "TbSame2Settings.h"
 
 DEFINE_LOG_CATEGORY(LogTbSame2SameEnum2InterfaceMsgBusAdapter);
 UTbSame2SameEnum2InterfaceMsgBusAdapter::UTbSame2SameEnum2InterfaceMsgBusAdapter()
@@ -53,6 +53,10 @@ void UTbSame2SameEnum2InterfaceMsgBusAdapter::_StartListening()
 
 	if (!_HeartbeatTimerHandle.IsValid() && GetWorld())
 	{
+		UTbSame2Settings* settings = GetMutableDefault<UTbSame2Settings>();
+		check(settings);
+		_HeartbeatIntervalMS = settings->MsgBusHeartbeatIntervalMS;
+
 		GetWorld()->GetTimerManager().SetTimer(_HeartbeatTimerHandle, this, &UTbSame2SameEnum2InterfaceMsgBusAdapter::_CheckClientTimeouts, _HeartbeatIntervalMS / 1000.0f, true);
 	}
 

--- a/goldenmaster/Plugins/TbSame2/Source/TbSame2/Private/Generated/MsgBus/TbSame2SameEnum2InterfaceMsgBusClient.cpp
+++ b/goldenmaster/Plugins/TbSame2/Source/TbSame2/Private/Generated/MsgBus/TbSame2SameEnum2InterfaceMsgBusClient.cpp
@@ -24,7 +24,6 @@ limitations under the License.
 #include "Generated/MsgBus/TbSame2SameEnum2InterfaceMsgBusMessages.h"
 #include "Async/Async.h"
 #include "Engine/World.h"
-#include "TimerManager.h"
 #include "Misc/DateTime.h"
 #include "GenericPlatform/GenericPlatformMath.h"
 #include "GenericPlatform/GenericPlatformTime.h"
@@ -66,19 +65,25 @@ void UTbSame2SameEnum2InterfaceMsgBusClient::Deinitialize()
 
 void UTbSame2SameEnum2InterfaceMsgBusClient::_Connect()
 {
-	if (!_HeartbeatTimerHandle.IsValid() && GetWorld())
+	if (_IsConnected())
+	{
+		UE_LOG(LogTbSame2SameEnum2InterfaceMsgBusClient, Log, TEXT("Already connected, cannot connect again."));
+		return;
+	}
+
+	if (!_HeartbeatTickerHandle.IsValid())
 	{
 		UTbSame2Settings* settings = GetMutableDefault<UTbSame2Settings>();
 		check(settings);
 		_HeartbeatIntervalMS = settings->MsgBusHeartbeatIntervalMS;
 
-		GetWorld()->GetTimerManager().SetTimer(_HeartbeatTimerHandle, this, &UTbSame2SameEnum2InterfaceMsgBusClient::_OnHeartbeat, _HeartbeatIntervalMS / 1000.0f, true);
-	}
-
-	if (_IsConnected())
-	{
-		UE_LOG(LogTbSame2SameEnum2InterfaceMsgBusClient, Log, TEXT("Already connected, cannot connect again."));
-		return;
+#if (ENGINE_MAJOR_VERSION < 5)
+		FTicker::GetCoreTicker().RemoveTicker(_HeartbeatTickerHandle);
+		_HeartbeatTickerHandle = FTicker::GetCoreTicker().AddTicker(FTickerDelegate::CreateUObject(this, &UTbSame2SameEnum2InterfaceMsgBusClient::_OnHeartbeatTick), _HeartbeatIntervalMS / 1000.0f);
+#else
+		FTSTicker::GetCoreTicker().RemoveTicker(_HeartbeatTickerHandle);
+		_HeartbeatTickerHandle = FTSTicker::GetCoreTicker().AddTicker(FTickerDelegate::CreateUObject(this, &UTbSame2SameEnum2InterfaceMsgBusClient::_OnHeartbeatTick), _HeartbeatIntervalMS / 1000.0f);
+#endif
 	}
 
 	if (TbSame2SameEnum2InterfaceMsgBusEndpoint.IsValid() && !ServiceAddress.IsValid())
@@ -107,10 +112,12 @@ void UTbSame2SameEnum2InterfaceMsgBusClient::_Connect()
 void UTbSame2SameEnum2InterfaceMsgBusClient::_Disconnect()
 {
 	_LastHbTimestamp = 0.0f;
-	if (_HeartbeatTimerHandle.IsValid() && GetWorld())
-	{
-		GetWorld()->GetTimerManager().ClearTimer(_HeartbeatTimerHandle);
-	}
+
+#if (ENGINE_MAJOR_VERSION < 5)
+	FTicker::GetCoreTicker().RemoveTicker(_HeartbeatTickerHandle);
+#else
+	FTSTicker::GetCoreTicker().RemoveTicker(_HeartbeatTickerHandle);
+#endif
 
 	if (!_IsConnected())
 	{
@@ -171,15 +178,13 @@ void UTbSame2SameEnum2InterfaceMsgBusClient::OnConnectionInit(const FTbSame2Same
 	{
 		_HeartbeatIntervalMS = InMessage._ClientPingIntervalMS;
 
-		if (_HeartbeatTimerHandle.IsValid() && GetWorld())
-		{
-			GetWorld()->GetTimerManager().ClearTimer(_HeartbeatTimerHandle);
-		}
-
-		if (!_HeartbeatTimerHandle.IsValid() && GetWorld())
-		{
-			GetWorld()->GetTimerManager().SetTimer(_HeartbeatTimerHandle, this, &UTbSame2SameEnum2InterfaceMsgBusClient::_OnHeartbeat, _HeartbeatIntervalMS / 1000.0f, true);
-		}
+#if (ENGINE_MAJOR_VERSION < 5)
+		FTicker::GetCoreTicker().RemoveTicker(_HeartbeatTickerHandle);
+		_HeartbeatTickerHandle = FTicker::GetCoreTicker().AddTicker(FTickerDelegate::CreateUObject(this, &UTbSame2SameEnum2InterfaceMsgBusClient::_OnHeartbeatTick), _HeartbeatIntervalMS / 1000.0f);
+#else
+		FTSTicker::GetCoreTicker().RemoveTicker(_HeartbeatTickerHandle);
+		_HeartbeatTickerHandle = FTSTicker::GetCoreTicker().AddTicker(FTickerDelegate::CreateUObject(this, &UTbSame2SameEnum2InterfaceMsgBusClient::_OnHeartbeatTick), _HeartbeatIntervalMS / 1000.0f);
+#endif
 	}
 	const bool bProp1Changed = InMessage.Prop1 != Prop1;
 	if (bProp1Changed)
@@ -196,6 +201,12 @@ void UTbSame2SameEnum2InterfaceMsgBusClient::OnConnectionInit(const FTbSame2Same
 	}
 
 	_ConnectionStatusChanged.Broadcast(true);
+}
+
+bool UTbSame2SameEnum2InterfaceMsgBusClient::_OnHeartbeatTick(float /*DeltaTime*/)
+{
+	_OnHeartbeat();
+	return true;
 }
 
 void UTbSame2SameEnum2InterfaceMsgBusClient::_OnHeartbeat()

--- a/goldenmaster/Plugins/TbSame2/Source/TbSame2/Private/Generated/MsgBus/TbSame2SameEnum2InterfaceMsgBusClient.cpp
+++ b/goldenmaster/Plugins/TbSame2/Source/TbSame2/Private/Generated/MsgBus/TbSame2SameEnum2InterfaceMsgBusClient.cpp
@@ -23,13 +23,14 @@ limitations under the License.
 #include "Generated/MsgBus/TbSame2SameEnum2InterfaceMsgBusClient.h"
 #include "Generated/MsgBus/TbSame2SameEnum2InterfaceMsgBusMessages.h"
 #include "Async/Async.h"
-#include "Engine/Engine.h"
+#include "Engine/World.h"
 #include "TimerManager.h"
 #include "Misc/DateTime.h"
 #include "GenericPlatform/GenericPlatformMath.h"
 #include "GenericPlatform/GenericPlatformTime.h"
 #include "MessageEndpointBuilder.h"
 #include "MessageEndpoint.h"
+#include "TbSame2Settings.h"
 #include <atomic>
 
 /**
@@ -67,6 +68,10 @@ void UTbSame2SameEnum2InterfaceMsgBusClient::_Connect()
 {
 	if (!_HeartbeatTimerHandle.IsValid() && GetWorld())
 	{
+		UTbSame2Settings* settings = GetMutableDefault<UTbSame2Settings>();
+		check(settings);
+		_HeartbeatIntervalMS = settings->MsgBusHeartbeatIntervalMS;
+
 		GetWorld()->GetTimerManager().SetTimer(_HeartbeatTimerHandle, this, &UTbSame2SameEnum2InterfaceMsgBusClient::_OnHeartbeat, _HeartbeatIntervalMS / 1000.0f, true);
 	}
 

--- a/goldenmaster/Plugins/TbSame2/Source/TbSame2/Private/Generated/MsgBus/TbSame2SameStruct1InterfaceMsgBusAdapter.cpp
+++ b/goldenmaster/Plugins/TbSame2/Source/TbSame2/Private/Generated/MsgBus/TbSame2SameStruct1InterfaceMsgBusAdapter.cpp
@@ -25,7 +25,6 @@ limitations under the License.
 #include "Async/Future.h"
 #include "Async/Async.h"
 #include "Engine/World.h"
-#include "TimerManager.h"
 #include "MessageEndpoint.h"
 #include "MessageEndpointBuilder.h"
 #include "Misc/DateTime.h"
@@ -51,13 +50,17 @@ void UTbSame2SameStruct1InterfaceMsgBusAdapter::Deinitialize()
 void UTbSame2SameStruct1InterfaceMsgBusAdapter::_StartListening()
 {
 
-	if (!_HeartbeatTimerHandle.IsValid() && GetWorld())
+	if (!_HeartbeatTickerHandle.IsValid())
 	{
 		UTbSame2Settings* settings = GetMutableDefault<UTbSame2Settings>();
 		check(settings);
 		_HeartbeatIntervalMS = settings->MsgBusHeartbeatIntervalMS;
 
-		GetWorld()->GetTimerManager().SetTimer(_HeartbeatTimerHandle, this, &UTbSame2SameStruct1InterfaceMsgBusAdapter::_CheckClientTimeouts, _HeartbeatIntervalMS / 1000.0f, true);
+#if (ENGINE_MAJOR_VERSION < 5)
+		_HeartbeatTickerHandle = FTicker::GetCoreTicker().AddTicker(FTickerDelegate::CreateUObject(this, &UTbSame2SameStruct1InterfaceMsgBusAdapter::_CheckClientTimeoutsTick), _HeartbeatIntervalMS / 1000.0f);
+#else
+		_HeartbeatTickerHandle = FTSTicker::GetCoreTicker().AddTicker(FTickerDelegate::CreateUObject(this, &UTbSame2SameStruct1InterfaceMsgBusAdapter::_CheckClientTimeoutsTick), _HeartbeatIntervalMS / 1000.0f);
+#endif
 	}
 
 	if (TbSame2SameStruct1InterfaceMsgBusEndpoint.IsValid())
@@ -97,9 +100,13 @@ void UTbSame2SameStruct1InterfaceMsgBusAdapter::_AnnounceService()
 
 void UTbSame2SameStruct1InterfaceMsgBusAdapter::_StopListening()
 {
-	if (_HeartbeatTimerHandle.IsValid() && GetWorld())
+	if (_HeartbeatTickerHandle.IsValid())
 	{
-		GetWorld()->GetTimerManager().ClearTimer(_HeartbeatTimerHandle);
+#if (ENGINE_MAJOR_VERSION < 5)
+		FTicker::GetCoreTicker().RemoveTicker(_HeartbeatTickerHandle);
+#else
+		FTSTicker::GetCoreTicker().RemoveTicker(_HeartbeatTickerHandle);
+#endif
 	}
 
 	auto msg = new FTbSame2SameStruct1InterfaceServiceDisconnectMessage();
@@ -241,6 +248,12 @@ void UTbSame2SameStruct1InterfaceMsgBusAdapter::OnClientDisconnected(const FTbSa
 	ConnectedClientsTimestamps.Remove(Context->GetSender());
 	_OnClientDisconnected.Broadcast(Context->GetSender().ToString());
 	_UpdateClientsConnected();
+}
+
+bool UTbSame2SameStruct1InterfaceMsgBusAdapter::_CheckClientTimeoutsTick(float /*DeltaTime*/)
+{
+	_CheckClientTimeouts();
+	return true;
 }
 
 void UTbSame2SameStruct1InterfaceMsgBusAdapter::_CheckClientTimeouts()

--- a/goldenmaster/Plugins/TbSame2/Source/TbSame2/Private/Generated/MsgBus/TbSame2SameStruct1InterfaceMsgBusAdapter.cpp
+++ b/goldenmaster/Plugins/TbSame2/Source/TbSame2/Private/Generated/MsgBus/TbSame2SameStruct1InterfaceMsgBusAdapter.cpp
@@ -24,12 +24,12 @@ limitations under the License.
 #include "Generated/MsgBus/TbSame2SameStruct1InterfaceMsgBusMessages.h"
 #include "Async/Future.h"
 #include "Async/Async.h"
-#include "Async/Async.h"
-#include "Engine/Engine.h"
+#include "Engine/World.h"
 #include "TimerManager.h"
 #include "MessageEndpoint.h"
 #include "MessageEndpointBuilder.h"
 #include "Misc/DateTime.h"
+#include "TbSame2Settings.h"
 
 DEFINE_LOG_CATEGORY(LogTbSame2SameStruct1InterfaceMsgBusAdapter);
 UTbSame2SameStruct1InterfaceMsgBusAdapter::UTbSame2SameStruct1InterfaceMsgBusAdapter()
@@ -53,6 +53,10 @@ void UTbSame2SameStruct1InterfaceMsgBusAdapter::_StartListening()
 
 	if (!_HeartbeatTimerHandle.IsValid() && GetWorld())
 	{
+		UTbSame2Settings* settings = GetMutableDefault<UTbSame2Settings>();
+		check(settings);
+		_HeartbeatIntervalMS = settings->MsgBusHeartbeatIntervalMS;
+
 		GetWorld()->GetTimerManager().SetTimer(_HeartbeatTimerHandle, this, &UTbSame2SameStruct1InterfaceMsgBusAdapter::_CheckClientTimeouts, _HeartbeatIntervalMS / 1000.0f, true);
 	}
 

--- a/goldenmaster/Plugins/TbSame2/Source/TbSame2/Private/Generated/MsgBus/TbSame2SameStruct1InterfaceMsgBusClient.cpp
+++ b/goldenmaster/Plugins/TbSame2/Source/TbSame2/Private/Generated/MsgBus/TbSame2SameStruct1InterfaceMsgBusClient.cpp
@@ -23,13 +23,14 @@ limitations under the License.
 #include "Generated/MsgBus/TbSame2SameStruct1InterfaceMsgBusClient.h"
 #include "Generated/MsgBus/TbSame2SameStruct1InterfaceMsgBusMessages.h"
 #include "Async/Async.h"
-#include "Engine/Engine.h"
+#include "Engine/World.h"
 #include "TimerManager.h"
 #include "Misc/DateTime.h"
 #include "GenericPlatform/GenericPlatformMath.h"
 #include "GenericPlatform/GenericPlatformTime.h"
 #include "MessageEndpointBuilder.h"
 #include "MessageEndpoint.h"
+#include "TbSame2Settings.h"
 #include "HAL/CriticalSection.h"
 
 /**
@@ -67,6 +68,10 @@ void UTbSame2SameStruct1InterfaceMsgBusClient::_Connect()
 {
 	if (!_HeartbeatTimerHandle.IsValid() && GetWorld())
 	{
+		UTbSame2Settings* settings = GetMutableDefault<UTbSame2Settings>();
+		check(settings);
+		_HeartbeatIntervalMS = settings->MsgBusHeartbeatIntervalMS;
+
 		GetWorld()->GetTimerManager().SetTimer(_HeartbeatTimerHandle, this, &UTbSame2SameStruct1InterfaceMsgBusClient::_OnHeartbeat, _HeartbeatIntervalMS / 1000.0f, true);
 	}
 

--- a/goldenmaster/Plugins/TbSame2/Source/TbSame2/Private/Generated/MsgBus/TbSame2SameStruct1InterfaceMsgBusClient.cpp
+++ b/goldenmaster/Plugins/TbSame2/Source/TbSame2/Private/Generated/MsgBus/TbSame2SameStruct1InterfaceMsgBusClient.cpp
@@ -24,7 +24,6 @@ limitations under the License.
 #include "Generated/MsgBus/TbSame2SameStruct1InterfaceMsgBusMessages.h"
 #include "Async/Async.h"
 #include "Engine/World.h"
-#include "TimerManager.h"
 #include "Misc/DateTime.h"
 #include "GenericPlatform/GenericPlatformMath.h"
 #include "GenericPlatform/GenericPlatformTime.h"
@@ -66,19 +65,25 @@ void UTbSame2SameStruct1InterfaceMsgBusClient::Deinitialize()
 
 void UTbSame2SameStruct1InterfaceMsgBusClient::_Connect()
 {
-	if (!_HeartbeatTimerHandle.IsValid() && GetWorld())
+	if (_IsConnected())
+	{
+		UE_LOG(LogTbSame2SameStruct1InterfaceMsgBusClient, Log, TEXT("Already connected, cannot connect again."));
+		return;
+	}
+
+	if (!_HeartbeatTickerHandle.IsValid())
 	{
 		UTbSame2Settings* settings = GetMutableDefault<UTbSame2Settings>();
 		check(settings);
 		_HeartbeatIntervalMS = settings->MsgBusHeartbeatIntervalMS;
 
-		GetWorld()->GetTimerManager().SetTimer(_HeartbeatTimerHandle, this, &UTbSame2SameStruct1InterfaceMsgBusClient::_OnHeartbeat, _HeartbeatIntervalMS / 1000.0f, true);
-	}
-
-	if (_IsConnected())
-	{
-		UE_LOG(LogTbSame2SameStruct1InterfaceMsgBusClient, Log, TEXT("Already connected, cannot connect again."));
-		return;
+#if (ENGINE_MAJOR_VERSION < 5)
+		FTicker::GetCoreTicker().RemoveTicker(_HeartbeatTickerHandle);
+		_HeartbeatTickerHandle = FTicker::GetCoreTicker().AddTicker(FTickerDelegate::CreateUObject(this, &UTbSame2SameStruct1InterfaceMsgBusClient::_OnHeartbeatTick), _HeartbeatIntervalMS / 1000.0f);
+#else
+		FTSTicker::GetCoreTicker().RemoveTicker(_HeartbeatTickerHandle);
+		_HeartbeatTickerHandle = FTSTicker::GetCoreTicker().AddTicker(FTickerDelegate::CreateUObject(this, &UTbSame2SameStruct1InterfaceMsgBusClient::_OnHeartbeatTick), _HeartbeatIntervalMS / 1000.0f);
+#endif
 	}
 
 	if (TbSame2SameStruct1InterfaceMsgBusEndpoint.IsValid() && !ServiceAddress.IsValid())
@@ -104,10 +109,12 @@ void UTbSame2SameStruct1InterfaceMsgBusClient::_Connect()
 void UTbSame2SameStruct1InterfaceMsgBusClient::_Disconnect()
 {
 	_LastHbTimestamp = 0.0f;
-	if (_HeartbeatTimerHandle.IsValid() && GetWorld())
-	{
-		GetWorld()->GetTimerManager().ClearTimer(_HeartbeatTimerHandle);
-	}
+
+#if (ENGINE_MAJOR_VERSION < 5)
+	FTicker::GetCoreTicker().RemoveTicker(_HeartbeatTickerHandle);
+#else
+	FTSTicker::GetCoreTicker().RemoveTicker(_HeartbeatTickerHandle);
+#endif
 
 	if (!_IsConnected())
 	{
@@ -168,15 +175,13 @@ void UTbSame2SameStruct1InterfaceMsgBusClient::OnConnectionInit(const FTbSame2Sa
 	{
 		_HeartbeatIntervalMS = InMessage._ClientPingIntervalMS;
 
-		if (_HeartbeatTimerHandle.IsValid() && GetWorld())
-		{
-			GetWorld()->GetTimerManager().ClearTimer(_HeartbeatTimerHandle);
-		}
-
-		if (!_HeartbeatTimerHandle.IsValid() && GetWorld())
-		{
-			GetWorld()->GetTimerManager().SetTimer(_HeartbeatTimerHandle, this, &UTbSame2SameStruct1InterfaceMsgBusClient::_OnHeartbeat, _HeartbeatIntervalMS / 1000.0f, true);
-		}
+#if (ENGINE_MAJOR_VERSION < 5)
+		FTicker::GetCoreTicker().RemoveTicker(_HeartbeatTickerHandle);
+		_HeartbeatTickerHandle = FTicker::GetCoreTicker().AddTicker(FTickerDelegate::CreateUObject(this, &UTbSame2SameStruct1InterfaceMsgBusClient::_OnHeartbeatTick), _HeartbeatIntervalMS / 1000.0f);
+#else
+		FTSTicker::GetCoreTicker().RemoveTicker(_HeartbeatTickerHandle);
+		_HeartbeatTickerHandle = FTSTicker::GetCoreTicker().AddTicker(FTickerDelegate::CreateUObject(this, &UTbSame2SameStruct1InterfaceMsgBusClient::_OnHeartbeatTick), _HeartbeatIntervalMS / 1000.0f);
+#endif
 	}
 	const bool bProp1Changed = InMessage.Prop1 != Prop1;
 	if (bProp1Changed)
@@ -186,6 +191,12 @@ void UTbSame2SameStruct1InterfaceMsgBusClient::OnConnectionInit(const FTbSame2Sa
 	}
 
 	_ConnectionStatusChanged.Broadcast(true);
+}
+
+bool UTbSame2SameStruct1InterfaceMsgBusClient::_OnHeartbeatTick(float /*DeltaTime*/)
+{
+	_OnHeartbeat();
+	return true;
 }
 
 void UTbSame2SameStruct1InterfaceMsgBusClient::_OnHeartbeat()

--- a/goldenmaster/Plugins/TbSame2/Source/TbSame2/Private/Generated/MsgBus/TbSame2SameStruct2InterfaceMsgBusAdapter.cpp
+++ b/goldenmaster/Plugins/TbSame2/Source/TbSame2/Private/Generated/MsgBus/TbSame2SameStruct2InterfaceMsgBusAdapter.cpp
@@ -25,7 +25,6 @@ limitations under the License.
 #include "Async/Future.h"
 #include "Async/Async.h"
 #include "Engine/World.h"
-#include "TimerManager.h"
 #include "MessageEndpoint.h"
 #include "MessageEndpointBuilder.h"
 #include "Misc/DateTime.h"
@@ -51,13 +50,17 @@ void UTbSame2SameStruct2InterfaceMsgBusAdapter::Deinitialize()
 void UTbSame2SameStruct2InterfaceMsgBusAdapter::_StartListening()
 {
 
-	if (!_HeartbeatTimerHandle.IsValid() && GetWorld())
+	if (!_HeartbeatTickerHandle.IsValid())
 	{
 		UTbSame2Settings* settings = GetMutableDefault<UTbSame2Settings>();
 		check(settings);
 		_HeartbeatIntervalMS = settings->MsgBusHeartbeatIntervalMS;
 
-		GetWorld()->GetTimerManager().SetTimer(_HeartbeatTimerHandle, this, &UTbSame2SameStruct2InterfaceMsgBusAdapter::_CheckClientTimeouts, _HeartbeatIntervalMS / 1000.0f, true);
+#if (ENGINE_MAJOR_VERSION < 5)
+		_HeartbeatTickerHandle = FTicker::GetCoreTicker().AddTicker(FTickerDelegate::CreateUObject(this, &UTbSame2SameStruct2InterfaceMsgBusAdapter::_CheckClientTimeoutsTick), _HeartbeatIntervalMS / 1000.0f);
+#else
+		_HeartbeatTickerHandle = FTSTicker::GetCoreTicker().AddTicker(FTickerDelegate::CreateUObject(this, &UTbSame2SameStruct2InterfaceMsgBusAdapter::_CheckClientTimeoutsTick), _HeartbeatIntervalMS / 1000.0f);
+#endif
 	}
 
 	if (TbSame2SameStruct2InterfaceMsgBusEndpoint.IsValid())
@@ -99,9 +102,13 @@ void UTbSame2SameStruct2InterfaceMsgBusAdapter::_AnnounceService()
 
 void UTbSame2SameStruct2InterfaceMsgBusAdapter::_StopListening()
 {
-	if (_HeartbeatTimerHandle.IsValid() && GetWorld())
+	if (_HeartbeatTickerHandle.IsValid())
 	{
-		GetWorld()->GetTimerManager().ClearTimer(_HeartbeatTimerHandle);
+#if (ENGINE_MAJOR_VERSION < 5)
+		FTicker::GetCoreTicker().RemoveTicker(_HeartbeatTickerHandle);
+#else
+		FTSTicker::GetCoreTicker().RemoveTicker(_HeartbeatTickerHandle);
+#endif
 	}
 
 	auto msg = new FTbSame2SameStruct2InterfaceServiceDisconnectMessage();
@@ -248,6 +255,12 @@ void UTbSame2SameStruct2InterfaceMsgBusAdapter::OnClientDisconnected(const FTbSa
 	ConnectedClientsTimestamps.Remove(Context->GetSender());
 	_OnClientDisconnected.Broadcast(Context->GetSender().ToString());
 	_UpdateClientsConnected();
+}
+
+bool UTbSame2SameStruct2InterfaceMsgBusAdapter::_CheckClientTimeoutsTick(float /*DeltaTime*/)
+{
+	_CheckClientTimeouts();
+	return true;
 }
 
 void UTbSame2SameStruct2InterfaceMsgBusAdapter::_CheckClientTimeouts()

--- a/goldenmaster/Plugins/TbSame2/Source/TbSame2/Private/Generated/MsgBus/TbSame2SameStruct2InterfaceMsgBusAdapter.cpp
+++ b/goldenmaster/Plugins/TbSame2/Source/TbSame2/Private/Generated/MsgBus/TbSame2SameStruct2InterfaceMsgBusAdapter.cpp
@@ -24,12 +24,12 @@ limitations under the License.
 #include "Generated/MsgBus/TbSame2SameStruct2InterfaceMsgBusMessages.h"
 #include "Async/Future.h"
 #include "Async/Async.h"
-#include "Async/Async.h"
-#include "Engine/Engine.h"
+#include "Engine/World.h"
 #include "TimerManager.h"
 #include "MessageEndpoint.h"
 #include "MessageEndpointBuilder.h"
 #include "Misc/DateTime.h"
+#include "TbSame2Settings.h"
 
 DEFINE_LOG_CATEGORY(LogTbSame2SameStruct2InterfaceMsgBusAdapter);
 UTbSame2SameStruct2InterfaceMsgBusAdapter::UTbSame2SameStruct2InterfaceMsgBusAdapter()
@@ -53,6 +53,10 @@ void UTbSame2SameStruct2InterfaceMsgBusAdapter::_StartListening()
 
 	if (!_HeartbeatTimerHandle.IsValid() && GetWorld())
 	{
+		UTbSame2Settings* settings = GetMutableDefault<UTbSame2Settings>();
+		check(settings);
+		_HeartbeatIntervalMS = settings->MsgBusHeartbeatIntervalMS;
+
 		GetWorld()->GetTimerManager().SetTimer(_HeartbeatTimerHandle, this, &UTbSame2SameStruct2InterfaceMsgBusAdapter::_CheckClientTimeouts, _HeartbeatIntervalMS / 1000.0f, true);
 	}
 

--- a/goldenmaster/Plugins/TbSame2/Source/TbSame2/Private/Generated/MsgBus/TbSame2SameStruct2InterfaceMsgBusClient.cpp
+++ b/goldenmaster/Plugins/TbSame2/Source/TbSame2/Private/Generated/MsgBus/TbSame2SameStruct2InterfaceMsgBusClient.cpp
@@ -24,7 +24,6 @@ limitations under the License.
 #include "Generated/MsgBus/TbSame2SameStruct2InterfaceMsgBusMessages.h"
 #include "Async/Async.h"
 #include "Engine/World.h"
-#include "TimerManager.h"
 #include "Misc/DateTime.h"
 #include "GenericPlatform/GenericPlatformMath.h"
 #include "GenericPlatform/GenericPlatformTime.h"
@@ -68,19 +67,25 @@ void UTbSame2SameStruct2InterfaceMsgBusClient::Deinitialize()
 
 void UTbSame2SameStruct2InterfaceMsgBusClient::_Connect()
 {
-	if (!_HeartbeatTimerHandle.IsValid() && GetWorld())
+	if (_IsConnected())
+	{
+		UE_LOG(LogTbSame2SameStruct2InterfaceMsgBusClient, Log, TEXT("Already connected, cannot connect again."));
+		return;
+	}
+
+	if (!_HeartbeatTickerHandle.IsValid())
 	{
 		UTbSame2Settings* settings = GetMutableDefault<UTbSame2Settings>();
 		check(settings);
 		_HeartbeatIntervalMS = settings->MsgBusHeartbeatIntervalMS;
 
-		GetWorld()->GetTimerManager().SetTimer(_HeartbeatTimerHandle, this, &UTbSame2SameStruct2InterfaceMsgBusClient::_OnHeartbeat, _HeartbeatIntervalMS / 1000.0f, true);
-	}
-
-	if (_IsConnected())
-	{
-		UE_LOG(LogTbSame2SameStruct2InterfaceMsgBusClient, Log, TEXT("Already connected, cannot connect again."));
-		return;
+#if (ENGINE_MAJOR_VERSION < 5)
+		FTicker::GetCoreTicker().RemoveTicker(_HeartbeatTickerHandle);
+		_HeartbeatTickerHandle = FTicker::GetCoreTicker().AddTicker(FTickerDelegate::CreateUObject(this, &UTbSame2SameStruct2InterfaceMsgBusClient::_OnHeartbeatTick), _HeartbeatIntervalMS / 1000.0f);
+#else
+		FTSTicker::GetCoreTicker().RemoveTicker(_HeartbeatTickerHandle);
+		_HeartbeatTickerHandle = FTSTicker::GetCoreTicker().AddTicker(FTickerDelegate::CreateUObject(this, &UTbSame2SameStruct2InterfaceMsgBusClient::_OnHeartbeatTick), _HeartbeatIntervalMS / 1000.0f);
+#endif
 	}
 
 	if (TbSame2SameStruct2InterfaceMsgBusEndpoint.IsValid() && !ServiceAddress.IsValid())
@@ -109,10 +114,12 @@ void UTbSame2SameStruct2InterfaceMsgBusClient::_Connect()
 void UTbSame2SameStruct2InterfaceMsgBusClient::_Disconnect()
 {
 	_LastHbTimestamp = 0.0f;
-	if (_HeartbeatTimerHandle.IsValid() && GetWorld())
-	{
-		GetWorld()->GetTimerManager().ClearTimer(_HeartbeatTimerHandle);
-	}
+
+#if (ENGINE_MAJOR_VERSION < 5)
+	FTicker::GetCoreTicker().RemoveTicker(_HeartbeatTickerHandle);
+#else
+	FTSTicker::GetCoreTicker().RemoveTicker(_HeartbeatTickerHandle);
+#endif
 
 	if (!_IsConnected())
 	{
@@ -173,15 +180,13 @@ void UTbSame2SameStruct2InterfaceMsgBusClient::OnConnectionInit(const FTbSame2Sa
 	{
 		_HeartbeatIntervalMS = InMessage._ClientPingIntervalMS;
 
-		if (_HeartbeatTimerHandle.IsValid() && GetWorld())
-		{
-			GetWorld()->GetTimerManager().ClearTimer(_HeartbeatTimerHandle);
-		}
-
-		if (!_HeartbeatTimerHandle.IsValid() && GetWorld())
-		{
-			GetWorld()->GetTimerManager().SetTimer(_HeartbeatTimerHandle, this, &UTbSame2SameStruct2InterfaceMsgBusClient::_OnHeartbeat, _HeartbeatIntervalMS / 1000.0f, true);
-		}
+#if (ENGINE_MAJOR_VERSION < 5)
+		FTicker::GetCoreTicker().RemoveTicker(_HeartbeatTickerHandle);
+		_HeartbeatTickerHandle = FTicker::GetCoreTicker().AddTicker(FTickerDelegate::CreateUObject(this, &UTbSame2SameStruct2InterfaceMsgBusClient::_OnHeartbeatTick), _HeartbeatIntervalMS / 1000.0f);
+#else
+		FTSTicker::GetCoreTicker().RemoveTicker(_HeartbeatTickerHandle);
+		_HeartbeatTickerHandle = FTSTicker::GetCoreTicker().AddTicker(FTickerDelegate::CreateUObject(this, &UTbSame2SameStruct2InterfaceMsgBusClient::_OnHeartbeatTick), _HeartbeatIntervalMS / 1000.0f);
+#endif
 	}
 	const bool bProp1Changed = InMessage.Prop1 != Prop1;
 	if (bProp1Changed)
@@ -198,6 +203,12 @@ void UTbSame2SameStruct2InterfaceMsgBusClient::OnConnectionInit(const FTbSame2Sa
 	}
 
 	_ConnectionStatusChanged.Broadcast(true);
+}
+
+bool UTbSame2SameStruct2InterfaceMsgBusClient::_OnHeartbeatTick(float /*DeltaTime*/)
+{
+	_OnHeartbeat();
+	return true;
 }
 
 void UTbSame2SameStruct2InterfaceMsgBusClient::_OnHeartbeat()

--- a/goldenmaster/Plugins/TbSame2/Source/TbSame2/Private/Generated/MsgBus/TbSame2SameStruct2InterfaceMsgBusClient.cpp
+++ b/goldenmaster/Plugins/TbSame2/Source/TbSame2/Private/Generated/MsgBus/TbSame2SameStruct2InterfaceMsgBusClient.cpp
@@ -23,13 +23,14 @@ limitations under the License.
 #include "Generated/MsgBus/TbSame2SameStruct2InterfaceMsgBusClient.h"
 #include "Generated/MsgBus/TbSame2SameStruct2InterfaceMsgBusMessages.h"
 #include "Async/Async.h"
-#include "Engine/Engine.h"
+#include "Engine/World.h"
 #include "TimerManager.h"
 #include "Misc/DateTime.h"
 #include "GenericPlatform/GenericPlatformMath.h"
 #include "GenericPlatform/GenericPlatformTime.h"
 #include "MessageEndpointBuilder.h"
 #include "MessageEndpoint.h"
+#include "TbSame2Settings.h"
 #include "HAL/CriticalSection.h"
 
 /**
@@ -69,6 +70,10 @@ void UTbSame2SameStruct2InterfaceMsgBusClient::_Connect()
 {
 	if (!_HeartbeatTimerHandle.IsValid() && GetWorld())
 	{
+		UTbSame2Settings* settings = GetMutableDefault<UTbSame2Settings>();
+		check(settings);
+		_HeartbeatIntervalMS = settings->MsgBusHeartbeatIntervalMS;
+
 		GetWorld()->GetTimerManager().SetTimer(_HeartbeatTimerHandle, this, &UTbSame2SameStruct2InterfaceMsgBusClient::_OnHeartbeat, _HeartbeatIntervalMS / 1000.0f, true);
 	}
 

--- a/goldenmaster/Plugins/TbSame2/Source/TbSame2/Public/Generated/MsgBus/TbSame2SameEnum1InterfaceMsgBusAdapter.h
+++ b/goldenmaster/Plugins/TbSame2/Source/TbSame2/Public/Generated/MsgBus/TbSame2SameEnum1InterfaceMsgBusAdapter.h
@@ -21,11 +21,7 @@ limitations under the License.
 #include "IMessageContext.h"
 #include "Templates/SharedPointer.h"
 #include "Runtime/Launch/Resources/Version.h"
-#if (ENGINE_MAJOR_VERSION < 5)
-#include "Engine/EngineTypes.h"
-#else
-#include "Engine/TimerHandle.h"
-#endif
+#include "Containers/Ticker.h"
 #include "TbSame2SameEnum1InterfaceMsgBusAdapter.generated.h"
 
 class FMessageEndpoint;
@@ -118,9 +114,14 @@ private:
 
 	// Heartbeat handling
 	void _CheckClientTimeouts();
+	bool _CheckClientTimeoutsTick(float DeltaTime);
 	void _UpdateClientsConnected();
 	TMap<FMessageAddress, double> ConnectedClientsTimestamps;
-	FTimerHandle _HeartbeatTimerHandle;
+#if (ENGINE_MAJOR_VERSION < 5)
+	::FDelegateHandle _HeartbeatTickerHandle;
+#else
+	FTSTicker::FDelegateHandle _HeartbeatTickerHandle;
+#endif
 	int32 _ClientsConnected = 0;
 	uint32 _HeartbeatIntervalMS = 100;
 };

--- a/goldenmaster/Plugins/TbSame2/Source/TbSame2/Public/Generated/MsgBus/TbSame2SameEnum1InterfaceMsgBusClient.h
+++ b/goldenmaster/Plugins/TbSame2/Source/TbSame2/Public/Generated/MsgBus/TbSame2SameEnum1InterfaceMsgBusClient.h
@@ -22,11 +22,7 @@ limitations under the License.
 #include "HAL/CriticalSection.h"
 #include "Async/Future.h"
 #include "Runtime/Launch/Resources/Version.h"
-#if (ENGINE_MAJOR_VERSION < 5)
-#include "Engine/EngineTypes.h"
-#else
-#include "Engine/TimerHandle.h"
-#endif
+#include "Containers/Ticker.h"
 #include "Templates/PimplPtr.h"
 #include "IMessageContext.h"
 #include "TbSame2SameEnum1InterfaceMsgBusClient.generated.h"
@@ -119,8 +115,13 @@ private:
 	size_t CurrentPingCounter = 0;
 	float _CalculateAverageRTT() const;
 	FTbSame2SameEnum1InterfaceStats Stats;
-	FTimerHandle _HeartbeatTimerHandle;
+#if (ENGINE_MAJOR_VERSION < 5)
+	::FDelegateHandle _HeartbeatTickerHandle;
+#else
+	FTSTicker::FDelegateHandle _HeartbeatTickerHandle;
+#endif
 	void _OnHeartbeat();
+	bool _OnHeartbeatTick(float DeltaTime);
 	uint32 _HeartbeatIntervalMS = 100;
 
 	// connection handling

--- a/goldenmaster/Plugins/TbSame2/Source/TbSame2/Public/Generated/MsgBus/TbSame2SameEnum2InterfaceMsgBusAdapter.h
+++ b/goldenmaster/Plugins/TbSame2/Source/TbSame2/Public/Generated/MsgBus/TbSame2SameEnum2InterfaceMsgBusAdapter.h
@@ -21,11 +21,7 @@ limitations under the License.
 #include "IMessageContext.h"
 #include "Templates/SharedPointer.h"
 #include "Runtime/Launch/Resources/Version.h"
-#if (ENGINE_MAJOR_VERSION < 5)
-#include "Engine/EngineTypes.h"
-#else
-#include "Engine/TimerHandle.h"
-#endif
+#include "Containers/Ticker.h"
 #include "TbSame2SameEnum2InterfaceMsgBusAdapter.generated.h"
 
 class FMessageEndpoint;
@@ -130,9 +126,14 @@ private:
 
 	// Heartbeat handling
 	void _CheckClientTimeouts();
+	bool _CheckClientTimeoutsTick(float DeltaTime);
 	void _UpdateClientsConnected();
 	TMap<FMessageAddress, double> ConnectedClientsTimestamps;
-	FTimerHandle _HeartbeatTimerHandle;
+#if (ENGINE_MAJOR_VERSION < 5)
+	::FDelegateHandle _HeartbeatTickerHandle;
+#else
+	FTSTicker::FDelegateHandle _HeartbeatTickerHandle;
+#endif
 	int32 _ClientsConnected = 0;
 	uint32 _HeartbeatIntervalMS = 100;
 };

--- a/goldenmaster/Plugins/TbSame2/Source/TbSame2/Public/Generated/MsgBus/TbSame2SameEnum2InterfaceMsgBusClient.h
+++ b/goldenmaster/Plugins/TbSame2/Source/TbSame2/Public/Generated/MsgBus/TbSame2SameEnum2InterfaceMsgBusClient.h
@@ -22,11 +22,7 @@ limitations under the License.
 #include "HAL/CriticalSection.h"
 #include "Async/Future.h"
 #include "Runtime/Launch/Resources/Version.h"
-#if (ENGINE_MAJOR_VERSION < 5)
-#include "Engine/EngineTypes.h"
-#else
-#include "Engine/TimerHandle.h"
-#endif
+#include "Containers/Ticker.h"
 #include "Templates/PimplPtr.h"
 #include "IMessageContext.h"
 #include "TbSame2SameEnum2InterfaceMsgBusClient.generated.h"
@@ -127,8 +123,13 @@ private:
 	size_t CurrentPingCounter = 0;
 	float _CalculateAverageRTT() const;
 	FTbSame2SameEnum2InterfaceStats Stats;
-	FTimerHandle _HeartbeatTimerHandle;
+#if (ENGINE_MAJOR_VERSION < 5)
+	::FDelegateHandle _HeartbeatTickerHandle;
+#else
+	FTSTicker::FDelegateHandle _HeartbeatTickerHandle;
+#endif
 	void _OnHeartbeat();
+	bool _OnHeartbeatTick(float DeltaTime);
 	uint32 _HeartbeatIntervalMS = 100;
 
 	// connection handling

--- a/goldenmaster/Plugins/TbSame2/Source/TbSame2/Public/Generated/MsgBus/TbSame2SameStruct1InterfaceMsgBusAdapter.h
+++ b/goldenmaster/Plugins/TbSame2/Source/TbSame2/Public/Generated/MsgBus/TbSame2SameStruct1InterfaceMsgBusAdapter.h
@@ -21,11 +21,7 @@ limitations under the License.
 #include "IMessageContext.h"
 #include "Templates/SharedPointer.h"
 #include "Runtime/Launch/Resources/Version.h"
-#if (ENGINE_MAJOR_VERSION < 5)
-#include "Engine/EngineTypes.h"
-#else
-#include "Engine/TimerHandle.h"
-#endif
+#include "Containers/Ticker.h"
 #include "TbSame2SameStruct1InterfaceMsgBusAdapter.generated.h"
 
 class FMessageEndpoint;
@@ -118,9 +114,14 @@ private:
 
 	// Heartbeat handling
 	void _CheckClientTimeouts();
+	bool _CheckClientTimeoutsTick(float DeltaTime);
 	void _UpdateClientsConnected();
 	TMap<FMessageAddress, double> ConnectedClientsTimestamps;
-	FTimerHandle _HeartbeatTimerHandle;
+#if (ENGINE_MAJOR_VERSION < 5)
+	::FDelegateHandle _HeartbeatTickerHandle;
+#else
+	FTSTicker::FDelegateHandle _HeartbeatTickerHandle;
+#endif
 	int32 _ClientsConnected = 0;
 	uint32 _HeartbeatIntervalMS = 100;
 };

--- a/goldenmaster/Plugins/TbSame2/Source/TbSame2/Public/Generated/MsgBus/TbSame2SameStruct1InterfaceMsgBusClient.h
+++ b/goldenmaster/Plugins/TbSame2/Source/TbSame2/Public/Generated/MsgBus/TbSame2SameStruct1InterfaceMsgBusClient.h
@@ -22,11 +22,7 @@ limitations under the License.
 #include "HAL/CriticalSection.h"
 #include "Async/Future.h"
 #include "Runtime/Launch/Resources/Version.h"
-#if (ENGINE_MAJOR_VERSION < 5)
-#include "Engine/EngineTypes.h"
-#else
-#include "Engine/TimerHandle.h"
-#endif
+#include "Containers/Ticker.h"
 #include "Templates/PimplPtr.h"
 #include "IMessageContext.h"
 #include "TbSame2SameStruct1InterfaceMsgBusClient.generated.h"
@@ -119,8 +115,13 @@ private:
 	size_t CurrentPingCounter = 0;
 	float _CalculateAverageRTT() const;
 	FTbSame2SameStruct1InterfaceStats Stats;
-	FTimerHandle _HeartbeatTimerHandle;
+#if (ENGINE_MAJOR_VERSION < 5)
+	::FDelegateHandle _HeartbeatTickerHandle;
+#else
+	FTSTicker::FDelegateHandle _HeartbeatTickerHandle;
+#endif
 	void _OnHeartbeat();
+	bool _OnHeartbeatTick(float DeltaTime);
 	uint32 _HeartbeatIntervalMS = 100;
 
 	// connection handling

--- a/goldenmaster/Plugins/TbSame2/Source/TbSame2/Public/Generated/MsgBus/TbSame2SameStruct2InterfaceMsgBusAdapter.h
+++ b/goldenmaster/Plugins/TbSame2/Source/TbSame2/Public/Generated/MsgBus/TbSame2SameStruct2InterfaceMsgBusAdapter.h
@@ -21,11 +21,7 @@ limitations under the License.
 #include "IMessageContext.h"
 #include "Templates/SharedPointer.h"
 #include "Runtime/Launch/Resources/Version.h"
-#if (ENGINE_MAJOR_VERSION < 5)
-#include "Engine/EngineTypes.h"
-#else
-#include "Engine/TimerHandle.h"
-#endif
+#include "Containers/Ticker.h"
 #include "TbSame2SameStruct2InterfaceMsgBusAdapter.generated.h"
 
 class FMessageEndpoint;
@@ -130,9 +126,14 @@ private:
 
 	// Heartbeat handling
 	void _CheckClientTimeouts();
+	bool _CheckClientTimeoutsTick(float DeltaTime);
 	void _UpdateClientsConnected();
 	TMap<FMessageAddress, double> ConnectedClientsTimestamps;
-	FTimerHandle _HeartbeatTimerHandle;
+#if (ENGINE_MAJOR_VERSION < 5)
+	::FDelegateHandle _HeartbeatTickerHandle;
+#else
+	FTSTicker::FDelegateHandle _HeartbeatTickerHandle;
+#endif
 	int32 _ClientsConnected = 0;
 	uint32 _HeartbeatIntervalMS = 100;
 };

--- a/goldenmaster/Plugins/TbSame2/Source/TbSame2/Public/Generated/MsgBus/TbSame2SameStruct2InterfaceMsgBusClient.h
+++ b/goldenmaster/Plugins/TbSame2/Source/TbSame2/Public/Generated/MsgBus/TbSame2SameStruct2InterfaceMsgBusClient.h
@@ -22,11 +22,7 @@ limitations under the License.
 #include "HAL/CriticalSection.h"
 #include "Async/Future.h"
 #include "Runtime/Launch/Resources/Version.h"
-#if (ENGINE_MAJOR_VERSION < 5)
-#include "Engine/EngineTypes.h"
-#else
-#include "Engine/TimerHandle.h"
-#endif
+#include "Containers/Ticker.h"
 #include "Templates/PimplPtr.h"
 #include "IMessageContext.h"
 #include "TbSame2SameStruct2InterfaceMsgBusClient.generated.h"
@@ -127,8 +123,13 @@ private:
 	size_t CurrentPingCounter = 0;
 	float _CalculateAverageRTT() const;
 	FTbSame2SameStruct2InterfaceStats Stats;
-	FTimerHandle _HeartbeatTimerHandle;
+#if (ENGINE_MAJOR_VERSION < 5)
+	::FDelegateHandle _HeartbeatTickerHandle;
+#else
+	FTSTicker::FDelegateHandle _HeartbeatTickerHandle;
+#endif
 	void _OnHeartbeat();
+	bool _OnHeartbeatTick(float DeltaTime);
 	uint32 _HeartbeatIntervalMS = 100;
 
 	// connection handling

--- a/goldenmaster/Plugins/TbSame2/Source/TbSame2/Public/TbSame2Settings.h
+++ b/goldenmaster/Plugins/TbSame2/Source/TbSame2/Public/TbSame2Settings.h
@@ -45,4 +45,11 @@ public:
 	/** Choose the olink connection to use */
 	UPROPERTY(EditAnywhere, config, Category = OLinkConnectionSetup)
 	FString OLinkConnectionIdentifier;
+
+	/** Choose the heartbeat interval in milliseconds for the msgbus connection on the service side.
+	 * On the service side this adjusts the heartbeat between client and service. The clients will receive the value from service.
+	 * On the client side this adjusts how often discovery messages are sent until a service is connected.
+	 */
+	UPROPERTY(EditAnywhere, config, Category = MsgBusConnectionSetup, meta = (DisplayName = "Heartbeat interval (in milliseconds)"))
+	uint32 MsgBusHeartbeatIntervalMS = 200;
 };

--- a/goldenmaster/Plugins/TbSame2/TbSame2.uplugin
+++ b/goldenmaster/Plugins/TbSame2/TbSame2.uplugin
@@ -2,7 +2,7 @@
 {
 	"FileVersion": 3,
 	"Version": 1,
-	"VersionName": "1.0.0",
+	"VersionName": "1.0.0+tpl.3.5.2",
 	"FriendlyName": "TbSame2",
 	"Description": "",
 	"Category": "Other",

--- a/goldenmaster/Plugins/TbSimple/Source/TbSimple/Private/Generated/MsgBus/TbSimpleEmptyInterfaceMsgBusAdapter.cpp
+++ b/goldenmaster/Plugins/TbSimple/Source/TbSimple/Private/Generated/MsgBus/TbSimpleEmptyInterfaceMsgBusAdapter.cpp
@@ -24,12 +24,12 @@ limitations under the License.
 #include "Generated/MsgBus/TbSimpleEmptyInterfaceMsgBusMessages.h"
 #include "Async/Future.h"
 #include "Async/Async.h"
-#include "Async/Async.h"
-#include "Engine/Engine.h"
+#include "Engine/World.h"
 #include "TimerManager.h"
 #include "MessageEndpoint.h"
 #include "MessageEndpointBuilder.h"
 #include "Misc/DateTime.h"
+#include "TbSimpleSettings.h"
 
 DEFINE_LOG_CATEGORY(LogTbSimpleEmptyInterfaceMsgBusAdapter);
 UTbSimpleEmptyInterfaceMsgBusAdapter::UTbSimpleEmptyInterfaceMsgBusAdapter()
@@ -53,6 +53,10 @@ void UTbSimpleEmptyInterfaceMsgBusAdapter::_StartListening()
 
 	if (!_HeartbeatTimerHandle.IsValid() && GetWorld())
 	{
+		UTbSimpleSettings* settings = GetMutableDefault<UTbSimpleSettings>();
+		check(settings);
+		_HeartbeatIntervalMS = settings->MsgBusHeartbeatIntervalMS;
+
 		GetWorld()->GetTimerManager().SetTimer(_HeartbeatTimerHandle, this, &UTbSimpleEmptyInterfaceMsgBusAdapter::_CheckClientTimeouts, _HeartbeatIntervalMS / 1000.0f, true);
 	}
 

--- a/goldenmaster/Plugins/TbSimple/Source/TbSimple/Private/Generated/MsgBus/TbSimpleEmptyInterfaceMsgBusClient.cpp
+++ b/goldenmaster/Plugins/TbSimple/Source/TbSimple/Private/Generated/MsgBus/TbSimpleEmptyInterfaceMsgBusClient.cpp
@@ -24,7 +24,6 @@ limitations under the License.
 #include "Generated/MsgBus/TbSimpleEmptyInterfaceMsgBusMessages.h"
 #include "Async/Async.h"
 #include "Engine/World.h"
-#include "TimerManager.h"
 #include "Misc/DateTime.h"
 #include "GenericPlatform/GenericPlatformMath.h"
 #include "GenericPlatform/GenericPlatformTime.h"
@@ -55,19 +54,25 @@ void UTbSimpleEmptyInterfaceMsgBusClient::Deinitialize()
 
 void UTbSimpleEmptyInterfaceMsgBusClient::_Connect()
 {
-	if (!_HeartbeatTimerHandle.IsValid() && GetWorld())
+	if (_IsConnected())
+	{
+		UE_LOG(LogTbSimpleEmptyInterfaceMsgBusClient, Log, TEXT("Already connected, cannot connect again."));
+		return;
+	}
+
+	if (!_HeartbeatTickerHandle.IsValid())
 	{
 		UTbSimpleSettings* settings = GetMutableDefault<UTbSimpleSettings>();
 		check(settings);
 		_HeartbeatIntervalMS = settings->MsgBusHeartbeatIntervalMS;
 
-		GetWorld()->GetTimerManager().SetTimer(_HeartbeatTimerHandle, this, &UTbSimpleEmptyInterfaceMsgBusClient::_OnHeartbeat, _HeartbeatIntervalMS / 1000.0f, true);
-	}
-
-	if (_IsConnected())
-	{
-		UE_LOG(LogTbSimpleEmptyInterfaceMsgBusClient, Log, TEXT("Already connected, cannot connect again."));
-		return;
+#if (ENGINE_MAJOR_VERSION < 5)
+		FTicker::GetCoreTicker().RemoveTicker(_HeartbeatTickerHandle);
+		_HeartbeatTickerHandle = FTicker::GetCoreTicker().AddTicker(FTickerDelegate::CreateUObject(this, &UTbSimpleEmptyInterfaceMsgBusClient::_OnHeartbeatTick), _HeartbeatIntervalMS / 1000.0f);
+#else
+		FTSTicker::GetCoreTicker().RemoveTicker(_HeartbeatTickerHandle);
+		_HeartbeatTickerHandle = FTSTicker::GetCoreTicker().AddTicker(FTickerDelegate::CreateUObject(this, &UTbSimpleEmptyInterfaceMsgBusClient::_OnHeartbeatTick), _HeartbeatIntervalMS / 1000.0f);
+#endif
 	}
 
 	if (TbSimpleEmptyInterfaceMsgBusEndpoint.IsValid() && !ServiceAddress.IsValid())
@@ -90,10 +95,12 @@ void UTbSimpleEmptyInterfaceMsgBusClient::_Connect()
 void UTbSimpleEmptyInterfaceMsgBusClient::_Disconnect()
 {
 	_LastHbTimestamp = 0.0f;
-	if (_HeartbeatTimerHandle.IsValid() && GetWorld())
-	{
-		GetWorld()->GetTimerManager().ClearTimer(_HeartbeatTimerHandle);
-	}
+
+#if (ENGINE_MAJOR_VERSION < 5)
+	FTicker::GetCoreTicker().RemoveTicker(_HeartbeatTickerHandle);
+#else
+	FTSTicker::GetCoreTicker().RemoveTicker(_HeartbeatTickerHandle);
+#endif
 
 	if (!_IsConnected())
 	{
@@ -154,18 +161,22 @@ void UTbSimpleEmptyInterfaceMsgBusClient::OnConnectionInit(const FTbSimpleEmptyI
 	{
 		_HeartbeatIntervalMS = InMessage._ClientPingIntervalMS;
 
-		if (_HeartbeatTimerHandle.IsValid() && GetWorld())
-		{
-			GetWorld()->GetTimerManager().ClearTimer(_HeartbeatTimerHandle);
-		}
-
-		if (!_HeartbeatTimerHandle.IsValid() && GetWorld())
-		{
-			GetWorld()->GetTimerManager().SetTimer(_HeartbeatTimerHandle, this, &UTbSimpleEmptyInterfaceMsgBusClient::_OnHeartbeat, _HeartbeatIntervalMS / 1000.0f, true);
-		}
+#if (ENGINE_MAJOR_VERSION < 5)
+		FTicker::GetCoreTicker().RemoveTicker(_HeartbeatTickerHandle);
+		_HeartbeatTickerHandle = FTicker::GetCoreTicker().AddTicker(FTickerDelegate::CreateUObject(this, &UTbSimpleEmptyInterfaceMsgBusClient::_OnHeartbeatTick), _HeartbeatIntervalMS / 1000.0f);
+#else
+		FTSTicker::GetCoreTicker().RemoveTicker(_HeartbeatTickerHandle);
+		_HeartbeatTickerHandle = FTSTicker::GetCoreTicker().AddTicker(FTickerDelegate::CreateUObject(this, &UTbSimpleEmptyInterfaceMsgBusClient::_OnHeartbeatTick), _HeartbeatIntervalMS / 1000.0f);
+#endif
 	}
 
 	_ConnectionStatusChanged.Broadcast(true);
+}
+
+bool UTbSimpleEmptyInterfaceMsgBusClient::_OnHeartbeatTick(float /*DeltaTime*/)
+{
+	_OnHeartbeat();
+	return true;
 }
 
 void UTbSimpleEmptyInterfaceMsgBusClient::_OnHeartbeat()

--- a/goldenmaster/Plugins/TbSimple/Source/TbSimple/Private/Generated/MsgBus/TbSimpleEmptyInterfaceMsgBusClient.cpp
+++ b/goldenmaster/Plugins/TbSimple/Source/TbSimple/Private/Generated/MsgBus/TbSimpleEmptyInterfaceMsgBusClient.cpp
@@ -23,13 +23,14 @@ limitations under the License.
 #include "Generated/MsgBus/TbSimpleEmptyInterfaceMsgBusClient.h"
 #include "Generated/MsgBus/TbSimpleEmptyInterfaceMsgBusMessages.h"
 #include "Async/Async.h"
-#include "Engine/Engine.h"
+#include "Engine/World.h"
 #include "TimerManager.h"
 #include "Misc/DateTime.h"
 #include "GenericPlatform/GenericPlatformMath.h"
 #include "GenericPlatform/GenericPlatformTime.h"
 #include "MessageEndpointBuilder.h"
 #include "MessageEndpoint.h"
+#include "TbSimpleSettings.h"
 DEFINE_LOG_CATEGORY(LogTbSimpleEmptyInterfaceMsgBusClient);
 
 UTbSimpleEmptyInterfaceMsgBusClient::UTbSimpleEmptyInterfaceMsgBusClient()
@@ -56,6 +57,10 @@ void UTbSimpleEmptyInterfaceMsgBusClient::_Connect()
 {
 	if (!_HeartbeatTimerHandle.IsValid() && GetWorld())
 	{
+		UTbSimpleSettings* settings = GetMutableDefault<UTbSimpleSettings>();
+		check(settings);
+		_HeartbeatIntervalMS = settings->MsgBusHeartbeatIntervalMS;
+
 		GetWorld()->GetTimerManager().SetTimer(_HeartbeatTimerHandle, this, &UTbSimpleEmptyInterfaceMsgBusClient::_OnHeartbeat, _HeartbeatIntervalMS / 1000.0f, true);
 	}
 

--- a/goldenmaster/Plugins/TbSimple/Source/TbSimple/Private/Generated/MsgBus/TbSimpleNoOperationsInterfaceMsgBusAdapter.cpp
+++ b/goldenmaster/Plugins/TbSimple/Source/TbSimple/Private/Generated/MsgBus/TbSimpleNoOperationsInterfaceMsgBusAdapter.cpp
@@ -24,12 +24,12 @@ limitations under the License.
 #include "Generated/MsgBus/TbSimpleNoOperationsInterfaceMsgBusMessages.h"
 #include "Async/Future.h"
 #include "Async/Async.h"
-#include "Async/Async.h"
-#include "Engine/Engine.h"
+#include "Engine/World.h"
 #include "TimerManager.h"
 #include "MessageEndpoint.h"
 #include "MessageEndpointBuilder.h"
 #include "Misc/DateTime.h"
+#include "TbSimpleSettings.h"
 
 DEFINE_LOG_CATEGORY(LogTbSimpleNoOperationsInterfaceMsgBusAdapter);
 UTbSimpleNoOperationsInterfaceMsgBusAdapter::UTbSimpleNoOperationsInterfaceMsgBusAdapter()
@@ -53,6 +53,10 @@ void UTbSimpleNoOperationsInterfaceMsgBusAdapter::_StartListening()
 
 	if (!_HeartbeatTimerHandle.IsValid() && GetWorld())
 	{
+		UTbSimpleSettings* settings = GetMutableDefault<UTbSimpleSettings>();
+		check(settings);
+		_HeartbeatIntervalMS = settings->MsgBusHeartbeatIntervalMS;
+
 		GetWorld()->GetTimerManager().SetTimer(_HeartbeatTimerHandle, this, &UTbSimpleNoOperationsInterfaceMsgBusAdapter::_CheckClientTimeouts, _HeartbeatIntervalMS / 1000.0f, true);
 	}
 

--- a/goldenmaster/Plugins/TbSimple/Source/TbSimple/Private/Generated/MsgBus/TbSimpleNoOperationsInterfaceMsgBusAdapter.cpp
+++ b/goldenmaster/Plugins/TbSimple/Source/TbSimple/Private/Generated/MsgBus/TbSimpleNoOperationsInterfaceMsgBusAdapter.cpp
@@ -25,7 +25,6 @@ limitations under the License.
 #include "Async/Future.h"
 #include "Async/Async.h"
 #include "Engine/World.h"
-#include "TimerManager.h"
 #include "MessageEndpoint.h"
 #include "MessageEndpointBuilder.h"
 #include "Misc/DateTime.h"
@@ -51,13 +50,17 @@ void UTbSimpleNoOperationsInterfaceMsgBusAdapter::Deinitialize()
 void UTbSimpleNoOperationsInterfaceMsgBusAdapter::_StartListening()
 {
 
-	if (!_HeartbeatTimerHandle.IsValid() && GetWorld())
+	if (!_HeartbeatTickerHandle.IsValid())
 	{
 		UTbSimpleSettings* settings = GetMutableDefault<UTbSimpleSettings>();
 		check(settings);
 		_HeartbeatIntervalMS = settings->MsgBusHeartbeatIntervalMS;
 
-		GetWorld()->GetTimerManager().SetTimer(_HeartbeatTimerHandle, this, &UTbSimpleNoOperationsInterfaceMsgBusAdapter::_CheckClientTimeouts, _HeartbeatIntervalMS / 1000.0f, true);
+#if (ENGINE_MAJOR_VERSION < 5)
+		_HeartbeatTickerHandle = FTicker::GetCoreTicker().AddTicker(FTickerDelegate::CreateUObject(this, &UTbSimpleNoOperationsInterfaceMsgBusAdapter::_CheckClientTimeoutsTick), _HeartbeatIntervalMS / 1000.0f);
+#else
+		_HeartbeatTickerHandle = FTSTicker::GetCoreTicker().AddTicker(FTickerDelegate::CreateUObject(this, &UTbSimpleNoOperationsInterfaceMsgBusAdapter::_CheckClientTimeoutsTick), _HeartbeatIntervalMS / 1000.0f);
+#endif
 	}
 
 	if (TbSimpleNoOperationsInterfaceMsgBusEndpoint.IsValid())
@@ -97,9 +100,13 @@ void UTbSimpleNoOperationsInterfaceMsgBusAdapter::_AnnounceService()
 
 void UTbSimpleNoOperationsInterfaceMsgBusAdapter::_StopListening()
 {
-	if (_HeartbeatTimerHandle.IsValid() && GetWorld())
+	if (_HeartbeatTickerHandle.IsValid())
 	{
-		GetWorld()->GetTimerManager().ClearTimer(_HeartbeatTimerHandle);
+#if (ENGINE_MAJOR_VERSION < 5)
+		FTicker::GetCoreTicker().RemoveTicker(_HeartbeatTickerHandle);
+#else
+		FTSTicker::GetCoreTicker().RemoveTicker(_HeartbeatTickerHandle);
+#endif
 	}
 
 	auto msg = new FTbSimpleNoOperationsInterfaceServiceDisconnectMessage();
@@ -246,6 +253,12 @@ void UTbSimpleNoOperationsInterfaceMsgBusAdapter::OnClientDisconnected(const FTb
 	ConnectedClientsTimestamps.Remove(Context->GetSender());
 	_OnClientDisconnected.Broadcast(Context->GetSender().ToString());
 	_UpdateClientsConnected();
+}
+
+bool UTbSimpleNoOperationsInterfaceMsgBusAdapter::_CheckClientTimeoutsTick(float /*DeltaTime*/)
+{
+	_CheckClientTimeouts();
+	return true;
 }
 
 void UTbSimpleNoOperationsInterfaceMsgBusAdapter::_CheckClientTimeouts()

--- a/goldenmaster/Plugins/TbSimple/Source/TbSimple/Private/Generated/MsgBus/TbSimpleNoOperationsInterfaceMsgBusClient.cpp
+++ b/goldenmaster/Plugins/TbSimple/Source/TbSimple/Private/Generated/MsgBus/TbSimpleNoOperationsInterfaceMsgBusClient.cpp
@@ -24,7 +24,6 @@ limitations under the License.
 #include "Generated/MsgBus/TbSimpleNoOperationsInterfaceMsgBusMessages.h"
 #include "Async/Async.h"
 #include "Engine/World.h"
-#include "TimerManager.h"
 #include "Misc/DateTime.h"
 #include "GenericPlatform/GenericPlatformMath.h"
 #include "GenericPlatform/GenericPlatformTime.h"
@@ -66,19 +65,25 @@ void UTbSimpleNoOperationsInterfaceMsgBusClient::Deinitialize()
 
 void UTbSimpleNoOperationsInterfaceMsgBusClient::_Connect()
 {
-	if (!_HeartbeatTimerHandle.IsValid() && GetWorld())
+	if (_IsConnected())
+	{
+		UE_LOG(LogTbSimpleNoOperationsInterfaceMsgBusClient, Log, TEXT("Already connected, cannot connect again."));
+		return;
+	}
+
+	if (!_HeartbeatTickerHandle.IsValid())
 	{
 		UTbSimpleSettings* settings = GetMutableDefault<UTbSimpleSettings>();
 		check(settings);
 		_HeartbeatIntervalMS = settings->MsgBusHeartbeatIntervalMS;
 
-		GetWorld()->GetTimerManager().SetTimer(_HeartbeatTimerHandle, this, &UTbSimpleNoOperationsInterfaceMsgBusClient::_OnHeartbeat, _HeartbeatIntervalMS / 1000.0f, true);
-	}
-
-	if (_IsConnected())
-	{
-		UE_LOG(LogTbSimpleNoOperationsInterfaceMsgBusClient, Log, TEXT("Already connected, cannot connect again."));
-		return;
+#if (ENGINE_MAJOR_VERSION < 5)
+		FTicker::GetCoreTicker().RemoveTicker(_HeartbeatTickerHandle);
+		_HeartbeatTickerHandle = FTicker::GetCoreTicker().AddTicker(FTickerDelegate::CreateUObject(this, &UTbSimpleNoOperationsInterfaceMsgBusClient::_OnHeartbeatTick), _HeartbeatIntervalMS / 1000.0f);
+#else
+		FTSTicker::GetCoreTicker().RemoveTicker(_HeartbeatTickerHandle);
+		_HeartbeatTickerHandle = FTSTicker::GetCoreTicker().AddTicker(FTickerDelegate::CreateUObject(this, &UTbSimpleNoOperationsInterfaceMsgBusClient::_OnHeartbeatTick), _HeartbeatIntervalMS / 1000.0f);
+#endif
 	}
 
 	if (TbSimpleNoOperationsInterfaceMsgBusEndpoint.IsValid() && !ServiceAddress.IsValid())
@@ -105,10 +110,12 @@ void UTbSimpleNoOperationsInterfaceMsgBusClient::_Connect()
 void UTbSimpleNoOperationsInterfaceMsgBusClient::_Disconnect()
 {
 	_LastHbTimestamp = 0.0f;
-	if (_HeartbeatTimerHandle.IsValid() && GetWorld())
-	{
-		GetWorld()->GetTimerManager().ClearTimer(_HeartbeatTimerHandle);
-	}
+
+#if (ENGINE_MAJOR_VERSION < 5)
+	FTicker::GetCoreTicker().RemoveTicker(_HeartbeatTickerHandle);
+#else
+	FTSTicker::GetCoreTicker().RemoveTicker(_HeartbeatTickerHandle);
+#endif
 
 	if (!_IsConnected())
 	{
@@ -169,15 +176,13 @@ void UTbSimpleNoOperationsInterfaceMsgBusClient::OnConnectionInit(const FTbSimpl
 	{
 		_HeartbeatIntervalMS = InMessage._ClientPingIntervalMS;
 
-		if (_HeartbeatTimerHandle.IsValid() && GetWorld())
-		{
-			GetWorld()->GetTimerManager().ClearTimer(_HeartbeatTimerHandle);
-		}
-
-		if (!_HeartbeatTimerHandle.IsValid() && GetWorld())
-		{
-			GetWorld()->GetTimerManager().SetTimer(_HeartbeatTimerHandle, this, &UTbSimpleNoOperationsInterfaceMsgBusClient::_OnHeartbeat, _HeartbeatIntervalMS / 1000.0f, true);
-		}
+#if (ENGINE_MAJOR_VERSION < 5)
+		FTicker::GetCoreTicker().RemoveTicker(_HeartbeatTickerHandle);
+		_HeartbeatTickerHandle = FTicker::GetCoreTicker().AddTicker(FTickerDelegate::CreateUObject(this, &UTbSimpleNoOperationsInterfaceMsgBusClient::_OnHeartbeatTick), _HeartbeatIntervalMS / 1000.0f);
+#else
+		FTSTicker::GetCoreTicker().RemoveTicker(_HeartbeatTickerHandle);
+		_HeartbeatTickerHandle = FTSTicker::GetCoreTicker().AddTicker(FTickerDelegate::CreateUObject(this, &UTbSimpleNoOperationsInterfaceMsgBusClient::_OnHeartbeatTick), _HeartbeatIntervalMS / 1000.0f);
+#endif
 	}
 	const bool bbPropBoolChanged = InMessage.bPropBool != bPropBool;
 	if (bbPropBoolChanged)
@@ -194,6 +199,12 @@ void UTbSimpleNoOperationsInterfaceMsgBusClient::OnConnectionInit(const FTbSimpl
 	}
 
 	_ConnectionStatusChanged.Broadcast(true);
+}
+
+bool UTbSimpleNoOperationsInterfaceMsgBusClient::_OnHeartbeatTick(float /*DeltaTime*/)
+{
+	_OnHeartbeat();
+	return true;
 }
 
 void UTbSimpleNoOperationsInterfaceMsgBusClient::_OnHeartbeat()

--- a/goldenmaster/Plugins/TbSimple/Source/TbSimple/Private/Generated/MsgBus/TbSimpleNoOperationsInterfaceMsgBusClient.cpp
+++ b/goldenmaster/Plugins/TbSimple/Source/TbSimple/Private/Generated/MsgBus/TbSimpleNoOperationsInterfaceMsgBusClient.cpp
@@ -23,13 +23,14 @@ limitations under the License.
 #include "Generated/MsgBus/TbSimpleNoOperationsInterfaceMsgBusClient.h"
 #include "Generated/MsgBus/TbSimpleNoOperationsInterfaceMsgBusMessages.h"
 #include "Async/Async.h"
-#include "Engine/Engine.h"
+#include "Engine/World.h"
 #include "TimerManager.h"
 #include "Misc/DateTime.h"
 #include "GenericPlatform/GenericPlatformMath.h"
 #include "GenericPlatform/GenericPlatformTime.h"
 #include "MessageEndpointBuilder.h"
 #include "MessageEndpoint.h"
+#include "TbSimpleSettings.h"
 #include <atomic>
 
 /**
@@ -67,6 +68,10 @@ void UTbSimpleNoOperationsInterfaceMsgBusClient::_Connect()
 {
 	if (!_HeartbeatTimerHandle.IsValid() && GetWorld())
 	{
+		UTbSimpleSettings* settings = GetMutableDefault<UTbSimpleSettings>();
+		check(settings);
+		_HeartbeatIntervalMS = settings->MsgBusHeartbeatIntervalMS;
+
 		GetWorld()->GetTimerManager().SetTimer(_HeartbeatTimerHandle, this, &UTbSimpleNoOperationsInterfaceMsgBusClient::_OnHeartbeat, _HeartbeatIntervalMS / 1000.0f, true);
 	}
 

--- a/goldenmaster/Plugins/TbSimple/Source/TbSimple/Private/Generated/MsgBus/TbSimpleNoPropertiesInterfaceMsgBusAdapter.cpp
+++ b/goldenmaster/Plugins/TbSimple/Source/TbSimple/Private/Generated/MsgBus/TbSimpleNoPropertiesInterfaceMsgBusAdapter.cpp
@@ -25,7 +25,6 @@ limitations under the License.
 #include "Async/Future.h"
 #include "Async/Async.h"
 #include "Engine/World.h"
-#include "TimerManager.h"
 #include "MessageEndpoint.h"
 #include "MessageEndpointBuilder.h"
 #include "Misc/DateTime.h"
@@ -51,13 +50,17 @@ void UTbSimpleNoPropertiesInterfaceMsgBusAdapter::Deinitialize()
 void UTbSimpleNoPropertiesInterfaceMsgBusAdapter::_StartListening()
 {
 
-	if (!_HeartbeatTimerHandle.IsValid() && GetWorld())
+	if (!_HeartbeatTickerHandle.IsValid())
 	{
 		UTbSimpleSettings* settings = GetMutableDefault<UTbSimpleSettings>();
 		check(settings);
 		_HeartbeatIntervalMS = settings->MsgBusHeartbeatIntervalMS;
 
-		GetWorld()->GetTimerManager().SetTimer(_HeartbeatTimerHandle, this, &UTbSimpleNoPropertiesInterfaceMsgBusAdapter::_CheckClientTimeouts, _HeartbeatIntervalMS / 1000.0f, true);
+#if (ENGINE_MAJOR_VERSION < 5)
+		_HeartbeatTickerHandle = FTicker::GetCoreTicker().AddTicker(FTickerDelegate::CreateUObject(this, &UTbSimpleNoPropertiesInterfaceMsgBusAdapter::_CheckClientTimeoutsTick), _HeartbeatIntervalMS / 1000.0f);
+#else
+		_HeartbeatTickerHandle = FTSTicker::GetCoreTicker().AddTicker(FTickerDelegate::CreateUObject(this, &UTbSimpleNoPropertiesInterfaceMsgBusAdapter::_CheckClientTimeoutsTick), _HeartbeatIntervalMS / 1000.0f);
+#endif
 	}
 
 	if (TbSimpleNoPropertiesInterfaceMsgBusEndpoint.IsValid())
@@ -97,9 +100,13 @@ void UTbSimpleNoPropertiesInterfaceMsgBusAdapter::_AnnounceService()
 
 void UTbSimpleNoPropertiesInterfaceMsgBusAdapter::_StopListening()
 {
-	if (_HeartbeatTimerHandle.IsValid() && GetWorld())
+	if (_HeartbeatTickerHandle.IsValid())
 	{
-		GetWorld()->GetTimerManager().ClearTimer(_HeartbeatTimerHandle);
+#if (ENGINE_MAJOR_VERSION < 5)
+		FTicker::GetCoreTicker().RemoveTicker(_HeartbeatTickerHandle);
+#else
+		FTSTicker::GetCoreTicker().RemoveTicker(_HeartbeatTickerHandle);
+#endif
 	}
 
 	auto msg = new FTbSimpleNoPropertiesInterfaceServiceDisconnectMessage();
@@ -240,6 +247,12 @@ void UTbSimpleNoPropertiesInterfaceMsgBusAdapter::OnClientDisconnected(const FTb
 	ConnectedClientsTimestamps.Remove(Context->GetSender());
 	_OnClientDisconnected.Broadcast(Context->GetSender().ToString());
 	_UpdateClientsConnected();
+}
+
+bool UTbSimpleNoPropertiesInterfaceMsgBusAdapter::_CheckClientTimeoutsTick(float /*DeltaTime*/)
+{
+	_CheckClientTimeouts();
+	return true;
 }
 
 void UTbSimpleNoPropertiesInterfaceMsgBusAdapter::_CheckClientTimeouts()

--- a/goldenmaster/Plugins/TbSimple/Source/TbSimple/Private/Generated/MsgBus/TbSimpleNoPropertiesInterfaceMsgBusAdapter.cpp
+++ b/goldenmaster/Plugins/TbSimple/Source/TbSimple/Private/Generated/MsgBus/TbSimpleNoPropertiesInterfaceMsgBusAdapter.cpp
@@ -24,12 +24,12 @@ limitations under the License.
 #include "Generated/MsgBus/TbSimpleNoPropertiesInterfaceMsgBusMessages.h"
 #include "Async/Future.h"
 #include "Async/Async.h"
-#include "Async/Async.h"
-#include "Engine/Engine.h"
+#include "Engine/World.h"
 #include "TimerManager.h"
 #include "MessageEndpoint.h"
 #include "MessageEndpointBuilder.h"
 #include "Misc/DateTime.h"
+#include "TbSimpleSettings.h"
 
 DEFINE_LOG_CATEGORY(LogTbSimpleNoPropertiesInterfaceMsgBusAdapter);
 UTbSimpleNoPropertiesInterfaceMsgBusAdapter::UTbSimpleNoPropertiesInterfaceMsgBusAdapter()
@@ -53,6 +53,10 @@ void UTbSimpleNoPropertiesInterfaceMsgBusAdapter::_StartListening()
 
 	if (!_HeartbeatTimerHandle.IsValid() && GetWorld())
 	{
+		UTbSimpleSettings* settings = GetMutableDefault<UTbSimpleSettings>();
+		check(settings);
+		_HeartbeatIntervalMS = settings->MsgBusHeartbeatIntervalMS;
+
 		GetWorld()->GetTimerManager().SetTimer(_HeartbeatTimerHandle, this, &UTbSimpleNoPropertiesInterfaceMsgBusAdapter::_CheckClientTimeouts, _HeartbeatIntervalMS / 1000.0f, true);
 	}
 

--- a/goldenmaster/Plugins/TbSimple/Source/TbSimple/Private/Generated/MsgBus/TbSimpleNoPropertiesInterfaceMsgBusClient.cpp
+++ b/goldenmaster/Plugins/TbSimple/Source/TbSimple/Private/Generated/MsgBus/TbSimpleNoPropertiesInterfaceMsgBusClient.cpp
@@ -23,13 +23,14 @@ limitations under the License.
 #include "Generated/MsgBus/TbSimpleNoPropertiesInterfaceMsgBusClient.h"
 #include "Generated/MsgBus/TbSimpleNoPropertiesInterfaceMsgBusMessages.h"
 #include "Async/Async.h"
-#include "Engine/Engine.h"
+#include "Engine/World.h"
 #include "TimerManager.h"
 #include "Misc/DateTime.h"
 #include "GenericPlatform/GenericPlatformMath.h"
 #include "GenericPlatform/GenericPlatformTime.h"
 #include "MessageEndpointBuilder.h"
 #include "MessageEndpoint.h"
+#include "TbSimpleSettings.h"
 DEFINE_LOG_CATEGORY(LogTbSimpleNoPropertiesInterfaceMsgBusClient);
 
 UTbSimpleNoPropertiesInterfaceMsgBusClient::UTbSimpleNoPropertiesInterfaceMsgBusClient()
@@ -56,6 +57,10 @@ void UTbSimpleNoPropertiesInterfaceMsgBusClient::_Connect()
 {
 	if (!_HeartbeatTimerHandle.IsValid() && GetWorld())
 	{
+		UTbSimpleSettings* settings = GetMutableDefault<UTbSimpleSettings>();
+		check(settings);
+		_HeartbeatIntervalMS = settings->MsgBusHeartbeatIntervalMS;
+
 		GetWorld()->GetTimerManager().SetTimer(_HeartbeatTimerHandle, this, &UTbSimpleNoPropertiesInterfaceMsgBusClient::_OnHeartbeat, _HeartbeatIntervalMS / 1000.0f, true);
 	}
 

--- a/goldenmaster/Plugins/TbSimple/Source/TbSimple/Private/Generated/MsgBus/TbSimpleNoPropertiesInterfaceMsgBusClient.cpp
+++ b/goldenmaster/Plugins/TbSimple/Source/TbSimple/Private/Generated/MsgBus/TbSimpleNoPropertiesInterfaceMsgBusClient.cpp
@@ -24,7 +24,6 @@ limitations under the License.
 #include "Generated/MsgBus/TbSimpleNoPropertiesInterfaceMsgBusMessages.h"
 #include "Async/Async.h"
 #include "Engine/World.h"
-#include "TimerManager.h"
 #include "Misc/DateTime.h"
 #include "GenericPlatform/GenericPlatformMath.h"
 #include "GenericPlatform/GenericPlatformTime.h"
@@ -55,19 +54,25 @@ void UTbSimpleNoPropertiesInterfaceMsgBusClient::Deinitialize()
 
 void UTbSimpleNoPropertiesInterfaceMsgBusClient::_Connect()
 {
-	if (!_HeartbeatTimerHandle.IsValid() && GetWorld())
+	if (_IsConnected())
+	{
+		UE_LOG(LogTbSimpleNoPropertiesInterfaceMsgBusClient, Log, TEXT("Already connected, cannot connect again."));
+		return;
+	}
+
+	if (!_HeartbeatTickerHandle.IsValid())
 	{
 		UTbSimpleSettings* settings = GetMutableDefault<UTbSimpleSettings>();
 		check(settings);
 		_HeartbeatIntervalMS = settings->MsgBusHeartbeatIntervalMS;
 
-		GetWorld()->GetTimerManager().SetTimer(_HeartbeatTimerHandle, this, &UTbSimpleNoPropertiesInterfaceMsgBusClient::_OnHeartbeat, _HeartbeatIntervalMS / 1000.0f, true);
-	}
-
-	if (_IsConnected())
-	{
-		UE_LOG(LogTbSimpleNoPropertiesInterfaceMsgBusClient, Log, TEXT("Already connected, cannot connect again."));
-		return;
+#if (ENGINE_MAJOR_VERSION < 5)
+		FTicker::GetCoreTicker().RemoveTicker(_HeartbeatTickerHandle);
+		_HeartbeatTickerHandle = FTicker::GetCoreTicker().AddTicker(FTickerDelegate::CreateUObject(this, &UTbSimpleNoPropertiesInterfaceMsgBusClient::_OnHeartbeatTick), _HeartbeatIntervalMS / 1000.0f);
+#else
+		FTSTicker::GetCoreTicker().RemoveTicker(_HeartbeatTickerHandle);
+		_HeartbeatTickerHandle = FTSTicker::GetCoreTicker().AddTicker(FTickerDelegate::CreateUObject(this, &UTbSimpleNoPropertiesInterfaceMsgBusClient::_OnHeartbeatTick), _HeartbeatIntervalMS / 1000.0f);
+#endif
 	}
 
 	if (TbSimpleNoPropertiesInterfaceMsgBusEndpoint.IsValid() && !ServiceAddress.IsValid())
@@ -93,10 +98,12 @@ void UTbSimpleNoPropertiesInterfaceMsgBusClient::_Connect()
 void UTbSimpleNoPropertiesInterfaceMsgBusClient::_Disconnect()
 {
 	_LastHbTimestamp = 0.0f;
-	if (_HeartbeatTimerHandle.IsValid() && GetWorld())
-	{
-		GetWorld()->GetTimerManager().ClearTimer(_HeartbeatTimerHandle);
-	}
+
+#if (ENGINE_MAJOR_VERSION < 5)
+	FTicker::GetCoreTicker().RemoveTicker(_HeartbeatTickerHandle);
+#else
+	FTSTicker::GetCoreTicker().RemoveTicker(_HeartbeatTickerHandle);
+#endif
 
 	if (!_IsConnected())
 	{
@@ -157,18 +164,22 @@ void UTbSimpleNoPropertiesInterfaceMsgBusClient::OnConnectionInit(const FTbSimpl
 	{
 		_HeartbeatIntervalMS = InMessage._ClientPingIntervalMS;
 
-		if (_HeartbeatTimerHandle.IsValid() && GetWorld())
-		{
-			GetWorld()->GetTimerManager().ClearTimer(_HeartbeatTimerHandle);
-		}
-
-		if (!_HeartbeatTimerHandle.IsValid() && GetWorld())
-		{
-			GetWorld()->GetTimerManager().SetTimer(_HeartbeatTimerHandle, this, &UTbSimpleNoPropertiesInterfaceMsgBusClient::_OnHeartbeat, _HeartbeatIntervalMS / 1000.0f, true);
-		}
+#if (ENGINE_MAJOR_VERSION < 5)
+		FTicker::GetCoreTicker().RemoveTicker(_HeartbeatTickerHandle);
+		_HeartbeatTickerHandle = FTicker::GetCoreTicker().AddTicker(FTickerDelegate::CreateUObject(this, &UTbSimpleNoPropertiesInterfaceMsgBusClient::_OnHeartbeatTick), _HeartbeatIntervalMS / 1000.0f);
+#else
+		FTSTicker::GetCoreTicker().RemoveTicker(_HeartbeatTickerHandle);
+		_HeartbeatTickerHandle = FTSTicker::GetCoreTicker().AddTicker(FTickerDelegate::CreateUObject(this, &UTbSimpleNoPropertiesInterfaceMsgBusClient::_OnHeartbeatTick), _HeartbeatIntervalMS / 1000.0f);
+#endif
 	}
 
 	_ConnectionStatusChanged.Broadcast(true);
+}
+
+bool UTbSimpleNoPropertiesInterfaceMsgBusClient::_OnHeartbeatTick(float /*DeltaTime*/)
+{
+	_OnHeartbeat();
+	return true;
 }
 
 void UTbSimpleNoPropertiesInterfaceMsgBusClient::_OnHeartbeat()

--- a/goldenmaster/Plugins/TbSimple/Source/TbSimple/Private/Generated/MsgBus/TbSimpleNoSignalsInterfaceMsgBusAdapter.cpp
+++ b/goldenmaster/Plugins/TbSimple/Source/TbSimple/Private/Generated/MsgBus/TbSimpleNoSignalsInterfaceMsgBusAdapter.cpp
@@ -25,7 +25,6 @@ limitations under the License.
 #include "Async/Future.h"
 #include "Async/Async.h"
 #include "Engine/World.h"
-#include "TimerManager.h"
 #include "MessageEndpoint.h"
 #include "MessageEndpointBuilder.h"
 #include "Misc/DateTime.h"
@@ -51,13 +50,17 @@ void UTbSimpleNoSignalsInterfaceMsgBusAdapter::Deinitialize()
 void UTbSimpleNoSignalsInterfaceMsgBusAdapter::_StartListening()
 {
 
-	if (!_HeartbeatTimerHandle.IsValid() && GetWorld())
+	if (!_HeartbeatTickerHandle.IsValid())
 	{
 		UTbSimpleSettings* settings = GetMutableDefault<UTbSimpleSettings>();
 		check(settings);
 		_HeartbeatIntervalMS = settings->MsgBusHeartbeatIntervalMS;
 
-		GetWorld()->GetTimerManager().SetTimer(_HeartbeatTimerHandle, this, &UTbSimpleNoSignalsInterfaceMsgBusAdapter::_CheckClientTimeouts, _HeartbeatIntervalMS / 1000.0f, true);
+#if (ENGINE_MAJOR_VERSION < 5)
+		_HeartbeatTickerHandle = FTicker::GetCoreTicker().AddTicker(FTickerDelegate::CreateUObject(this, &UTbSimpleNoSignalsInterfaceMsgBusAdapter::_CheckClientTimeoutsTick), _HeartbeatIntervalMS / 1000.0f);
+#else
+		_HeartbeatTickerHandle = FTSTicker::GetCoreTicker().AddTicker(FTickerDelegate::CreateUObject(this, &UTbSimpleNoSignalsInterfaceMsgBusAdapter::_CheckClientTimeoutsTick), _HeartbeatIntervalMS / 1000.0f);
+#endif
 	}
 
 	if (TbSimpleNoSignalsInterfaceMsgBusEndpoint.IsValid())
@@ -99,9 +102,13 @@ void UTbSimpleNoSignalsInterfaceMsgBusAdapter::_AnnounceService()
 
 void UTbSimpleNoSignalsInterfaceMsgBusAdapter::_StopListening()
 {
-	if (_HeartbeatTimerHandle.IsValid() && GetWorld())
+	if (_HeartbeatTickerHandle.IsValid())
 	{
-		GetWorld()->GetTimerManager().ClearTimer(_HeartbeatTimerHandle);
+#if (ENGINE_MAJOR_VERSION < 5)
+		FTicker::GetCoreTicker().RemoveTicker(_HeartbeatTickerHandle);
+#else
+		FTSTicker::GetCoreTicker().RemoveTicker(_HeartbeatTickerHandle);
+#endif
 	}
 
 	auto msg = new FTbSimpleNoSignalsInterfaceServiceDisconnectMessage();
@@ -244,6 +251,12 @@ void UTbSimpleNoSignalsInterfaceMsgBusAdapter::OnClientDisconnected(const FTbSim
 	ConnectedClientsTimestamps.Remove(Context->GetSender());
 	_OnClientDisconnected.Broadcast(Context->GetSender().ToString());
 	_UpdateClientsConnected();
+}
+
+bool UTbSimpleNoSignalsInterfaceMsgBusAdapter::_CheckClientTimeoutsTick(float /*DeltaTime*/)
+{
+	_CheckClientTimeouts();
+	return true;
 }
 
 void UTbSimpleNoSignalsInterfaceMsgBusAdapter::_CheckClientTimeouts()

--- a/goldenmaster/Plugins/TbSimple/Source/TbSimple/Private/Generated/MsgBus/TbSimpleNoSignalsInterfaceMsgBusAdapter.cpp
+++ b/goldenmaster/Plugins/TbSimple/Source/TbSimple/Private/Generated/MsgBus/TbSimpleNoSignalsInterfaceMsgBusAdapter.cpp
@@ -24,12 +24,12 @@ limitations under the License.
 #include "Generated/MsgBus/TbSimpleNoSignalsInterfaceMsgBusMessages.h"
 #include "Async/Future.h"
 #include "Async/Async.h"
-#include "Async/Async.h"
-#include "Engine/Engine.h"
+#include "Engine/World.h"
 #include "TimerManager.h"
 #include "MessageEndpoint.h"
 #include "MessageEndpointBuilder.h"
 #include "Misc/DateTime.h"
+#include "TbSimpleSettings.h"
 
 DEFINE_LOG_CATEGORY(LogTbSimpleNoSignalsInterfaceMsgBusAdapter);
 UTbSimpleNoSignalsInterfaceMsgBusAdapter::UTbSimpleNoSignalsInterfaceMsgBusAdapter()
@@ -53,6 +53,10 @@ void UTbSimpleNoSignalsInterfaceMsgBusAdapter::_StartListening()
 
 	if (!_HeartbeatTimerHandle.IsValid() && GetWorld())
 	{
+		UTbSimpleSettings* settings = GetMutableDefault<UTbSimpleSettings>();
+		check(settings);
+		_HeartbeatIntervalMS = settings->MsgBusHeartbeatIntervalMS;
+
 		GetWorld()->GetTimerManager().SetTimer(_HeartbeatTimerHandle, this, &UTbSimpleNoSignalsInterfaceMsgBusAdapter::_CheckClientTimeouts, _HeartbeatIntervalMS / 1000.0f, true);
 	}
 

--- a/goldenmaster/Plugins/TbSimple/Source/TbSimple/Private/Generated/MsgBus/TbSimpleNoSignalsInterfaceMsgBusClient.cpp
+++ b/goldenmaster/Plugins/TbSimple/Source/TbSimple/Private/Generated/MsgBus/TbSimpleNoSignalsInterfaceMsgBusClient.cpp
@@ -24,7 +24,6 @@ limitations under the License.
 #include "Generated/MsgBus/TbSimpleNoSignalsInterfaceMsgBusMessages.h"
 #include "Async/Async.h"
 #include "Engine/World.h"
-#include "TimerManager.h"
 #include "Misc/DateTime.h"
 #include "GenericPlatform/GenericPlatformMath.h"
 #include "GenericPlatform/GenericPlatformTime.h"
@@ -66,19 +65,25 @@ void UTbSimpleNoSignalsInterfaceMsgBusClient::Deinitialize()
 
 void UTbSimpleNoSignalsInterfaceMsgBusClient::_Connect()
 {
-	if (!_HeartbeatTimerHandle.IsValid() && GetWorld())
+	if (_IsConnected())
+	{
+		UE_LOG(LogTbSimpleNoSignalsInterfaceMsgBusClient, Log, TEXT("Already connected, cannot connect again."));
+		return;
+	}
+
+	if (!_HeartbeatTickerHandle.IsValid())
 	{
 		UTbSimpleSettings* settings = GetMutableDefault<UTbSimpleSettings>();
 		check(settings);
 		_HeartbeatIntervalMS = settings->MsgBusHeartbeatIntervalMS;
 
-		GetWorld()->GetTimerManager().SetTimer(_HeartbeatTimerHandle, this, &UTbSimpleNoSignalsInterfaceMsgBusClient::_OnHeartbeat, _HeartbeatIntervalMS / 1000.0f, true);
-	}
-
-	if (_IsConnected())
-	{
-		UE_LOG(LogTbSimpleNoSignalsInterfaceMsgBusClient, Log, TEXT("Already connected, cannot connect again."));
-		return;
+#if (ENGINE_MAJOR_VERSION < 5)
+		FTicker::GetCoreTicker().RemoveTicker(_HeartbeatTickerHandle);
+		_HeartbeatTickerHandle = FTicker::GetCoreTicker().AddTicker(FTickerDelegate::CreateUObject(this, &UTbSimpleNoSignalsInterfaceMsgBusClient::_OnHeartbeatTick), _HeartbeatIntervalMS / 1000.0f);
+#else
+		FTSTicker::GetCoreTicker().RemoveTicker(_HeartbeatTickerHandle);
+		_HeartbeatTickerHandle = FTSTicker::GetCoreTicker().AddTicker(FTickerDelegate::CreateUObject(this, &UTbSimpleNoSignalsInterfaceMsgBusClient::_OnHeartbeatTick), _HeartbeatIntervalMS / 1000.0f);
+#endif
 	}
 
 	if (TbSimpleNoSignalsInterfaceMsgBusEndpoint.IsValid() && !ServiceAddress.IsValid())
@@ -104,10 +109,12 @@ void UTbSimpleNoSignalsInterfaceMsgBusClient::_Connect()
 void UTbSimpleNoSignalsInterfaceMsgBusClient::_Disconnect()
 {
 	_LastHbTimestamp = 0.0f;
-	if (_HeartbeatTimerHandle.IsValid() && GetWorld())
-	{
-		GetWorld()->GetTimerManager().ClearTimer(_HeartbeatTimerHandle);
-	}
+
+#if (ENGINE_MAJOR_VERSION < 5)
+	FTicker::GetCoreTicker().RemoveTicker(_HeartbeatTickerHandle);
+#else
+	FTSTicker::GetCoreTicker().RemoveTicker(_HeartbeatTickerHandle);
+#endif
 
 	if (!_IsConnected())
 	{
@@ -168,15 +175,13 @@ void UTbSimpleNoSignalsInterfaceMsgBusClient::OnConnectionInit(const FTbSimpleNo
 	{
 		_HeartbeatIntervalMS = InMessage._ClientPingIntervalMS;
 
-		if (_HeartbeatTimerHandle.IsValid() && GetWorld())
-		{
-			GetWorld()->GetTimerManager().ClearTimer(_HeartbeatTimerHandle);
-		}
-
-		if (!_HeartbeatTimerHandle.IsValid() && GetWorld())
-		{
-			GetWorld()->GetTimerManager().SetTimer(_HeartbeatTimerHandle, this, &UTbSimpleNoSignalsInterfaceMsgBusClient::_OnHeartbeat, _HeartbeatIntervalMS / 1000.0f, true);
-		}
+#if (ENGINE_MAJOR_VERSION < 5)
+		FTicker::GetCoreTicker().RemoveTicker(_HeartbeatTickerHandle);
+		_HeartbeatTickerHandle = FTicker::GetCoreTicker().AddTicker(FTickerDelegate::CreateUObject(this, &UTbSimpleNoSignalsInterfaceMsgBusClient::_OnHeartbeatTick), _HeartbeatIntervalMS / 1000.0f);
+#else
+		FTSTicker::GetCoreTicker().RemoveTicker(_HeartbeatTickerHandle);
+		_HeartbeatTickerHandle = FTSTicker::GetCoreTicker().AddTicker(FTickerDelegate::CreateUObject(this, &UTbSimpleNoSignalsInterfaceMsgBusClient::_OnHeartbeatTick), _HeartbeatIntervalMS / 1000.0f);
+#endif
 	}
 	const bool bbPropBoolChanged = InMessage.bPropBool != bPropBool;
 	if (bbPropBoolChanged)
@@ -193,6 +198,12 @@ void UTbSimpleNoSignalsInterfaceMsgBusClient::OnConnectionInit(const FTbSimpleNo
 	}
 
 	_ConnectionStatusChanged.Broadcast(true);
+}
+
+bool UTbSimpleNoSignalsInterfaceMsgBusClient::_OnHeartbeatTick(float /*DeltaTime*/)
+{
+	_OnHeartbeat();
+	return true;
 }
 
 void UTbSimpleNoSignalsInterfaceMsgBusClient::_OnHeartbeat()

--- a/goldenmaster/Plugins/TbSimple/Source/TbSimple/Private/Generated/MsgBus/TbSimpleNoSignalsInterfaceMsgBusClient.cpp
+++ b/goldenmaster/Plugins/TbSimple/Source/TbSimple/Private/Generated/MsgBus/TbSimpleNoSignalsInterfaceMsgBusClient.cpp
@@ -23,13 +23,14 @@ limitations under the License.
 #include "Generated/MsgBus/TbSimpleNoSignalsInterfaceMsgBusClient.h"
 #include "Generated/MsgBus/TbSimpleNoSignalsInterfaceMsgBusMessages.h"
 #include "Async/Async.h"
-#include "Engine/Engine.h"
+#include "Engine/World.h"
 #include "TimerManager.h"
 #include "Misc/DateTime.h"
 #include "GenericPlatform/GenericPlatformMath.h"
 #include "GenericPlatform/GenericPlatformTime.h"
 #include "MessageEndpointBuilder.h"
 #include "MessageEndpoint.h"
+#include "TbSimpleSettings.h"
 #include <atomic>
 
 /**
@@ -67,6 +68,10 @@ void UTbSimpleNoSignalsInterfaceMsgBusClient::_Connect()
 {
 	if (!_HeartbeatTimerHandle.IsValid() && GetWorld())
 	{
+		UTbSimpleSettings* settings = GetMutableDefault<UTbSimpleSettings>();
+		check(settings);
+		_HeartbeatIntervalMS = settings->MsgBusHeartbeatIntervalMS;
+
 		GetWorld()->GetTimerManager().SetTimer(_HeartbeatTimerHandle, this, &UTbSimpleNoSignalsInterfaceMsgBusClient::_OnHeartbeat, _HeartbeatIntervalMS / 1000.0f, true);
 	}
 

--- a/goldenmaster/Plugins/TbSimple/Source/TbSimple/Private/Generated/MsgBus/TbSimpleSimpleArrayInterfaceMsgBusAdapter.cpp
+++ b/goldenmaster/Plugins/TbSimple/Source/TbSimple/Private/Generated/MsgBus/TbSimpleSimpleArrayInterfaceMsgBusAdapter.cpp
@@ -24,12 +24,12 @@ limitations under the License.
 #include "Generated/MsgBus/TbSimpleSimpleArrayInterfaceMsgBusMessages.h"
 #include "Async/Future.h"
 #include "Async/Async.h"
-#include "Async/Async.h"
-#include "Engine/Engine.h"
+#include "Engine/World.h"
 #include "TimerManager.h"
 #include "MessageEndpoint.h"
 #include "MessageEndpointBuilder.h"
 #include "Misc/DateTime.h"
+#include "TbSimpleSettings.h"
 
 DEFINE_LOG_CATEGORY(LogTbSimpleSimpleArrayInterfaceMsgBusAdapter);
 UTbSimpleSimpleArrayInterfaceMsgBusAdapter::UTbSimpleSimpleArrayInterfaceMsgBusAdapter()
@@ -53,6 +53,10 @@ void UTbSimpleSimpleArrayInterfaceMsgBusAdapter::_StartListening()
 
 	if (!_HeartbeatTimerHandle.IsValid() && GetWorld())
 	{
+		UTbSimpleSettings* settings = GetMutableDefault<UTbSimpleSettings>();
+		check(settings);
+		_HeartbeatIntervalMS = settings->MsgBusHeartbeatIntervalMS;
+
 		GetWorld()->GetTimerManager().SetTimer(_HeartbeatTimerHandle, this, &UTbSimpleSimpleArrayInterfaceMsgBusAdapter::_CheckClientTimeouts, _HeartbeatIntervalMS / 1000.0f, true);
 	}
 

--- a/goldenmaster/Plugins/TbSimple/Source/TbSimple/Private/Generated/MsgBus/TbSimpleSimpleArrayInterfaceMsgBusAdapter.cpp
+++ b/goldenmaster/Plugins/TbSimple/Source/TbSimple/Private/Generated/MsgBus/TbSimpleSimpleArrayInterfaceMsgBusAdapter.cpp
@@ -25,7 +25,6 @@ limitations under the License.
 #include "Async/Future.h"
 #include "Async/Async.h"
 #include "Engine/World.h"
-#include "TimerManager.h"
 #include "MessageEndpoint.h"
 #include "MessageEndpointBuilder.h"
 #include "Misc/DateTime.h"
@@ -51,13 +50,17 @@ void UTbSimpleSimpleArrayInterfaceMsgBusAdapter::Deinitialize()
 void UTbSimpleSimpleArrayInterfaceMsgBusAdapter::_StartListening()
 {
 
-	if (!_HeartbeatTimerHandle.IsValid() && GetWorld())
+	if (!_HeartbeatTickerHandle.IsValid())
 	{
 		UTbSimpleSettings* settings = GetMutableDefault<UTbSimpleSettings>();
 		check(settings);
 		_HeartbeatIntervalMS = settings->MsgBusHeartbeatIntervalMS;
 
-		GetWorld()->GetTimerManager().SetTimer(_HeartbeatTimerHandle, this, &UTbSimpleSimpleArrayInterfaceMsgBusAdapter::_CheckClientTimeouts, _HeartbeatIntervalMS / 1000.0f, true);
+#if (ENGINE_MAJOR_VERSION < 5)
+		_HeartbeatTickerHandle = FTicker::GetCoreTicker().AddTicker(FTickerDelegate::CreateUObject(this, &UTbSimpleSimpleArrayInterfaceMsgBusAdapter::_CheckClientTimeoutsTick), _HeartbeatIntervalMS / 1000.0f);
+#else
+		_HeartbeatTickerHandle = FTSTicker::GetCoreTicker().AddTicker(FTickerDelegate::CreateUObject(this, &UTbSimpleSimpleArrayInterfaceMsgBusAdapter::_CheckClientTimeoutsTick), _HeartbeatIntervalMS / 1000.0f);
+#endif
 	}
 
 	if (TbSimpleSimpleArrayInterfaceMsgBusEndpoint.IsValid())
@@ -111,9 +114,13 @@ void UTbSimpleSimpleArrayInterfaceMsgBusAdapter::_AnnounceService()
 
 void UTbSimpleSimpleArrayInterfaceMsgBusAdapter::_StopListening()
 {
-	if (_HeartbeatTimerHandle.IsValid() && GetWorld())
+	if (_HeartbeatTickerHandle.IsValid())
 	{
-		GetWorld()->GetTimerManager().ClearTimer(_HeartbeatTimerHandle);
+#if (ENGINE_MAJOR_VERSION < 5)
+		FTicker::GetCoreTicker().RemoveTicker(_HeartbeatTickerHandle);
+#else
+		FTSTicker::GetCoreTicker().RemoveTicker(_HeartbeatTickerHandle);
+#endif
 	}
 
 	auto msg = new FTbSimpleSimpleArrayInterfaceServiceDisconnectMessage();
@@ -293,6 +300,12 @@ void UTbSimpleSimpleArrayInterfaceMsgBusAdapter::OnClientDisconnected(const FTbS
 	ConnectedClientsTimestamps.Remove(Context->GetSender());
 	_OnClientDisconnected.Broadcast(Context->GetSender().ToString());
 	_UpdateClientsConnected();
+}
+
+bool UTbSimpleSimpleArrayInterfaceMsgBusAdapter::_CheckClientTimeoutsTick(float /*DeltaTime*/)
+{
+	_CheckClientTimeouts();
+	return true;
 }
 
 void UTbSimpleSimpleArrayInterfaceMsgBusAdapter::_CheckClientTimeouts()

--- a/goldenmaster/Plugins/TbSimple/Source/TbSimple/Private/Generated/MsgBus/TbSimpleSimpleArrayInterfaceMsgBusClient.cpp
+++ b/goldenmaster/Plugins/TbSimple/Source/TbSimple/Private/Generated/MsgBus/TbSimpleSimpleArrayInterfaceMsgBusClient.cpp
@@ -24,7 +24,6 @@ limitations under the License.
 #include "Generated/MsgBus/TbSimpleSimpleArrayInterfaceMsgBusMessages.h"
 #include "Async/Async.h"
 #include "Engine/World.h"
-#include "TimerManager.h"
 #include "Misc/DateTime.h"
 #include "GenericPlatform/GenericPlatformMath.h"
 #include "GenericPlatform/GenericPlatformTime.h"
@@ -82,19 +81,25 @@ void UTbSimpleSimpleArrayInterfaceMsgBusClient::Deinitialize()
 
 void UTbSimpleSimpleArrayInterfaceMsgBusClient::_Connect()
 {
-	if (!_HeartbeatTimerHandle.IsValid() && GetWorld())
+	if (_IsConnected())
+	{
+		UE_LOG(LogTbSimpleSimpleArrayInterfaceMsgBusClient, Log, TEXT("Already connected, cannot connect again."));
+		return;
+	}
+
+	if (!_HeartbeatTickerHandle.IsValid())
 	{
 		UTbSimpleSettings* settings = GetMutableDefault<UTbSimpleSettings>();
 		check(settings);
 		_HeartbeatIntervalMS = settings->MsgBusHeartbeatIntervalMS;
 
-		GetWorld()->GetTimerManager().SetTimer(_HeartbeatTimerHandle, this, &UTbSimpleSimpleArrayInterfaceMsgBusClient::_OnHeartbeat, _HeartbeatIntervalMS / 1000.0f, true);
-	}
-
-	if (_IsConnected())
-	{
-		UE_LOG(LogTbSimpleSimpleArrayInterfaceMsgBusClient, Log, TEXT("Already connected, cannot connect again."));
-		return;
+#if (ENGINE_MAJOR_VERSION < 5)
+		FTicker::GetCoreTicker().RemoveTicker(_HeartbeatTickerHandle);
+		_HeartbeatTickerHandle = FTicker::GetCoreTicker().AddTicker(FTickerDelegate::CreateUObject(this, &UTbSimpleSimpleArrayInterfaceMsgBusClient::_OnHeartbeatTick), _HeartbeatIntervalMS / 1000.0f);
+#else
+		FTSTicker::GetCoreTicker().RemoveTicker(_HeartbeatTickerHandle);
+		_HeartbeatTickerHandle = FTSTicker::GetCoreTicker().AddTicker(FTickerDelegate::CreateUObject(this, &UTbSimpleSimpleArrayInterfaceMsgBusClient::_OnHeartbeatTick), _HeartbeatIntervalMS / 1000.0f);
+#endif
 	}
 
 	if (TbSimpleSimpleArrayInterfaceMsgBusEndpoint.IsValid() && !ServiceAddress.IsValid())
@@ -142,10 +147,12 @@ void UTbSimpleSimpleArrayInterfaceMsgBusClient::_Connect()
 void UTbSimpleSimpleArrayInterfaceMsgBusClient::_Disconnect()
 {
 	_LastHbTimestamp = 0.0f;
-	if (_HeartbeatTimerHandle.IsValid() && GetWorld())
-	{
-		GetWorld()->GetTimerManager().ClearTimer(_HeartbeatTimerHandle);
-	}
+
+#if (ENGINE_MAJOR_VERSION < 5)
+	FTicker::GetCoreTicker().RemoveTicker(_HeartbeatTickerHandle);
+#else
+	FTSTicker::GetCoreTicker().RemoveTicker(_HeartbeatTickerHandle);
+#endif
 
 	if (!_IsConnected())
 	{
@@ -206,15 +213,13 @@ void UTbSimpleSimpleArrayInterfaceMsgBusClient::OnConnectionInit(const FTbSimple
 	{
 		_HeartbeatIntervalMS = InMessage._ClientPingIntervalMS;
 
-		if (_HeartbeatTimerHandle.IsValid() && GetWorld())
-		{
-			GetWorld()->GetTimerManager().ClearTimer(_HeartbeatTimerHandle);
-		}
-
-		if (!_HeartbeatTimerHandle.IsValid() && GetWorld())
-		{
-			GetWorld()->GetTimerManager().SetTimer(_HeartbeatTimerHandle, this, &UTbSimpleSimpleArrayInterfaceMsgBusClient::_OnHeartbeat, _HeartbeatIntervalMS / 1000.0f, true);
-		}
+#if (ENGINE_MAJOR_VERSION < 5)
+		FTicker::GetCoreTicker().RemoveTicker(_HeartbeatTickerHandle);
+		_HeartbeatTickerHandle = FTicker::GetCoreTicker().AddTicker(FTickerDelegate::CreateUObject(this, &UTbSimpleSimpleArrayInterfaceMsgBusClient::_OnHeartbeatTick), _HeartbeatIntervalMS / 1000.0f);
+#else
+		FTSTicker::GetCoreTicker().RemoveTicker(_HeartbeatTickerHandle);
+		_HeartbeatTickerHandle = FTSTicker::GetCoreTicker().AddTicker(FTickerDelegate::CreateUObject(this, &UTbSimpleSimpleArrayInterfaceMsgBusClient::_OnHeartbeatTick), _HeartbeatIntervalMS / 1000.0f);
+#endif
 	}
 	const bool bPropBoolChanged = InMessage.PropBool != PropBool;
 	if (bPropBoolChanged)
@@ -280,6 +285,12 @@ void UTbSimpleSimpleArrayInterfaceMsgBusClient::OnConnectionInit(const FTbSimple
 	}
 
 	_ConnectionStatusChanged.Broadcast(true);
+}
+
+bool UTbSimpleSimpleArrayInterfaceMsgBusClient::_OnHeartbeatTick(float /*DeltaTime*/)
+{
+	_OnHeartbeat();
+	return true;
 }
 
 void UTbSimpleSimpleArrayInterfaceMsgBusClient::_OnHeartbeat()

--- a/goldenmaster/Plugins/TbSimple/Source/TbSimple/Private/Generated/MsgBus/TbSimpleSimpleArrayInterfaceMsgBusClient.cpp
+++ b/goldenmaster/Plugins/TbSimple/Source/TbSimple/Private/Generated/MsgBus/TbSimpleSimpleArrayInterfaceMsgBusClient.cpp
@@ -23,13 +23,14 @@ limitations under the License.
 #include "Generated/MsgBus/TbSimpleSimpleArrayInterfaceMsgBusClient.h"
 #include "Generated/MsgBus/TbSimpleSimpleArrayInterfaceMsgBusMessages.h"
 #include "Async/Async.h"
-#include "Engine/Engine.h"
+#include "Engine/World.h"
 #include "TimerManager.h"
 #include "Misc/DateTime.h"
 #include "GenericPlatform/GenericPlatformMath.h"
 #include "GenericPlatform/GenericPlatformTime.h"
 #include "MessageEndpointBuilder.h"
 #include "MessageEndpoint.h"
+#include "TbSimpleSettings.h"
 #include "HAL/CriticalSection.h"
 
 /**
@@ -83,6 +84,10 @@ void UTbSimpleSimpleArrayInterfaceMsgBusClient::_Connect()
 {
 	if (!_HeartbeatTimerHandle.IsValid() && GetWorld())
 	{
+		UTbSimpleSettings* settings = GetMutableDefault<UTbSimpleSettings>();
+		check(settings);
+		_HeartbeatIntervalMS = settings->MsgBusHeartbeatIntervalMS;
+
 		GetWorld()->GetTimerManager().SetTimer(_HeartbeatTimerHandle, this, &UTbSimpleSimpleArrayInterfaceMsgBusClient::_OnHeartbeat, _HeartbeatIntervalMS / 1000.0f, true);
 	}
 

--- a/goldenmaster/Plugins/TbSimple/Source/TbSimple/Private/Generated/MsgBus/TbSimpleSimpleInterfaceMsgBusAdapter.cpp
+++ b/goldenmaster/Plugins/TbSimple/Source/TbSimple/Private/Generated/MsgBus/TbSimpleSimpleInterfaceMsgBusAdapter.cpp
@@ -24,12 +24,12 @@ limitations under the License.
 #include "Generated/MsgBus/TbSimpleSimpleInterfaceMsgBusMessages.h"
 #include "Async/Future.h"
 #include "Async/Async.h"
-#include "Async/Async.h"
-#include "Engine/Engine.h"
+#include "Engine/World.h"
 #include "TimerManager.h"
 #include "MessageEndpoint.h"
 #include "MessageEndpointBuilder.h"
 #include "Misc/DateTime.h"
+#include "TbSimpleSettings.h"
 
 DEFINE_LOG_CATEGORY(LogTbSimpleSimpleInterfaceMsgBusAdapter);
 UTbSimpleSimpleInterfaceMsgBusAdapter::UTbSimpleSimpleInterfaceMsgBusAdapter()
@@ -53,6 +53,10 @@ void UTbSimpleSimpleInterfaceMsgBusAdapter::_StartListening()
 
 	if (!_HeartbeatTimerHandle.IsValid() && GetWorld())
 	{
+		UTbSimpleSettings* settings = GetMutableDefault<UTbSimpleSettings>();
+		check(settings);
+		_HeartbeatIntervalMS = settings->MsgBusHeartbeatIntervalMS;
+
 		GetWorld()->GetTimerManager().SetTimer(_HeartbeatTimerHandle, this, &UTbSimpleSimpleInterfaceMsgBusAdapter::_CheckClientTimeouts, _HeartbeatIntervalMS / 1000.0f, true);
 	}
 

--- a/goldenmaster/Plugins/TbSimple/Source/TbSimple/Private/Generated/MsgBus/TbSimpleSimpleInterfaceMsgBusAdapter.cpp
+++ b/goldenmaster/Plugins/TbSimple/Source/TbSimple/Private/Generated/MsgBus/TbSimpleSimpleInterfaceMsgBusAdapter.cpp
@@ -25,7 +25,6 @@ limitations under the License.
 #include "Async/Future.h"
 #include "Async/Async.h"
 #include "Engine/World.h"
-#include "TimerManager.h"
 #include "MessageEndpoint.h"
 #include "MessageEndpointBuilder.h"
 #include "Misc/DateTime.h"
@@ -51,13 +50,17 @@ void UTbSimpleSimpleInterfaceMsgBusAdapter::Deinitialize()
 void UTbSimpleSimpleInterfaceMsgBusAdapter::_StartListening()
 {
 
-	if (!_HeartbeatTimerHandle.IsValid() && GetWorld())
+	if (!_HeartbeatTickerHandle.IsValid())
 	{
 		UTbSimpleSettings* settings = GetMutableDefault<UTbSimpleSettings>();
 		check(settings);
 		_HeartbeatIntervalMS = settings->MsgBusHeartbeatIntervalMS;
 
-		GetWorld()->GetTimerManager().SetTimer(_HeartbeatTimerHandle, this, &UTbSimpleSimpleInterfaceMsgBusAdapter::_CheckClientTimeouts, _HeartbeatIntervalMS / 1000.0f, true);
+#if (ENGINE_MAJOR_VERSION < 5)
+		_HeartbeatTickerHandle = FTicker::GetCoreTicker().AddTicker(FTickerDelegate::CreateUObject(this, &UTbSimpleSimpleInterfaceMsgBusAdapter::_CheckClientTimeoutsTick), _HeartbeatIntervalMS / 1000.0f);
+#else
+		_HeartbeatTickerHandle = FTSTicker::GetCoreTicker().AddTicker(FTickerDelegate::CreateUObject(this, &UTbSimpleSimpleInterfaceMsgBusAdapter::_CheckClientTimeoutsTick), _HeartbeatIntervalMS / 1000.0f);
+#endif
 	}
 
 	if (TbSimpleSimpleInterfaceMsgBusEndpoint.IsValid())
@@ -112,9 +115,13 @@ void UTbSimpleSimpleInterfaceMsgBusAdapter::_AnnounceService()
 
 void UTbSimpleSimpleInterfaceMsgBusAdapter::_StopListening()
 {
-	if (_HeartbeatTimerHandle.IsValid() && GetWorld())
+	if (_HeartbeatTickerHandle.IsValid())
 	{
-		GetWorld()->GetTimerManager().ClearTimer(_HeartbeatTimerHandle);
+#if (ENGINE_MAJOR_VERSION < 5)
+		FTicker::GetCoreTicker().RemoveTicker(_HeartbeatTickerHandle);
+#else
+		FTSTicker::GetCoreTicker().RemoveTicker(_HeartbeatTickerHandle);
+#endif
 	}
 
 	auto msg = new FTbSimpleSimpleInterfaceServiceDisconnectMessage();
@@ -291,6 +298,12 @@ void UTbSimpleSimpleInterfaceMsgBusAdapter::OnClientDisconnected(const FTbSimple
 	ConnectedClientsTimestamps.Remove(Context->GetSender());
 	_OnClientDisconnected.Broadcast(Context->GetSender().ToString());
 	_UpdateClientsConnected();
+}
+
+bool UTbSimpleSimpleInterfaceMsgBusAdapter::_CheckClientTimeoutsTick(float /*DeltaTime*/)
+{
+	_CheckClientTimeouts();
+	return true;
 }
 
 void UTbSimpleSimpleInterfaceMsgBusAdapter::_CheckClientTimeouts()

--- a/goldenmaster/Plugins/TbSimple/Source/TbSimple/Private/Generated/MsgBus/TbSimpleSimpleInterfaceMsgBusClient.cpp
+++ b/goldenmaster/Plugins/TbSimple/Source/TbSimple/Private/Generated/MsgBus/TbSimpleSimpleInterfaceMsgBusClient.cpp
@@ -24,7 +24,6 @@ limitations under the License.
 #include "Generated/MsgBus/TbSimpleSimpleInterfaceMsgBusMessages.h"
 #include "Async/Async.h"
 #include "Engine/World.h"
-#include "TimerManager.h"
 #include "Misc/DateTime.h"
 #include "GenericPlatform/GenericPlatformMath.h"
 #include "GenericPlatform/GenericPlatformTime.h"
@@ -74,19 +73,25 @@ void UTbSimpleSimpleInterfaceMsgBusClient::Deinitialize()
 
 void UTbSimpleSimpleInterfaceMsgBusClient::_Connect()
 {
-	if (!_HeartbeatTimerHandle.IsValid() && GetWorld())
+	if (_IsConnected())
+	{
+		UE_LOG(LogTbSimpleSimpleInterfaceMsgBusClient, Log, TEXT("Already connected, cannot connect again."));
+		return;
+	}
+
+	if (!_HeartbeatTickerHandle.IsValid())
 	{
 		UTbSimpleSettings* settings = GetMutableDefault<UTbSimpleSettings>();
 		check(settings);
 		_HeartbeatIntervalMS = settings->MsgBusHeartbeatIntervalMS;
 
-		GetWorld()->GetTimerManager().SetTimer(_HeartbeatTimerHandle, this, &UTbSimpleSimpleInterfaceMsgBusClient::_OnHeartbeat, _HeartbeatIntervalMS / 1000.0f, true);
-	}
-
-	if (_IsConnected())
-	{
-		UE_LOG(LogTbSimpleSimpleInterfaceMsgBusClient, Log, TEXT("Already connected, cannot connect again."));
-		return;
+#if (ENGINE_MAJOR_VERSION < 5)
+		FTicker::GetCoreTicker().RemoveTicker(_HeartbeatTickerHandle);
+		_HeartbeatTickerHandle = FTicker::GetCoreTicker().AddTicker(FTickerDelegate::CreateUObject(this, &UTbSimpleSimpleInterfaceMsgBusClient::_OnHeartbeatTick), _HeartbeatIntervalMS / 1000.0f);
+#else
+		FTSTicker::GetCoreTicker().RemoveTicker(_HeartbeatTickerHandle);
+		_HeartbeatTickerHandle = FTSTicker::GetCoreTicker().AddTicker(FTickerDelegate::CreateUObject(this, &UTbSimpleSimpleInterfaceMsgBusClient::_OnHeartbeatTick), _HeartbeatIntervalMS / 1000.0f);
+#endif
 	}
 
 	if (TbSimpleSimpleInterfaceMsgBusEndpoint.IsValid() && !ServiceAddress.IsValid())
@@ -133,10 +138,12 @@ void UTbSimpleSimpleInterfaceMsgBusClient::_Connect()
 void UTbSimpleSimpleInterfaceMsgBusClient::_Disconnect()
 {
 	_LastHbTimestamp = 0.0f;
-	if (_HeartbeatTimerHandle.IsValid() && GetWorld())
-	{
-		GetWorld()->GetTimerManager().ClearTimer(_HeartbeatTimerHandle);
-	}
+
+#if (ENGINE_MAJOR_VERSION < 5)
+	FTicker::GetCoreTicker().RemoveTicker(_HeartbeatTickerHandle);
+#else
+	FTSTicker::GetCoreTicker().RemoveTicker(_HeartbeatTickerHandle);
+#endif
 
 	if (!_IsConnected())
 	{
@@ -197,15 +204,13 @@ void UTbSimpleSimpleInterfaceMsgBusClient::OnConnectionInit(const FTbSimpleSimpl
 	{
 		_HeartbeatIntervalMS = InMessage._ClientPingIntervalMS;
 
-		if (_HeartbeatTimerHandle.IsValid() && GetWorld())
-		{
-			GetWorld()->GetTimerManager().ClearTimer(_HeartbeatTimerHandle);
-		}
-
-		if (!_HeartbeatTimerHandle.IsValid() && GetWorld())
-		{
-			GetWorld()->GetTimerManager().SetTimer(_HeartbeatTimerHandle, this, &UTbSimpleSimpleInterfaceMsgBusClient::_OnHeartbeat, _HeartbeatIntervalMS / 1000.0f, true);
-		}
+#if (ENGINE_MAJOR_VERSION < 5)
+		FTicker::GetCoreTicker().RemoveTicker(_HeartbeatTickerHandle);
+		_HeartbeatTickerHandle = FTicker::GetCoreTicker().AddTicker(FTickerDelegate::CreateUObject(this, &UTbSimpleSimpleInterfaceMsgBusClient::_OnHeartbeatTick), _HeartbeatIntervalMS / 1000.0f);
+#else
+		FTSTicker::GetCoreTicker().RemoveTicker(_HeartbeatTickerHandle);
+		_HeartbeatTickerHandle = FTSTicker::GetCoreTicker().AddTicker(FTickerDelegate::CreateUObject(this, &UTbSimpleSimpleInterfaceMsgBusClient::_OnHeartbeatTick), _HeartbeatIntervalMS / 1000.0f);
+#endif
 	}
 	const bool bbPropBoolChanged = InMessage.bPropBool != bPropBool;
 	if (bbPropBoolChanged)
@@ -264,6 +269,12 @@ void UTbSimpleSimpleInterfaceMsgBusClient::OnConnectionInit(const FTbSimpleSimpl
 	}
 
 	_ConnectionStatusChanged.Broadcast(true);
+}
+
+bool UTbSimpleSimpleInterfaceMsgBusClient::_OnHeartbeatTick(float /*DeltaTime*/)
+{
+	_OnHeartbeat();
+	return true;
 }
 
 void UTbSimpleSimpleInterfaceMsgBusClient::_OnHeartbeat()

--- a/goldenmaster/Plugins/TbSimple/Source/TbSimple/Private/Generated/MsgBus/TbSimpleSimpleInterfaceMsgBusClient.cpp
+++ b/goldenmaster/Plugins/TbSimple/Source/TbSimple/Private/Generated/MsgBus/TbSimpleSimpleInterfaceMsgBusClient.cpp
@@ -23,13 +23,14 @@ limitations under the License.
 #include "Generated/MsgBus/TbSimpleSimpleInterfaceMsgBusClient.h"
 #include "Generated/MsgBus/TbSimpleSimpleInterfaceMsgBusMessages.h"
 #include "Async/Async.h"
-#include "Engine/Engine.h"
+#include "Engine/World.h"
 #include "TimerManager.h"
 #include "Misc/DateTime.h"
 #include "GenericPlatform/GenericPlatformMath.h"
 #include "GenericPlatform/GenericPlatformTime.h"
 #include "MessageEndpointBuilder.h"
 #include "MessageEndpoint.h"
+#include "TbSimpleSettings.h"
 #include <atomic>
 #include "HAL/CriticalSection.h"
 
@@ -75,6 +76,10 @@ void UTbSimpleSimpleInterfaceMsgBusClient::_Connect()
 {
 	if (!_HeartbeatTimerHandle.IsValid() && GetWorld())
 	{
+		UTbSimpleSettings* settings = GetMutableDefault<UTbSimpleSettings>();
+		check(settings);
+		_HeartbeatIntervalMS = settings->MsgBusHeartbeatIntervalMS;
+
 		GetWorld()->GetTimerManager().SetTimer(_HeartbeatTimerHandle, this, &UTbSimpleSimpleInterfaceMsgBusClient::_OnHeartbeat, _HeartbeatIntervalMS / 1000.0f, true);
 	}
 

--- a/goldenmaster/Plugins/TbSimple/Source/TbSimple/Private/Generated/MsgBus/TbSimpleVoidInterfaceMsgBusAdapter.cpp
+++ b/goldenmaster/Plugins/TbSimple/Source/TbSimple/Private/Generated/MsgBus/TbSimpleVoidInterfaceMsgBusAdapter.cpp
@@ -24,12 +24,12 @@ limitations under the License.
 #include "Generated/MsgBus/TbSimpleVoidInterfaceMsgBusMessages.h"
 #include "Async/Future.h"
 #include "Async/Async.h"
-#include "Async/Async.h"
-#include "Engine/Engine.h"
+#include "Engine/World.h"
 #include "TimerManager.h"
 #include "MessageEndpoint.h"
 #include "MessageEndpointBuilder.h"
 #include "Misc/DateTime.h"
+#include "TbSimpleSettings.h"
 
 DEFINE_LOG_CATEGORY(LogTbSimpleVoidInterfaceMsgBusAdapter);
 UTbSimpleVoidInterfaceMsgBusAdapter::UTbSimpleVoidInterfaceMsgBusAdapter()
@@ -53,6 +53,10 @@ void UTbSimpleVoidInterfaceMsgBusAdapter::_StartListening()
 
 	if (!_HeartbeatTimerHandle.IsValid() && GetWorld())
 	{
+		UTbSimpleSettings* settings = GetMutableDefault<UTbSimpleSettings>();
+		check(settings);
+		_HeartbeatIntervalMS = settings->MsgBusHeartbeatIntervalMS;
+
 		GetWorld()->GetTimerManager().SetTimer(_HeartbeatTimerHandle, this, &UTbSimpleVoidInterfaceMsgBusAdapter::_CheckClientTimeouts, _HeartbeatIntervalMS / 1000.0f, true);
 	}
 

--- a/goldenmaster/Plugins/TbSimple/Source/TbSimple/Private/Generated/MsgBus/TbSimpleVoidInterfaceMsgBusAdapter.cpp
+++ b/goldenmaster/Plugins/TbSimple/Source/TbSimple/Private/Generated/MsgBus/TbSimpleVoidInterfaceMsgBusAdapter.cpp
@@ -25,7 +25,6 @@ limitations under the License.
 #include "Async/Future.h"
 #include "Async/Async.h"
 #include "Engine/World.h"
-#include "TimerManager.h"
 #include "MessageEndpoint.h"
 #include "MessageEndpointBuilder.h"
 #include "Misc/DateTime.h"
@@ -51,13 +50,17 @@ void UTbSimpleVoidInterfaceMsgBusAdapter::Deinitialize()
 void UTbSimpleVoidInterfaceMsgBusAdapter::_StartListening()
 {
 
-	if (!_HeartbeatTimerHandle.IsValid() && GetWorld())
+	if (!_HeartbeatTickerHandle.IsValid())
 	{
 		UTbSimpleSettings* settings = GetMutableDefault<UTbSimpleSettings>();
 		check(settings);
 		_HeartbeatIntervalMS = settings->MsgBusHeartbeatIntervalMS;
 
-		GetWorld()->GetTimerManager().SetTimer(_HeartbeatTimerHandle, this, &UTbSimpleVoidInterfaceMsgBusAdapter::_CheckClientTimeouts, _HeartbeatIntervalMS / 1000.0f, true);
+#if (ENGINE_MAJOR_VERSION < 5)
+		_HeartbeatTickerHandle = FTicker::GetCoreTicker().AddTicker(FTickerDelegate::CreateUObject(this, &UTbSimpleVoidInterfaceMsgBusAdapter::_CheckClientTimeoutsTick), _HeartbeatIntervalMS / 1000.0f);
+#else
+		_HeartbeatTickerHandle = FTSTicker::GetCoreTicker().AddTicker(FTickerDelegate::CreateUObject(this, &UTbSimpleVoidInterfaceMsgBusAdapter::_CheckClientTimeoutsTick), _HeartbeatIntervalMS / 1000.0f);
+#endif
 	}
 
 	if (TbSimpleVoidInterfaceMsgBusEndpoint.IsValid())
@@ -96,9 +99,13 @@ void UTbSimpleVoidInterfaceMsgBusAdapter::_AnnounceService()
 
 void UTbSimpleVoidInterfaceMsgBusAdapter::_StopListening()
 {
-	if (_HeartbeatTimerHandle.IsValid() && GetWorld())
+	if (_HeartbeatTickerHandle.IsValid())
 	{
-		GetWorld()->GetTimerManager().ClearTimer(_HeartbeatTimerHandle);
+#if (ENGINE_MAJOR_VERSION < 5)
+		FTicker::GetCoreTicker().RemoveTicker(_HeartbeatTickerHandle);
+#else
+		FTSTicker::GetCoreTicker().RemoveTicker(_HeartbeatTickerHandle);
+#endif
 	}
 
 	auto msg = new FTbSimpleVoidInterfaceServiceDisconnectMessage();
@@ -237,6 +244,12 @@ void UTbSimpleVoidInterfaceMsgBusAdapter::OnClientDisconnected(const FTbSimpleVo
 	ConnectedClientsTimestamps.Remove(Context->GetSender());
 	_OnClientDisconnected.Broadcast(Context->GetSender().ToString());
 	_UpdateClientsConnected();
+}
+
+bool UTbSimpleVoidInterfaceMsgBusAdapter::_CheckClientTimeoutsTick(float /*DeltaTime*/)
+{
+	_CheckClientTimeouts();
+	return true;
 }
 
 void UTbSimpleVoidInterfaceMsgBusAdapter::_CheckClientTimeouts()

--- a/goldenmaster/Plugins/TbSimple/Source/TbSimple/Private/Generated/MsgBus/TbSimpleVoidInterfaceMsgBusClient.cpp
+++ b/goldenmaster/Plugins/TbSimple/Source/TbSimple/Private/Generated/MsgBus/TbSimpleVoidInterfaceMsgBusClient.cpp
@@ -24,7 +24,6 @@ limitations under the License.
 #include "Generated/MsgBus/TbSimpleVoidInterfaceMsgBusMessages.h"
 #include "Async/Async.h"
 #include "Engine/World.h"
-#include "TimerManager.h"
 #include "Misc/DateTime.h"
 #include "GenericPlatform/GenericPlatformMath.h"
 #include "GenericPlatform/GenericPlatformTime.h"
@@ -55,19 +54,25 @@ void UTbSimpleVoidInterfaceMsgBusClient::Deinitialize()
 
 void UTbSimpleVoidInterfaceMsgBusClient::_Connect()
 {
-	if (!_HeartbeatTimerHandle.IsValid() && GetWorld())
+	if (_IsConnected())
+	{
+		UE_LOG(LogTbSimpleVoidInterfaceMsgBusClient, Log, TEXT("Already connected, cannot connect again."));
+		return;
+	}
+
+	if (!_HeartbeatTickerHandle.IsValid())
 	{
 		UTbSimpleSettings* settings = GetMutableDefault<UTbSimpleSettings>();
 		check(settings);
 		_HeartbeatIntervalMS = settings->MsgBusHeartbeatIntervalMS;
 
-		GetWorld()->GetTimerManager().SetTimer(_HeartbeatTimerHandle, this, &UTbSimpleVoidInterfaceMsgBusClient::_OnHeartbeat, _HeartbeatIntervalMS / 1000.0f, true);
-	}
-
-	if (_IsConnected())
-	{
-		UE_LOG(LogTbSimpleVoidInterfaceMsgBusClient, Log, TEXT("Already connected, cannot connect again."));
-		return;
+#if (ENGINE_MAJOR_VERSION < 5)
+		FTicker::GetCoreTicker().RemoveTicker(_HeartbeatTickerHandle);
+		_HeartbeatTickerHandle = FTicker::GetCoreTicker().AddTicker(FTickerDelegate::CreateUObject(this, &UTbSimpleVoidInterfaceMsgBusClient::_OnHeartbeatTick), _HeartbeatIntervalMS / 1000.0f);
+#else
+		FTSTicker::GetCoreTicker().RemoveTicker(_HeartbeatTickerHandle);
+		_HeartbeatTickerHandle = FTSTicker::GetCoreTicker().AddTicker(FTickerDelegate::CreateUObject(this, &UTbSimpleVoidInterfaceMsgBusClient::_OnHeartbeatTick), _HeartbeatIntervalMS / 1000.0f);
+#endif
 	}
 
 	if (TbSimpleVoidInterfaceMsgBusEndpoint.IsValid() && !ServiceAddress.IsValid())
@@ -91,10 +96,12 @@ void UTbSimpleVoidInterfaceMsgBusClient::_Connect()
 void UTbSimpleVoidInterfaceMsgBusClient::_Disconnect()
 {
 	_LastHbTimestamp = 0.0f;
-	if (_HeartbeatTimerHandle.IsValid() && GetWorld())
-	{
-		GetWorld()->GetTimerManager().ClearTimer(_HeartbeatTimerHandle);
-	}
+
+#if (ENGINE_MAJOR_VERSION < 5)
+	FTicker::GetCoreTicker().RemoveTicker(_HeartbeatTickerHandle);
+#else
+	FTSTicker::GetCoreTicker().RemoveTicker(_HeartbeatTickerHandle);
+#endif
 
 	if (!_IsConnected())
 	{
@@ -155,18 +162,22 @@ void UTbSimpleVoidInterfaceMsgBusClient::OnConnectionInit(const FTbSimpleVoidInt
 	{
 		_HeartbeatIntervalMS = InMessage._ClientPingIntervalMS;
 
-		if (_HeartbeatTimerHandle.IsValid() && GetWorld())
-		{
-			GetWorld()->GetTimerManager().ClearTimer(_HeartbeatTimerHandle);
-		}
-
-		if (!_HeartbeatTimerHandle.IsValid() && GetWorld())
-		{
-			GetWorld()->GetTimerManager().SetTimer(_HeartbeatTimerHandle, this, &UTbSimpleVoidInterfaceMsgBusClient::_OnHeartbeat, _HeartbeatIntervalMS / 1000.0f, true);
-		}
+#if (ENGINE_MAJOR_VERSION < 5)
+		FTicker::GetCoreTicker().RemoveTicker(_HeartbeatTickerHandle);
+		_HeartbeatTickerHandle = FTicker::GetCoreTicker().AddTicker(FTickerDelegate::CreateUObject(this, &UTbSimpleVoidInterfaceMsgBusClient::_OnHeartbeatTick), _HeartbeatIntervalMS / 1000.0f);
+#else
+		FTSTicker::GetCoreTicker().RemoveTicker(_HeartbeatTickerHandle);
+		_HeartbeatTickerHandle = FTSTicker::GetCoreTicker().AddTicker(FTickerDelegate::CreateUObject(this, &UTbSimpleVoidInterfaceMsgBusClient::_OnHeartbeatTick), _HeartbeatIntervalMS / 1000.0f);
+#endif
 	}
 
 	_ConnectionStatusChanged.Broadcast(true);
+}
+
+bool UTbSimpleVoidInterfaceMsgBusClient::_OnHeartbeatTick(float /*DeltaTime*/)
+{
+	_OnHeartbeat();
+	return true;
 }
 
 void UTbSimpleVoidInterfaceMsgBusClient::_OnHeartbeat()

--- a/goldenmaster/Plugins/TbSimple/Source/TbSimple/Private/Generated/MsgBus/TbSimpleVoidInterfaceMsgBusClient.cpp
+++ b/goldenmaster/Plugins/TbSimple/Source/TbSimple/Private/Generated/MsgBus/TbSimpleVoidInterfaceMsgBusClient.cpp
@@ -23,13 +23,14 @@ limitations under the License.
 #include "Generated/MsgBus/TbSimpleVoidInterfaceMsgBusClient.h"
 #include "Generated/MsgBus/TbSimpleVoidInterfaceMsgBusMessages.h"
 #include "Async/Async.h"
-#include "Engine/Engine.h"
+#include "Engine/World.h"
 #include "TimerManager.h"
 #include "Misc/DateTime.h"
 #include "GenericPlatform/GenericPlatformMath.h"
 #include "GenericPlatform/GenericPlatformTime.h"
 #include "MessageEndpointBuilder.h"
 #include "MessageEndpoint.h"
+#include "TbSimpleSettings.h"
 DEFINE_LOG_CATEGORY(LogTbSimpleVoidInterfaceMsgBusClient);
 
 UTbSimpleVoidInterfaceMsgBusClient::UTbSimpleVoidInterfaceMsgBusClient()
@@ -56,6 +57,10 @@ void UTbSimpleVoidInterfaceMsgBusClient::_Connect()
 {
 	if (!_HeartbeatTimerHandle.IsValid() && GetWorld())
 	{
+		UTbSimpleSettings* settings = GetMutableDefault<UTbSimpleSettings>();
+		check(settings);
+		_HeartbeatIntervalMS = settings->MsgBusHeartbeatIntervalMS;
+
 		GetWorld()->GetTimerManager().SetTimer(_HeartbeatTimerHandle, this, &UTbSimpleVoidInterfaceMsgBusClient::_OnHeartbeat, _HeartbeatIntervalMS / 1000.0f, true);
 	}
 

--- a/goldenmaster/Plugins/TbSimple/Source/TbSimple/Public/Generated/MsgBus/TbSimpleEmptyInterfaceMsgBusAdapter.h
+++ b/goldenmaster/Plugins/TbSimple/Source/TbSimple/Public/Generated/MsgBus/TbSimpleEmptyInterfaceMsgBusAdapter.h
@@ -21,11 +21,7 @@ limitations under the License.
 #include "IMessageContext.h"
 #include "Templates/SharedPointer.h"
 #include "Runtime/Launch/Resources/Version.h"
-#if (ENGINE_MAJOR_VERSION < 5)
-#include "Engine/EngineTypes.h"
-#else
-#include "Engine/TimerHandle.h"
-#endif
+#include "Containers/Ticker.h"
 #include "TbSimpleEmptyInterfaceMsgBusAdapter.generated.h"
 
 class FMessageEndpoint;
@@ -107,9 +103,14 @@ private:
 
 	// Heartbeat handling
 	void _CheckClientTimeouts();
+	bool _CheckClientTimeoutsTick(float DeltaTime);
 	void _UpdateClientsConnected();
 	TMap<FMessageAddress, double> ConnectedClientsTimestamps;
-	FTimerHandle _HeartbeatTimerHandle;
+#if (ENGINE_MAJOR_VERSION < 5)
+	::FDelegateHandle _HeartbeatTickerHandle;
+#else
+	FTSTicker::FDelegateHandle _HeartbeatTickerHandle;
+#endif
 	int32 _ClientsConnected = 0;
 	uint32 _HeartbeatIntervalMS = 100;
 };

--- a/goldenmaster/Plugins/TbSimple/Source/TbSimple/Public/Generated/MsgBus/TbSimpleEmptyInterfaceMsgBusClient.h
+++ b/goldenmaster/Plugins/TbSimple/Source/TbSimple/Public/Generated/MsgBus/TbSimpleEmptyInterfaceMsgBusClient.h
@@ -22,11 +22,7 @@ limitations under the License.
 #include "HAL/CriticalSection.h"
 #include "Async/Future.h"
 #include "Runtime/Launch/Resources/Version.h"
-#if (ENGINE_MAJOR_VERSION < 5)
-#include "Engine/EngineTypes.h"
-#else
-#include "Engine/TimerHandle.h"
-#endif
+#include "Containers/Ticker.h"
 #include "Templates/PimplPtr.h"
 #include "IMessageContext.h"
 #include "TbSimpleEmptyInterfaceMsgBusClient.generated.h"
@@ -110,8 +106,13 @@ private:
 	size_t CurrentPingCounter = 0;
 	float _CalculateAverageRTT() const;
 	FTbSimpleEmptyInterfaceStats Stats;
-	FTimerHandle _HeartbeatTimerHandle;
+#if (ENGINE_MAJOR_VERSION < 5)
+	::FDelegateHandle _HeartbeatTickerHandle;
+#else
+	FTSTicker::FDelegateHandle _HeartbeatTickerHandle;
+#endif
 	void _OnHeartbeat();
+	bool _OnHeartbeatTick(float DeltaTime);
 	uint32 _HeartbeatIntervalMS = 100;
 
 	// connection handling

--- a/goldenmaster/Plugins/TbSimple/Source/TbSimple/Public/Generated/MsgBus/TbSimpleNoOperationsInterfaceMsgBusAdapter.h
+++ b/goldenmaster/Plugins/TbSimple/Source/TbSimple/Public/Generated/MsgBus/TbSimpleNoOperationsInterfaceMsgBusAdapter.h
@@ -21,11 +21,7 @@ limitations under the License.
 #include "IMessageContext.h"
 #include "Templates/SharedPointer.h"
 #include "Runtime/Launch/Resources/Version.h"
-#if (ENGINE_MAJOR_VERSION < 5)
-#include "Engine/EngineTypes.h"
-#else
-#include "Engine/TimerHandle.h"
-#endif
+#include "Containers/Ticker.h"
 #include "TbSimpleNoOperationsInterfaceMsgBusAdapter.generated.h"
 
 class FMessageEndpoint;
@@ -126,9 +122,14 @@ private:
 
 	// Heartbeat handling
 	void _CheckClientTimeouts();
+	bool _CheckClientTimeoutsTick(float DeltaTime);
 	void _UpdateClientsConnected();
 	TMap<FMessageAddress, double> ConnectedClientsTimestamps;
-	FTimerHandle _HeartbeatTimerHandle;
+#if (ENGINE_MAJOR_VERSION < 5)
+	::FDelegateHandle _HeartbeatTickerHandle;
+#else
+	FTSTicker::FDelegateHandle _HeartbeatTickerHandle;
+#endif
 	int32 _ClientsConnected = 0;
 	uint32 _HeartbeatIntervalMS = 100;
 };

--- a/goldenmaster/Plugins/TbSimple/Source/TbSimple/Public/Generated/MsgBus/TbSimpleNoOperationsInterfaceMsgBusClient.h
+++ b/goldenmaster/Plugins/TbSimple/Source/TbSimple/Public/Generated/MsgBus/TbSimpleNoOperationsInterfaceMsgBusClient.h
@@ -22,11 +22,7 @@ limitations under the License.
 #include "HAL/CriticalSection.h"
 #include "Async/Future.h"
 #include "Runtime/Launch/Resources/Version.h"
-#if (ENGINE_MAJOR_VERSION < 5)
-#include "Engine/EngineTypes.h"
-#else
-#include "Engine/TimerHandle.h"
-#endif
+#include "Containers/Ticker.h"
 #include "Templates/PimplPtr.h"
 #include "IMessageContext.h"
 #include "TbSimpleNoOperationsInterfaceMsgBusClient.generated.h"
@@ -122,8 +118,13 @@ private:
 	size_t CurrentPingCounter = 0;
 	float _CalculateAverageRTT() const;
 	FTbSimpleNoOperationsInterfaceStats Stats;
-	FTimerHandle _HeartbeatTimerHandle;
+#if (ENGINE_MAJOR_VERSION < 5)
+	::FDelegateHandle _HeartbeatTickerHandle;
+#else
+	FTSTicker::FDelegateHandle _HeartbeatTickerHandle;
+#endif
 	void _OnHeartbeat();
+	bool _OnHeartbeatTick(float DeltaTime);
 	uint32 _HeartbeatIntervalMS = 100;
 
 	// connection handling

--- a/goldenmaster/Plugins/TbSimple/Source/TbSimple/Public/Generated/MsgBus/TbSimpleNoPropertiesInterfaceMsgBusAdapter.h
+++ b/goldenmaster/Plugins/TbSimple/Source/TbSimple/Public/Generated/MsgBus/TbSimpleNoPropertiesInterfaceMsgBusAdapter.h
@@ -21,11 +21,7 @@ limitations under the License.
 #include "IMessageContext.h"
 #include "Templates/SharedPointer.h"
 #include "Runtime/Launch/Resources/Version.h"
-#if (ENGINE_MAJOR_VERSION < 5)
-#include "Engine/EngineTypes.h"
-#else
-#include "Engine/TimerHandle.h"
-#endif
+#include "Containers/Ticker.h"
 #include "TbSimpleNoPropertiesInterfaceMsgBusAdapter.generated.h"
 
 class FMessageEndpoint;
@@ -118,9 +114,14 @@ private:
 
 	// Heartbeat handling
 	void _CheckClientTimeouts();
+	bool _CheckClientTimeoutsTick(float DeltaTime);
 	void _UpdateClientsConnected();
 	TMap<FMessageAddress, double> ConnectedClientsTimestamps;
-	FTimerHandle _HeartbeatTimerHandle;
+#if (ENGINE_MAJOR_VERSION < 5)
+	::FDelegateHandle _HeartbeatTickerHandle;
+#else
+	FTSTicker::FDelegateHandle _HeartbeatTickerHandle;
+#endif
 	int32 _ClientsConnected = 0;
 	uint32 _HeartbeatIntervalMS = 100;
 };

--- a/goldenmaster/Plugins/TbSimple/Source/TbSimple/Public/Generated/MsgBus/TbSimpleNoPropertiesInterfaceMsgBusClient.h
+++ b/goldenmaster/Plugins/TbSimple/Source/TbSimple/Public/Generated/MsgBus/TbSimpleNoPropertiesInterfaceMsgBusClient.h
@@ -22,11 +22,7 @@ limitations under the License.
 #include "HAL/CriticalSection.h"
 #include "Async/Future.h"
 #include "Runtime/Launch/Resources/Version.h"
-#if (ENGINE_MAJOR_VERSION < 5)
-#include "Engine/EngineTypes.h"
-#else
-#include "Engine/TimerHandle.h"
-#endif
+#include "Containers/Ticker.h"
 #include "Templates/PimplPtr.h"
 #include "IMessageContext.h"
 #include "TbSimpleNoPropertiesInterfaceMsgBusClient.generated.h"
@@ -116,8 +112,13 @@ private:
 	size_t CurrentPingCounter = 0;
 	float _CalculateAverageRTT() const;
 	FTbSimpleNoPropertiesInterfaceStats Stats;
-	FTimerHandle _HeartbeatTimerHandle;
+#if (ENGINE_MAJOR_VERSION < 5)
+	::FDelegateHandle _HeartbeatTickerHandle;
+#else
+	FTSTicker::FDelegateHandle _HeartbeatTickerHandle;
+#endif
 	void _OnHeartbeat();
+	bool _OnHeartbeatTick(float DeltaTime);
 	uint32 _HeartbeatIntervalMS = 100;
 
 	// connection handling

--- a/goldenmaster/Plugins/TbSimple/Source/TbSimple/Public/Generated/MsgBus/TbSimpleNoSignalsInterfaceMsgBusAdapter.h
+++ b/goldenmaster/Plugins/TbSimple/Source/TbSimple/Public/Generated/MsgBus/TbSimpleNoSignalsInterfaceMsgBusAdapter.h
@@ -21,11 +21,7 @@ limitations under the License.
 #include "IMessageContext.h"
 #include "Templates/SharedPointer.h"
 #include "Runtime/Launch/Resources/Version.h"
-#if (ENGINE_MAJOR_VERSION < 5)
-#include "Engine/EngineTypes.h"
-#else
-#include "Engine/TimerHandle.h"
-#endif
+#include "Containers/Ticker.h"
 #include "TbSimpleNoSignalsInterfaceMsgBusAdapter.generated.h"
 
 class FMessageEndpoint;
@@ -123,9 +119,14 @@ private:
 
 	// Heartbeat handling
 	void _CheckClientTimeouts();
+	bool _CheckClientTimeoutsTick(float DeltaTime);
 	void _UpdateClientsConnected();
 	TMap<FMessageAddress, double> ConnectedClientsTimestamps;
-	FTimerHandle _HeartbeatTimerHandle;
+#if (ENGINE_MAJOR_VERSION < 5)
+	::FDelegateHandle _HeartbeatTickerHandle;
+#else
+	FTSTicker::FDelegateHandle _HeartbeatTickerHandle;
+#endif
 	int32 _ClientsConnected = 0;
 	uint32 _HeartbeatIntervalMS = 100;
 };

--- a/goldenmaster/Plugins/TbSimple/Source/TbSimple/Public/Generated/MsgBus/TbSimpleNoSignalsInterfaceMsgBusClient.h
+++ b/goldenmaster/Plugins/TbSimple/Source/TbSimple/Public/Generated/MsgBus/TbSimpleNoSignalsInterfaceMsgBusClient.h
@@ -22,11 +22,7 @@ limitations under the License.
 #include "HAL/CriticalSection.h"
 #include "Async/Future.h"
 #include "Runtime/Launch/Resources/Version.h"
-#if (ENGINE_MAJOR_VERSION < 5)
-#include "Engine/EngineTypes.h"
-#else
-#include "Engine/TimerHandle.h"
-#endif
+#include "Containers/Ticker.h"
 #include "Templates/PimplPtr.h"
 #include "IMessageContext.h"
 #include "TbSimpleNoSignalsInterfaceMsgBusClient.generated.h"
@@ -124,8 +120,13 @@ private:
 	size_t CurrentPingCounter = 0;
 	float _CalculateAverageRTT() const;
 	FTbSimpleNoSignalsInterfaceStats Stats;
-	FTimerHandle _HeartbeatTimerHandle;
+#if (ENGINE_MAJOR_VERSION < 5)
+	::FDelegateHandle _HeartbeatTickerHandle;
+#else
+	FTSTicker::FDelegateHandle _HeartbeatTickerHandle;
+#endif
 	void _OnHeartbeat();
+	bool _OnHeartbeatTick(float DeltaTime);
 	uint32 _HeartbeatIntervalMS = 100;
 
 	// connection handling

--- a/goldenmaster/Plugins/TbSimple/Source/TbSimple/Public/Generated/MsgBus/TbSimpleSimpleArrayInterfaceMsgBusAdapter.h
+++ b/goldenmaster/Plugins/TbSimple/Source/TbSimple/Public/Generated/MsgBus/TbSimpleSimpleArrayInterfaceMsgBusAdapter.h
@@ -21,11 +21,7 @@ limitations under the License.
 #include "IMessageContext.h"
 #include "Templates/SharedPointer.h"
 #include "Runtime/Launch/Resources/Version.h"
-#if (ENGINE_MAJOR_VERSION < 5)
-#include "Engine/EngineTypes.h"
-#else
-#include "Engine/TimerHandle.h"
-#endif
+#include "Containers/Ticker.h"
 #include "TbSimpleSimpleArrayInterfaceMsgBusAdapter.generated.h"
 
 class FMessageEndpoint;
@@ -207,9 +203,14 @@ private:
 
 	// Heartbeat handling
 	void _CheckClientTimeouts();
+	bool _CheckClientTimeoutsTick(float DeltaTime);
 	void _UpdateClientsConnected();
 	TMap<FMessageAddress, double> ConnectedClientsTimestamps;
-	FTimerHandle _HeartbeatTimerHandle;
+#if (ENGINE_MAJOR_VERSION < 5)
+	::FDelegateHandle _HeartbeatTickerHandle;
+#else
+	FTSTicker::FDelegateHandle _HeartbeatTickerHandle;
+#endif
 	int32 _ClientsConnected = 0;
 	uint32 _HeartbeatIntervalMS = 100;
 };

--- a/goldenmaster/Plugins/TbSimple/Source/TbSimple/Public/Generated/MsgBus/TbSimpleSimpleArrayInterfaceMsgBusClient.h
+++ b/goldenmaster/Plugins/TbSimple/Source/TbSimple/Public/Generated/MsgBus/TbSimpleSimpleArrayInterfaceMsgBusClient.h
@@ -22,11 +22,7 @@ limitations under the License.
 #include "HAL/CriticalSection.h"
 #include "Async/Future.h"
 #include "Runtime/Launch/Resources/Version.h"
-#if (ENGINE_MAJOR_VERSION < 5)
-#include "Engine/EngineTypes.h"
-#else
-#include "Engine/TimerHandle.h"
-#endif
+#include "Containers/Ticker.h"
 #include "Templates/PimplPtr.h"
 #include "IMessageContext.h"
 #include "TbSimpleSimpleArrayInterfaceMsgBusClient.generated.h"
@@ -178,8 +174,13 @@ private:
 	size_t CurrentPingCounter = 0;
 	float _CalculateAverageRTT() const;
 	FTbSimpleSimpleArrayInterfaceStats Stats;
-	FTimerHandle _HeartbeatTimerHandle;
+#if (ENGINE_MAJOR_VERSION < 5)
+	::FDelegateHandle _HeartbeatTickerHandle;
+#else
+	FTSTicker::FDelegateHandle _HeartbeatTickerHandle;
+#endif
 	void _OnHeartbeat();
+	bool _OnHeartbeatTick(float DeltaTime);
 	uint32 _HeartbeatIntervalMS = 100;
 
 	// connection handling

--- a/goldenmaster/Plugins/TbSimple/Source/TbSimple/Public/Generated/MsgBus/TbSimpleSimpleInterfaceMsgBusAdapter.h
+++ b/goldenmaster/Plugins/TbSimple/Source/TbSimple/Public/Generated/MsgBus/TbSimpleSimpleInterfaceMsgBusAdapter.h
@@ -21,11 +21,7 @@ limitations under the License.
 #include "IMessageContext.h"
 #include "Templates/SharedPointer.h"
 #include "Runtime/Launch/Resources/Version.h"
-#if (ENGINE_MAJOR_VERSION < 5)
-#include "Engine/EngineTypes.h"
-#else
-#include "Engine/TimerHandle.h"
-#endif
+#include "Containers/Ticker.h"
 #include "TbSimpleSimpleInterfaceMsgBusAdapter.generated.h"
 
 class FMessageEndpoint;
@@ -204,9 +200,14 @@ private:
 
 	// Heartbeat handling
 	void _CheckClientTimeouts();
+	bool _CheckClientTimeoutsTick(float DeltaTime);
 	void _UpdateClientsConnected();
 	TMap<FMessageAddress, double> ConnectedClientsTimestamps;
-	FTimerHandle _HeartbeatTimerHandle;
+#if (ENGINE_MAJOR_VERSION < 5)
+	::FDelegateHandle _HeartbeatTickerHandle;
+#else
+	FTSTicker::FDelegateHandle _HeartbeatTickerHandle;
+#endif
 	int32 _ClientsConnected = 0;
 	uint32 _HeartbeatIntervalMS = 100;
 };

--- a/goldenmaster/Plugins/TbSimple/Source/TbSimple/Public/Generated/MsgBus/TbSimpleSimpleInterfaceMsgBusClient.h
+++ b/goldenmaster/Plugins/TbSimple/Source/TbSimple/Public/Generated/MsgBus/TbSimpleSimpleInterfaceMsgBusClient.h
@@ -22,11 +22,7 @@ limitations under the License.
 #include "HAL/CriticalSection.h"
 #include "Async/Future.h"
 #include "Runtime/Launch/Resources/Version.h"
-#if (ENGINE_MAJOR_VERSION < 5)
-#include "Engine/EngineTypes.h"
-#else
-#include "Engine/TimerHandle.h"
-#endif
+#include "Containers/Ticker.h"
 #include "Templates/PimplPtr.h"
 #include "IMessageContext.h"
 #include "TbSimpleSimpleInterfaceMsgBusClient.generated.h"
@@ -177,8 +173,13 @@ private:
 	size_t CurrentPingCounter = 0;
 	float _CalculateAverageRTT() const;
 	FTbSimpleSimpleInterfaceStats Stats;
-	FTimerHandle _HeartbeatTimerHandle;
+#if (ENGINE_MAJOR_VERSION < 5)
+	::FDelegateHandle _HeartbeatTickerHandle;
+#else
+	FTSTicker::FDelegateHandle _HeartbeatTickerHandle;
+#endif
 	void _OnHeartbeat();
+	bool _OnHeartbeatTick(float DeltaTime);
 	uint32 _HeartbeatIntervalMS = 100;
 
 	// connection handling

--- a/goldenmaster/Plugins/TbSimple/Source/TbSimple/Public/Generated/MsgBus/TbSimpleVoidInterfaceMsgBusAdapter.h
+++ b/goldenmaster/Plugins/TbSimple/Source/TbSimple/Public/Generated/MsgBus/TbSimpleVoidInterfaceMsgBusAdapter.h
@@ -21,11 +21,7 @@ limitations under the License.
 #include "IMessageContext.h"
 #include "Templates/SharedPointer.h"
 #include "Runtime/Launch/Resources/Version.h"
-#if (ENGINE_MAJOR_VERSION < 5)
-#include "Engine/EngineTypes.h"
-#else
-#include "Engine/TimerHandle.h"
-#endif
+#include "Containers/Ticker.h"
 #include "TbSimpleVoidInterfaceMsgBusAdapter.generated.h"
 
 class FMessageEndpoint;
@@ -112,9 +108,14 @@ private:
 
 	// Heartbeat handling
 	void _CheckClientTimeouts();
+	bool _CheckClientTimeoutsTick(float DeltaTime);
 	void _UpdateClientsConnected();
 	TMap<FMessageAddress, double> ConnectedClientsTimestamps;
-	FTimerHandle _HeartbeatTimerHandle;
+#if (ENGINE_MAJOR_VERSION < 5)
+	::FDelegateHandle _HeartbeatTickerHandle;
+#else
+	FTSTicker::FDelegateHandle _HeartbeatTickerHandle;
+#endif
 	int32 _ClientsConnected = 0;
 	uint32 _HeartbeatIntervalMS = 100;
 };

--- a/goldenmaster/Plugins/TbSimple/Source/TbSimple/Public/Generated/MsgBus/TbSimpleVoidInterfaceMsgBusClient.h
+++ b/goldenmaster/Plugins/TbSimple/Source/TbSimple/Public/Generated/MsgBus/TbSimpleVoidInterfaceMsgBusClient.h
@@ -22,11 +22,7 @@ limitations under the License.
 #include "HAL/CriticalSection.h"
 #include "Async/Future.h"
 #include "Runtime/Launch/Resources/Version.h"
-#if (ENGINE_MAJOR_VERSION < 5)
-#include "Engine/EngineTypes.h"
-#else
-#include "Engine/TimerHandle.h"
-#endif
+#include "Containers/Ticker.h"
 #include "Templates/PimplPtr.h"
 #include "IMessageContext.h"
 #include "TbSimpleVoidInterfaceMsgBusClient.generated.h"
@@ -112,8 +108,13 @@ private:
 	size_t CurrentPingCounter = 0;
 	float _CalculateAverageRTT() const;
 	FTbSimpleVoidInterfaceStats Stats;
-	FTimerHandle _HeartbeatTimerHandle;
+#if (ENGINE_MAJOR_VERSION < 5)
+	::FDelegateHandle _HeartbeatTickerHandle;
+#else
+	FTSTicker::FDelegateHandle _HeartbeatTickerHandle;
+#endif
 	void _OnHeartbeat();
+	bool _OnHeartbeatTick(float DeltaTime);
 	uint32 _HeartbeatIntervalMS = 100;
 
 	// connection handling

--- a/goldenmaster/Plugins/TbSimple/Source/TbSimple/Public/TbSimpleSettings.h
+++ b/goldenmaster/Plugins/TbSimple/Source/TbSimple/Public/TbSimpleSettings.h
@@ -45,4 +45,11 @@ public:
 	/** Choose the olink connection to use */
 	UPROPERTY(EditAnywhere, config, Category = OLinkConnectionSetup)
 	FString OLinkConnectionIdentifier;
+
+	/** Choose the heartbeat interval in milliseconds for the msgbus connection on the service side.
+	 * On the service side this adjusts the heartbeat between client and service. The clients will receive the value from service.
+	 * On the client side this adjusts how often discovery messages are sent until a service is connected.
+	 */
+	UPROPERTY(EditAnywhere, config, Category = MsgBusConnectionSetup, meta = (DisplayName = "Heartbeat interval (in milliseconds)"))
+	uint32 MsgBusHeartbeatIntervalMS = 200;
 };

--- a/goldenmaster/Plugins/TbSimple/TbSimple.uplugin
+++ b/goldenmaster/Plugins/TbSimple/TbSimple.uplugin
@@ -2,7 +2,7 @@
 {
 	"FileVersion": 3,
 	"Version": 1,
-	"VersionName": "1.0.0",
+	"VersionName": "1.0.0+tpl.3.5.2",
 	"FriendlyName": "TbSimple",
 	"Description": "",
 	"Category": "Other",

--- a/goldenmaster/Plugins/Testbed1/Source/Testbed1/Private/Generated/MsgBus/Testbed1StructArray2InterfaceMsgBusAdapter.cpp
+++ b/goldenmaster/Plugins/Testbed1/Source/Testbed1/Private/Generated/MsgBus/Testbed1StructArray2InterfaceMsgBusAdapter.cpp
@@ -24,12 +24,12 @@ limitations under the License.
 #include "Generated/MsgBus/Testbed1StructArray2InterfaceMsgBusMessages.h"
 #include "Async/Future.h"
 #include "Async/Async.h"
-#include "Async/Async.h"
-#include "Engine/Engine.h"
+#include "Engine/World.h"
 #include "TimerManager.h"
 #include "MessageEndpoint.h"
 #include "MessageEndpointBuilder.h"
 #include "Misc/DateTime.h"
+#include "Testbed1Settings.h"
 
 DEFINE_LOG_CATEGORY(LogTestbed1StructArray2InterfaceMsgBusAdapter);
 UTestbed1StructArray2InterfaceMsgBusAdapter::UTestbed1StructArray2InterfaceMsgBusAdapter()
@@ -53,6 +53,10 @@ void UTestbed1StructArray2InterfaceMsgBusAdapter::_StartListening()
 
 	if (!_HeartbeatTimerHandle.IsValid() && GetWorld())
 	{
+		UTestbed1Settings* settings = GetMutableDefault<UTestbed1Settings>();
+		check(settings);
+		_HeartbeatIntervalMS = settings->MsgBusHeartbeatIntervalMS;
+
 		GetWorld()->GetTimerManager().SetTimer(_HeartbeatTimerHandle, this, &UTestbed1StructArray2InterfaceMsgBusAdapter::_CheckClientTimeouts, _HeartbeatIntervalMS / 1000.0f, true);
 	}
 

--- a/goldenmaster/Plugins/Testbed1/Source/Testbed1/Private/Generated/MsgBus/Testbed1StructArray2InterfaceMsgBusAdapter.cpp
+++ b/goldenmaster/Plugins/Testbed1/Source/Testbed1/Private/Generated/MsgBus/Testbed1StructArray2InterfaceMsgBusAdapter.cpp
@@ -25,7 +25,6 @@ limitations under the License.
 #include "Async/Future.h"
 #include "Async/Async.h"
 #include "Engine/World.h"
-#include "TimerManager.h"
 #include "MessageEndpoint.h"
 #include "MessageEndpointBuilder.h"
 #include "Misc/DateTime.h"
@@ -51,13 +50,17 @@ void UTestbed1StructArray2InterfaceMsgBusAdapter::Deinitialize()
 void UTestbed1StructArray2InterfaceMsgBusAdapter::_StartListening()
 {
 
-	if (!_HeartbeatTimerHandle.IsValid() && GetWorld())
+	if (!_HeartbeatTickerHandle.IsValid())
 	{
 		UTestbed1Settings* settings = GetMutableDefault<UTestbed1Settings>();
 		check(settings);
 		_HeartbeatIntervalMS = settings->MsgBusHeartbeatIntervalMS;
 
-		GetWorld()->GetTimerManager().SetTimer(_HeartbeatTimerHandle, this, &UTestbed1StructArray2InterfaceMsgBusAdapter::_CheckClientTimeouts, _HeartbeatIntervalMS / 1000.0f, true);
+#if (ENGINE_MAJOR_VERSION < 5)
+		_HeartbeatTickerHandle = FTicker::GetCoreTicker().AddTicker(FTickerDelegate::CreateUObject(this, &UTestbed1StructArray2InterfaceMsgBusAdapter::_CheckClientTimeoutsTick), _HeartbeatIntervalMS / 1000.0f);
+#else
+		_HeartbeatTickerHandle = FTSTicker::GetCoreTicker().AddTicker(FTickerDelegate::CreateUObject(this, &UTestbed1StructArray2InterfaceMsgBusAdapter::_CheckClientTimeoutsTick), _HeartbeatIntervalMS / 1000.0f);
+#endif
 	}
 
 	if (Testbed1StructArray2InterfaceMsgBusEndpoint.IsValid())
@@ -105,9 +108,13 @@ void UTestbed1StructArray2InterfaceMsgBusAdapter::_AnnounceService()
 
 void UTestbed1StructArray2InterfaceMsgBusAdapter::_StopListening()
 {
-	if (_HeartbeatTimerHandle.IsValid() && GetWorld())
+	if (_HeartbeatTickerHandle.IsValid())
 	{
-		GetWorld()->GetTimerManager().ClearTimer(_HeartbeatTimerHandle);
+#if (ENGINE_MAJOR_VERSION < 5)
+		FTicker::GetCoreTicker().RemoveTicker(_HeartbeatTickerHandle);
+#else
+		FTSTicker::GetCoreTicker().RemoveTicker(_HeartbeatTickerHandle);
+#endif
 	}
 
 	auto msg = new FTestbed1StructArray2InterfaceServiceDisconnectMessage();
@@ -267,6 +274,12 @@ void UTestbed1StructArray2InterfaceMsgBusAdapter::OnClientDisconnected(const FTe
 	ConnectedClientsTimestamps.Remove(Context->GetSender());
 	_OnClientDisconnected.Broadcast(Context->GetSender().ToString());
 	_UpdateClientsConnected();
+}
+
+bool UTestbed1StructArray2InterfaceMsgBusAdapter::_CheckClientTimeoutsTick(float /*DeltaTime*/)
+{
+	_CheckClientTimeouts();
+	return true;
 }
 
 void UTestbed1StructArray2InterfaceMsgBusAdapter::_CheckClientTimeouts()

--- a/goldenmaster/Plugins/Testbed1/Source/Testbed1/Private/Generated/MsgBus/Testbed1StructArray2InterfaceMsgBusClient.cpp
+++ b/goldenmaster/Plugins/Testbed1/Source/Testbed1/Private/Generated/MsgBus/Testbed1StructArray2InterfaceMsgBusClient.cpp
@@ -23,13 +23,14 @@ limitations under the License.
 #include "Generated/MsgBus/Testbed1StructArray2InterfaceMsgBusClient.h"
 #include "Generated/MsgBus/Testbed1StructArray2InterfaceMsgBusMessages.h"
 #include "Async/Async.h"
-#include "Engine/Engine.h"
+#include "Engine/World.h"
 #include "TimerManager.h"
 #include "Misc/DateTime.h"
 #include "GenericPlatform/GenericPlatformMath.h"
 #include "GenericPlatform/GenericPlatformTime.h"
 #include "MessageEndpointBuilder.h"
 #include "MessageEndpoint.h"
+#include "Testbed1Settings.h"
 #include "HAL/CriticalSection.h"
 
 /**
@@ -75,6 +76,10 @@ void UTestbed1StructArray2InterfaceMsgBusClient::_Connect()
 {
 	if (!_HeartbeatTimerHandle.IsValid() && GetWorld())
 	{
+		UTestbed1Settings* settings = GetMutableDefault<UTestbed1Settings>();
+		check(settings);
+		_HeartbeatIntervalMS = settings->MsgBusHeartbeatIntervalMS;
+
 		GetWorld()->GetTimerManager().SetTimer(_HeartbeatTimerHandle, this, &UTestbed1StructArray2InterfaceMsgBusClient::_OnHeartbeat, _HeartbeatIntervalMS / 1000.0f, true);
 	}
 

--- a/goldenmaster/Plugins/Testbed1/Source/Testbed1/Private/Generated/MsgBus/Testbed1StructArray2InterfaceMsgBusClient.cpp
+++ b/goldenmaster/Plugins/Testbed1/Source/Testbed1/Private/Generated/MsgBus/Testbed1StructArray2InterfaceMsgBusClient.cpp
@@ -24,7 +24,6 @@ limitations under the License.
 #include "Generated/MsgBus/Testbed1StructArray2InterfaceMsgBusMessages.h"
 #include "Async/Async.h"
 #include "Engine/World.h"
-#include "TimerManager.h"
 #include "Misc/DateTime.h"
 #include "GenericPlatform/GenericPlatformMath.h"
 #include "GenericPlatform/GenericPlatformTime.h"
@@ -74,19 +73,25 @@ void UTestbed1StructArray2InterfaceMsgBusClient::Deinitialize()
 
 void UTestbed1StructArray2InterfaceMsgBusClient::_Connect()
 {
-	if (!_HeartbeatTimerHandle.IsValid() && GetWorld())
+	if (_IsConnected())
+	{
+		UE_LOG(LogTestbed1StructArray2InterfaceMsgBusClient, Log, TEXT("Already connected, cannot connect again."));
+		return;
+	}
+
+	if (!_HeartbeatTickerHandle.IsValid())
 	{
 		UTestbed1Settings* settings = GetMutableDefault<UTestbed1Settings>();
 		check(settings);
 		_HeartbeatIntervalMS = settings->MsgBusHeartbeatIntervalMS;
 
-		GetWorld()->GetTimerManager().SetTimer(_HeartbeatTimerHandle, this, &UTestbed1StructArray2InterfaceMsgBusClient::_OnHeartbeat, _HeartbeatIntervalMS / 1000.0f, true);
-	}
-
-	if (_IsConnected())
-	{
-		UE_LOG(LogTestbed1StructArray2InterfaceMsgBusClient, Log, TEXT("Already connected, cannot connect again."));
-		return;
+#if (ENGINE_MAJOR_VERSION < 5)
+		FTicker::GetCoreTicker().RemoveTicker(_HeartbeatTickerHandle);
+		_HeartbeatTickerHandle = FTicker::GetCoreTicker().AddTicker(FTickerDelegate::CreateUObject(this, &UTestbed1StructArray2InterfaceMsgBusClient::_OnHeartbeatTick), _HeartbeatIntervalMS / 1000.0f);
+#else
+		FTSTicker::GetCoreTicker().RemoveTicker(_HeartbeatTickerHandle);
+		_HeartbeatTickerHandle = FTSTicker::GetCoreTicker().AddTicker(FTickerDelegate::CreateUObject(this, &UTestbed1StructArray2InterfaceMsgBusClient::_OnHeartbeatTick), _HeartbeatIntervalMS / 1000.0f);
+#endif
 	}
 
 	if (Testbed1StructArray2InterfaceMsgBusEndpoint.IsValid() && !ServiceAddress.IsValid())
@@ -123,10 +128,12 @@ void UTestbed1StructArray2InterfaceMsgBusClient::_Connect()
 void UTestbed1StructArray2InterfaceMsgBusClient::_Disconnect()
 {
 	_LastHbTimestamp = 0.0f;
-	if (_HeartbeatTimerHandle.IsValid() && GetWorld())
-	{
-		GetWorld()->GetTimerManager().ClearTimer(_HeartbeatTimerHandle);
-	}
+
+#if (ENGINE_MAJOR_VERSION < 5)
+	FTicker::GetCoreTicker().RemoveTicker(_HeartbeatTickerHandle);
+#else
+	FTSTicker::GetCoreTicker().RemoveTicker(_HeartbeatTickerHandle);
+#endif
 
 	if (!_IsConnected())
 	{
@@ -187,15 +194,13 @@ void UTestbed1StructArray2InterfaceMsgBusClient::OnConnectionInit(const FTestbed
 	{
 		_HeartbeatIntervalMS = InMessage._ClientPingIntervalMS;
 
-		if (_HeartbeatTimerHandle.IsValid() && GetWorld())
-		{
-			GetWorld()->GetTimerManager().ClearTimer(_HeartbeatTimerHandle);
-		}
-
-		if (!_HeartbeatTimerHandle.IsValid() && GetWorld())
-		{
-			GetWorld()->GetTimerManager().SetTimer(_HeartbeatTimerHandle, this, &UTestbed1StructArray2InterfaceMsgBusClient::_OnHeartbeat, _HeartbeatIntervalMS / 1000.0f, true);
-		}
+#if (ENGINE_MAJOR_VERSION < 5)
+		FTicker::GetCoreTicker().RemoveTicker(_HeartbeatTickerHandle);
+		_HeartbeatTickerHandle = FTicker::GetCoreTicker().AddTicker(FTickerDelegate::CreateUObject(this, &UTestbed1StructArray2InterfaceMsgBusClient::_OnHeartbeatTick), _HeartbeatIntervalMS / 1000.0f);
+#else
+		FTSTicker::GetCoreTicker().RemoveTicker(_HeartbeatTickerHandle);
+		_HeartbeatTickerHandle = FTSTicker::GetCoreTicker().AddTicker(FTickerDelegate::CreateUObject(this, &UTestbed1StructArray2InterfaceMsgBusClient::_OnHeartbeatTick), _HeartbeatIntervalMS / 1000.0f);
+#endif
 	}
 	const bool bPropBoolChanged = InMessage.PropBool != PropBool;
 	if (bPropBoolChanged)
@@ -233,6 +238,12 @@ void UTestbed1StructArray2InterfaceMsgBusClient::OnConnectionInit(const FTestbed
 	}
 
 	_ConnectionStatusChanged.Broadcast(true);
+}
+
+bool UTestbed1StructArray2InterfaceMsgBusClient::_OnHeartbeatTick(float /*DeltaTime*/)
+{
+	_OnHeartbeat();
+	return true;
 }
 
 void UTestbed1StructArray2InterfaceMsgBusClient::_OnHeartbeat()

--- a/goldenmaster/Plugins/Testbed1/Source/Testbed1/Private/Generated/MsgBus/Testbed1StructArrayInterfaceMsgBusAdapter.cpp
+++ b/goldenmaster/Plugins/Testbed1/Source/Testbed1/Private/Generated/MsgBus/Testbed1StructArrayInterfaceMsgBusAdapter.cpp
@@ -25,7 +25,6 @@ limitations under the License.
 #include "Async/Future.h"
 #include "Async/Async.h"
 #include "Engine/World.h"
-#include "TimerManager.h"
 #include "MessageEndpoint.h"
 #include "MessageEndpointBuilder.h"
 #include "Misc/DateTime.h"
@@ -51,13 +50,17 @@ void UTestbed1StructArrayInterfaceMsgBusAdapter::Deinitialize()
 void UTestbed1StructArrayInterfaceMsgBusAdapter::_StartListening()
 {
 
-	if (!_HeartbeatTimerHandle.IsValid() && GetWorld())
+	if (!_HeartbeatTickerHandle.IsValid())
 	{
 		UTestbed1Settings* settings = GetMutableDefault<UTestbed1Settings>();
 		check(settings);
 		_HeartbeatIntervalMS = settings->MsgBusHeartbeatIntervalMS;
 
-		GetWorld()->GetTimerManager().SetTimer(_HeartbeatTimerHandle, this, &UTestbed1StructArrayInterfaceMsgBusAdapter::_CheckClientTimeouts, _HeartbeatIntervalMS / 1000.0f, true);
+#if (ENGINE_MAJOR_VERSION < 5)
+		_HeartbeatTickerHandle = FTicker::GetCoreTicker().AddTicker(FTickerDelegate::CreateUObject(this, &UTestbed1StructArrayInterfaceMsgBusAdapter::_CheckClientTimeoutsTick), _HeartbeatIntervalMS / 1000.0f);
+#else
+		_HeartbeatTickerHandle = FTSTicker::GetCoreTicker().AddTicker(FTickerDelegate::CreateUObject(this, &UTestbed1StructArrayInterfaceMsgBusAdapter::_CheckClientTimeoutsTick), _HeartbeatIntervalMS / 1000.0f);
+#endif
 	}
 
 	if (Testbed1StructArrayInterfaceMsgBusEndpoint.IsValid())
@@ -105,9 +108,13 @@ void UTestbed1StructArrayInterfaceMsgBusAdapter::_AnnounceService()
 
 void UTestbed1StructArrayInterfaceMsgBusAdapter::_StopListening()
 {
-	if (_HeartbeatTimerHandle.IsValid() && GetWorld())
+	if (_HeartbeatTickerHandle.IsValid())
 	{
-		GetWorld()->GetTimerManager().ClearTimer(_HeartbeatTimerHandle);
+#if (ENGINE_MAJOR_VERSION < 5)
+		FTicker::GetCoreTicker().RemoveTicker(_HeartbeatTickerHandle);
+#else
+		FTSTicker::GetCoreTicker().RemoveTicker(_HeartbeatTickerHandle);
+#endif
 	}
 
 	auto msg = new FTestbed1StructArrayInterfaceServiceDisconnectMessage();
@@ -269,6 +276,12 @@ void UTestbed1StructArrayInterfaceMsgBusAdapter::OnClientDisconnected(const FTes
 	ConnectedClientsTimestamps.Remove(Context->GetSender());
 	_OnClientDisconnected.Broadcast(Context->GetSender().ToString());
 	_UpdateClientsConnected();
+}
+
+bool UTestbed1StructArrayInterfaceMsgBusAdapter::_CheckClientTimeoutsTick(float /*DeltaTime*/)
+{
+	_CheckClientTimeouts();
+	return true;
 }
 
 void UTestbed1StructArrayInterfaceMsgBusAdapter::_CheckClientTimeouts()

--- a/goldenmaster/Plugins/Testbed1/Source/Testbed1/Private/Generated/MsgBus/Testbed1StructArrayInterfaceMsgBusAdapter.cpp
+++ b/goldenmaster/Plugins/Testbed1/Source/Testbed1/Private/Generated/MsgBus/Testbed1StructArrayInterfaceMsgBusAdapter.cpp
@@ -24,12 +24,12 @@ limitations under the License.
 #include "Generated/MsgBus/Testbed1StructArrayInterfaceMsgBusMessages.h"
 #include "Async/Future.h"
 #include "Async/Async.h"
-#include "Async/Async.h"
-#include "Engine/Engine.h"
+#include "Engine/World.h"
 #include "TimerManager.h"
 #include "MessageEndpoint.h"
 #include "MessageEndpointBuilder.h"
 #include "Misc/DateTime.h"
+#include "Testbed1Settings.h"
 
 DEFINE_LOG_CATEGORY(LogTestbed1StructArrayInterfaceMsgBusAdapter);
 UTestbed1StructArrayInterfaceMsgBusAdapter::UTestbed1StructArrayInterfaceMsgBusAdapter()
@@ -53,6 +53,10 @@ void UTestbed1StructArrayInterfaceMsgBusAdapter::_StartListening()
 
 	if (!_HeartbeatTimerHandle.IsValid() && GetWorld())
 	{
+		UTestbed1Settings* settings = GetMutableDefault<UTestbed1Settings>();
+		check(settings);
+		_HeartbeatIntervalMS = settings->MsgBusHeartbeatIntervalMS;
+
 		GetWorld()->GetTimerManager().SetTimer(_HeartbeatTimerHandle, this, &UTestbed1StructArrayInterfaceMsgBusAdapter::_CheckClientTimeouts, _HeartbeatIntervalMS / 1000.0f, true);
 	}
 

--- a/goldenmaster/Plugins/Testbed1/Source/Testbed1/Private/Generated/MsgBus/Testbed1StructArrayInterfaceMsgBusClient.cpp
+++ b/goldenmaster/Plugins/Testbed1/Source/Testbed1/Private/Generated/MsgBus/Testbed1StructArrayInterfaceMsgBusClient.cpp
@@ -24,7 +24,6 @@ limitations under the License.
 #include "Generated/MsgBus/Testbed1StructArrayInterfaceMsgBusMessages.h"
 #include "Async/Async.h"
 #include "Engine/World.h"
-#include "TimerManager.h"
 #include "Misc/DateTime.h"
 #include "GenericPlatform/GenericPlatformMath.h"
 #include "GenericPlatform/GenericPlatformTime.h"
@@ -74,19 +73,25 @@ void UTestbed1StructArrayInterfaceMsgBusClient::Deinitialize()
 
 void UTestbed1StructArrayInterfaceMsgBusClient::_Connect()
 {
-	if (!_HeartbeatTimerHandle.IsValid() && GetWorld())
+	if (_IsConnected())
+	{
+		UE_LOG(LogTestbed1StructArrayInterfaceMsgBusClient, Log, TEXT("Already connected, cannot connect again."));
+		return;
+	}
+
+	if (!_HeartbeatTickerHandle.IsValid())
 	{
 		UTestbed1Settings* settings = GetMutableDefault<UTestbed1Settings>();
 		check(settings);
 		_HeartbeatIntervalMS = settings->MsgBusHeartbeatIntervalMS;
 
-		GetWorld()->GetTimerManager().SetTimer(_HeartbeatTimerHandle, this, &UTestbed1StructArrayInterfaceMsgBusClient::_OnHeartbeat, _HeartbeatIntervalMS / 1000.0f, true);
-	}
-
-	if (_IsConnected())
-	{
-		UE_LOG(LogTestbed1StructArrayInterfaceMsgBusClient, Log, TEXT("Already connected, cannot connect again."));
-		return;
+#if (ENGINE_MAJOR_VERSION < 5)
+		FTicker::GetCoreTicker().RemoveTicker(_HeartbeatTickerHandle);
+		_HeartbeatTickerHandle = FTicker::GetCoreTicker().AddTicker(FTickerDelegate::CreateUObject(this, &UTestbed1StructArrayInterfaceMsgBusClient::_OnHeartbeatTick), _HeartbeatIntervalMS / 1000.0f);
+#else
+		FTSTicker::GetCoreTicker().RemoveTicker(_HeartbeatTickerHandle);
+		_HeartbeatTickerHandle = FTSTicker::GetCoreTicker().AddTicker(FTickerDelegate::CreateUObject(this, &UTestbed1StructArrayInterfaceMsgBusClient::_OnHeartbeatTick), _HeartbeatIntervalMS / 1000.0f);
+#endif
 	}
 
 	if (Testbed1StructArrayInterfaceMsgBusEndpoint.IsValid() && !ServiceAddress.IsValid())
@@ -124,10 +129,12 @@ void UTestbed1StructArrayInterfaceMsgBusClient::_Connect()
 void UTestbed1StructArrayInterfaceMsgBusClient::_Disconnect()
 {
 	_LastHbTimestamp = 0.0f;
-	if (_HeartbeatTimerHandle.IsValid() && GetWorld())
-	{
-		GetWorld()->GetTimerManager().ClearTimer(_HeartbeatTimerHandle);
-	}
+
+#if (ENGINE_MAJOR_VERSION < 5)
+	FTicker::GetCoreTicker().RemoveTicker(_HeartbeatTickerHandle);
+#else
+	FTSTicker::GetCoreTicker().RemoveTicker(_HeartbeatTickerHandle);
+#endif
 
 	if (!_IsConnected())
 	{
@@ -188,15 +195,13 @@ void UTestbed1StructArrayInterfaceMsgBusClient::OnConnectionInit(const FTestbed1
 	{
 		_HeartbeatIntervalMS = InMessage._ClientPingIntervalMS;
 
-		if (_HeartbeatTimerHandle.IsValid() && GetWorld())
-		{
-			GetWorld()->GetTimerManager().ClearTimer(_HeartbeatTimerHandle);
-		}
-
-		if (!_HeartbeatTimerHandle.IsValid() && GetWorld())
-		{
-			GetWorld()->GetTimerManager().SetTimer(_HeartbeatTimerHandle, this, &UTestbed1StructArrayInterfaceMsgBusClient::_OnHeartbeat, _HeartbeatIntervalMS / 1000.0f, true);
-		}
+#if (ENGINE_MAJOR_VERSION < 5)
+		FTicker::GetCoreTicker().RemoveTicker(_HeartbeatTickerHandle);
+		_HeartbeatTickerHandle = FTicker::GetCoreTicker().AddTicker(FTickerDelegate::CreateUObject(this, &UTestbed1StructArrayInterfaceMsgBusClient::_OnHeartbeatTick), _HeartbeatIntervalMS / 1000.0f);
+#else
+		FTSTicker::GetCoreTicker().RemoveTicker(_HeartbeatTickerHandle);
+		_HeartbeatTickerHandle = FTSTicker::GetCoreTicker().AddTicker(FTickerDelegate::CreateUObject(this, &UTestbed1StructArrayInterfaceMsgBusClient::_OnHeartbeatTick), _HeartbeatIntervalMS / 1000.0f);
+#endif
 	}
 	const bool bPropBoolChanged = InMessage.PropBool != PropBool;
 	if (bPropBoolChanged)
@@ -234,6 +239,12 @@ void UTestbed1StructArrayInterfaceMsgBusClient::OnConnectionInit(const FTestbed1
 	}
 
 	_ConnectionStatusChanged.Broadcast(true);
+}
+
+bool UTestbed1StructArrayInterfaceMsgBusClient::_OnHeartbeatTick(float /*DeltaTime*/)
+{
+	_OnHeartbeat();
+	return true;
 }
 
 void UTestbed1StructArrayInterfaceMsgBusClient::_OnHeartbeat()

--- a/goldenmaster/Plugins/Testbed1/Source/Testbed1/Private/Generated/MsgBus/Testbed1StructArrayInterfaceMsgBusClient.cpp
+++ b/goldenmaster/Plugins/Testbed1/Source/Testbed1/Private/Generated/MsgBus/Testbed1StructArrayInterfaceMsgBusClient.cpp
@@ -23,13 +23,14 @@ limitations under the License.
 #include "Generated/MsgBus/Testbed1StructArrayInterfaceMsgBusClient.h"
 #include "Generated/MsgBus/Testbed1StructArrayInterfaceMsgBusMessages.h"
 #include "Async/Async.h"
-#include "Engine/Engine.h"
+#include "Engine/World.h"
 #include "TimerManager.h"
 #include "Misc/DateTime.h"
 #include "GenericPlatform/GenericPlatformMath.h"
 #include "GenericPlatform/GenericPlatformTime.h"
 #include "MessageEndpointBuilder.h"
 #include "MessageEndpoint.h"
+#include "Testbed1Settings.h"
 #include "HAL/CriticalSection.h"
 
 /**
@@ -75,6 +76,10 @@ void UTestbed1StructArrayInterfaceMsgBusClient::_Connect()
 {
 	if (!_HeartbeatTimerHandle.IsValid() && GetWorld())
 	{
+		UTestbed1Settings* settings = GetMutableDefault<UTestbed1Settings>();
+		check(settings);
+		_HeartbeatIntervalMS = settings->MsgBusHeartbeatIntervalMS;
+
 		GetWorld()->GetTimerManager().SetTimer(_HeartbeatTimerHandle, this, &UTestbed1StructArrayInterfaceMsgBusClient::_OnHeartbeat, _HeartbeatIntervalMS / 1000.0f, true);
 	}
 

--- a/goldenmaster/Plugins/Testbed1/Source/Testbed1/Private/Generated/MsgBus/Testbed1StructInterfaceMsgBusAdapter.cpp
+++ b/goldenmaster/Plugins/Testbed1/Source/Testbed1/Private/Generated/MsgBus/Testbed1StructInterfaceMsgBusAdapter.cpp
@@ -25,7 +25,6 @@ limitations under the License.
 #include "Async/Future.h"
 #include "Async/Async.h"
 #include "Engine/World.h"
-#include "TimerManager.h"
 #include "MessageEndpoint.h"
 #include "MessageEndpointBuilder.h"
 #include "Misc/DateTime.h"
@@ -51,13 +50,17 @@ void UTestbed1StructInterfaceMsgBusAdapter::Deinitialize()
 void UTestbed1StructInterfaceMsgBusAdapter::_StartListening()
 {
 
-	if (!_HeartbeatTimerHandle.IsValid() && GetWorld())
+	if (!_HeartbeatTickerHandle.IsValid())
 	{
 		UTestbed1Settings* settings = GetMutableDefault<UTestbed1Settings>();
 		check(settings);
 		_HeartbeatIntervalMS = settings->MsgBusHeartbeatIntervalMS;
 
-		GetWorld()->GetTimerManager().SetTimer(_HeartbeatTimerHandle, this, &UTestbed1StructInterfaceMsgBusAdapter::_CheckClientTimeouts, _HeartbeatIntervalMS / 1000.0f, true);
+#if (ENGINE_MAJOR_VERSION < 5)
+		_HeartbeatTickerHandle = FTicker::GetCoreTicker().AddTicker(FTickerDelegate::CreateUObject(this, &UTestbed1StructInterfaceMsgBusAdapter::_CheckClientTimeoutsTick), _HeartbeatIntervalMS / 1000.0f);
+#else
+		_HeartbeatTickerHandle = FTSTicker::GetCoreTicker().AddTicker(FTickerDelegate::CreateUObject(this, &UTestbed1StructInterfaceMsgBusAdapter::_CheckClientTimeoutsTick), _HeartbeatIntervalMS / 1000.0f);
+#endif
 	}
 
 	if (Testbed1StructInterfaceMsgBusEndpoint.IsValid())
@@ -103,9 +106,13 @@ void UTestbed1StructInterfaceMsgBusAdapter::_AnnounceService()
 
 void UTestbed1StructInterfaceMsgBusAdapter::_StopListening()
 {
-	if (_HeartbeatTimerHandle.IsValid() && GetWorld())
+	if (_HeartbeatTickerHandle.IsValid())
 	{
-		GetWorld()->GetTimerManager().ClearTimer(_HeartbeatTimerHandle);
+#if (ENGINE_MAJOR_VERSION < 5)
+		FTicker::GetCoreTicker().RemoveTicker(_HeartbeatTickerHandle);
+#else
+		FTSTicker::GetCoreTicker().RemoveTicker(_HeartbeatTickerHandle);
+#endif
 	}
 
 	auto msg = new FTestbed1StructInterfaceServiceDisconnectMessage();
@@ -262,6 +269,12 @@ void UTestbed1StructInterfaceMsgBusAdapter::OnClientDisconnected(const FTestbed1
 	ConnectedClientsTimestamps.Remove(Context->GetSender());
 	_OnClientDisconnected.Broadcast(Context->GetSender().ToString());
 	_UpdateClientsConnected();
+}
+
+bool UTestbed1StructInterfaceMsgBusAdapter::_CheckClientTimeoutsTick(float /*DeltaTime*/)
+{
+	_CheckClientTimeouts();
+	return true;
 }
 
 void UTestbed1StructInterfaceMsgBusAdapter::_CheckClientTimeouts()

--- a/goldenmaster/Plugins/Testbed1/Source/Testbed1/Private/Generated/MsgBus/Testbed1StructInterfaceMsgBusAdapter.cpp
+++ b/goldenmaster/Plugins/Testbed1/Source/Testbed1/Private/Generated/MsgBus/Testbed1StructInterfaceMsgBusAdapter.cpp
@@ -24,12 +24,12 @@ limitations under the License.
 #include "Generated/MsgBus/Testbed1StructInterfaceMsgBusMessages.h"
 #include "Async/Future.h"
 #include "Async/Async.h"
-#include "Async/Async.h"
-#include "Engine/Engine.h"
+#include "Engine/World.h"
 #include "TimerManager.h"
 #include "MessageEndpoint.h"
 #include "MessageEndpointBuilder.h"
 #include "Misc/DateTime.h"
+#include "Testbed1Settings.h"
 
 DEFINE_LOG_CATEGORY(LogTestbed1StructInterfaceMsgBusAdapter);
 UTestbed1StructInterfaceMsgBusAdapter::UTestbed1StructInterfaceMsgBusAdapter()
@@ -53,6 +53,10 @@ void UTestbed1StructInterfaceMsgBusAdapter::_StartListening()
 
 	if (!_HeartbeatTimerHandle.IsValid() && GetWorld())
 	{
+		UTestbed1Settings* settings = GetMutableDefault<UTestbed1Settings>();
+		check(settings);
+		_HeartbeatIntervalMS = settings->MsgBusHeartbeatIntervalMS;
+
 		GetWorld()->GetTimerManager().SetTimer(_HeartbeatTimerHandle, this, &UTestbed1StructInterfaceMsgBusAdapter::_CheckClientTimeouts, _HeartbeatIntervalMS / 1000.0f, true);
 	}
 

--- a/goldenmaster/Plugins/Testbed1/Source/Testbed1/Private/Generated/MsgBus/Testbed1StructInterfaceMsgBusClient.cpp
+++ b/goldenmaster/Plugins/Testbed1/Source/Testbed1/Private/Generated/MsgBus/Testbed1StructInterfaceMsgBusClient.cpp
@@ -23,13 +23,14 @@ limitations under the License.
 #include "Generated/MsgBus/Testbed1StructInterfaceMsgBusClient.h"
 #include "Generated/MsgBus/Testbed1StructInterfaceMsgBusMessages.h"
 #include "Async/Async.h"
-#include "Engine/Engine.h"
+#include "Engine/World.h"
 #include "TimerManager.h"
 #include "Misc/DateTime.h"
 #include "GenericPlatform/GenericPlatformMath.h"
 #include "GenericPlatform/GenericPlatformTime.h"
 #include "MessageEndpointBuilder.h"
 #include "MessageEndpoint.h"
+#include "Testbed1Settings.h"
 #include "HAL/CriticalSection.h"
 
 /**
@@ -73,6 +74,10 @@ void UTestbed1StructInterfaceMsgBusClient::_Connect()
 {
 	if (!_HeartbeatTimerHandle.IsValid() && GetWorld())
 	{
+		UTestbed1Settings* settings = GetMutableDefault<UTestbed1Settings>();
+		check(settings);
+		_HeartbeatIntervalMS = settings->MsgBusHeartbeatIntervalMS;
+
 		GetWorld()->GetTimerManager().SetTimer(_HeartbeatTimerHandle, this, &UTestbed1StructInterfaceMsgBusClient::_OnHeartbeat, _HeartbeatIntervalMS / 1000.0f, true);
 	}
 

--- a/goldenmaster/Plugins/Testbed1/Source/Testbed1/Private/Generated/MsgBus/Testbed1StructInterfaceMsgBusClient.cpp
+++ b/goldenmaster/Plugins/Testbed1/Source/Testbed1/Private/Generated/MsgBus/Testbed1StructInterfaceMsgBusClient.cpp
@@ -24,7 +24,6 @@ limitations under the License.
 #include "Generated/MsgBus/Testbed1StructInterfaceMsgBusMessages.h"
 #include "Async/Async.h"
 #include "Engine/World.h"
-#include "TimerManager.h"
 #include "Misc/DateTime.h"
 #include "GenericPlatform/GenericPlatformMath.h"
 #include "GenericPlatform/GenericPlatformTime.h"
@@ -72,19 +71,25 @@ void UTestbed1StructInterfaceMsgBusClient::Deinitialize()
 
 void UTestbed1StructInterfaceMsgBusClient::_Connect()
 {
-	if (!_HeartbeatTimerHandle.IsValid() && GetWorld())
+	if (_IsConnected())
+	{
+		UE_LOG(LogTestbed1StructInterfaceMsgBusClient, Log, TEXT("Already connected, cannot connect again."));
+		return;
+	}
+
+	if (!_HeartbeatTickerHandle.IsValid())
 	{
 		UTestbed1Settings* settings = GetMutableDefault<UTestbed1Settings>();
 		check(settings);
 		_HeartbeatIntervalMS = settings->MsgBusHeartbeatIntervalMS;
 
-		GetWorld()->GetTimerManager().SetTimer(_HeartbeatTimerHandle, this, &UTestbed1StructInterfaceMsgBusClient::_OnHeartbeat, _HeartbeatIntervalMS / 1000.0f, true);
-	}
-
-	if (_IsConnected())
-	{
-		UE_LOG(LogTestbed1StructInterfaceMsgBusClient, Log, TEXT("Already connected, cannot connect again."));
-		return;
+#if (ENGINE_MAJOR_VERSION < 5)
+		FTicker::GetCoreTicker().RemoveTicker(_HeartbeatTickerHandle);
+		_HeartbeatTickerHandle = FTicker::GetCoreTicker().AddTicker(FTickerDelegate::CreateUObject(this, &UTestbed1StructInterfaceMsgBusClient::_OnHeartbeatTick), _HeartbeatIntervalMS / 1000.0f);
+#else
+		FTSTicker::GetCoreTicker().RemoveTicker(_HeartbeatTickerHandle);
+		_HeartbeatTickerHandle = FTSTicker::GetCoreTicker().AddTicker(FTickerDelegate::CreateUObject(this, &UTestbed1StructInterfaceMsgBusClient::_OnHeartbeatTick), _HeartbeatIntervalMS / 1000.0f);
+#endif
 	}
 
 	if (Testbed1StructInterfaceMsgBusEndpoint.IsValid() && !ServiceAddress.IsValid())
@@ -119,10 +124,12 @@ void UTestbed1StructInterfaceMsgBusClient::_Connect()
 void UTestbed1StructInterfaceMsgBusClient::_Disconnect()
 {
 	_LastHbTimestamp = 0.0f;
-	if (_HeartbeatTimerHandle.IsValid() && GetWorld())
-	{
-		GetWorld()->GetTimerManager().ClearTimer(_HeartbeatTimerHandle);
-	}
+
+#if (ENGINE_MAJOR_VERSION < 5)
+	FTicker::GetCoreTicker().RemoveTicker(_HeartbeatTickerHandle);
+#else
+	FTSTicker::GetCoreTicker().RemoveTicker(_HeartbeatTickerHandle);
+#endif
 
 	if (!_IsConnected())
 	{
@@ -183,15 +190,13 @@ void UTestbed1StructInterfaceMsgBusClient::OnConnectionInit(const FTestbed1Struc
 	{
 		_HeartbeatIntervalMS = InMessage._ClientPingIntervalMS;
 
-		if (_HeartbeatTimerHandle.IsValid() && GetWorld())
-		{
-			GetWorld()->GetTimerManager().ClearTimer(_HeartbeatTimerHandle);
-		}
-
-		if (!_HeartbeatTimerHandle.IsValid() && GetWorld())
-		{
-			GetWorld()->GetTimerManager().SetTimer(_HeartbeatTimerHandle, this, &UTestbed1StructInterfaceMsgBusClient::_OnHeartbeat, _HeartbeatIntervalMS / 1000.0f, true);
-		}
+#if (ENGINE_MAJOR_VERSION < 5)
+		FTicker::GetCoreTicker().RemoveTicker(_HeartbeatTickerHandle);
+		_HeartbeatTickerHandle = FTicker::GetCoreTicker().AddTicker(FTickerDelegate::CreateUObject(this, &UTestbed1StructInterfaceMsgBusClient::_OnHeartbeatTick), _HeartbeatIntervalMS / 1000.0f);
+#else
+		FTSTicker::GetCoreTicker().RemoveTicker(_HeartbeatTickerHandle);
+		_HeartbeatTickerHandle = FTSTicker::GetCoreTicker().AddTicker(FTickerDelegate::CreateUObject(this, &UTestbed1StructInterfaceMsgBusClient::_OnHeartbeatTick), _HeartbeatIntervalMS / 1000.0f);
+#endif
 	}
 	const bool bPropBoolChanged = InMessage.PropBool != PropBool;
 	if (bPropBoolChanged)
@@ -222,6 +227,12 @@ void UTestbed1StructInterfaceMsgBusClient::OnConnectionInit(const FTestbed1Struc
 	}
 
 	_ConnectionStatusChanged.Broadcast(true);
+}
+
+bool UTestbed1StructInterfaceMsgBusClient::_OnHeartbeatTick(float /*DeltaTime*/)
+{
+	_OnHeartbeat();
+	return true;
 }
 
 void UTestbed1StructInterfaceMsgBusClient::_OnHeartbeat()

--- a/goldenmaster/Plugins/Testbed1/Source/Testbed1/Public/Generated/MsgBus/Testbed1StructArray2InterfaceMsgBusAdapter.h
+++ b/goldenmaster/Plugins/Testbed1/Source/Testbed1/Public/Generated/MsgBus/Testbed1StructArray2InterfaceMsgBusAdapter.h
@@ -21,11 +21,7 @@ limitations under the License.
 #include "IMessageContext.h"
 #include "Templates/SharedPointer.h"
 #include "Runtime/Launch/Resources/Version.h"
-#if (ENGINE_MAJOR_VERSION < 5)
-#include "Engine/EngineTypes.h"
-#else
-#include "Engine/TimerHandle.h"
-#endif
+#include "Containers/Ticker.h"
 #include "Testbed1StructArray2InterfaceMsgBusAdapter.generated.h"
 
 class FMessageEndpoint;
@@ -162,9 +158,14 @@ private:
 
 	// Heartbeat handling
 	void _CheckClientTimeouts();
+	bool _CheckClientTimeoutsTick(float DeltaTime);
 	void _UpdateClientsConnected();
 	TMap<FMessageAddress, double> ConnectedClientsTimestamps;
-	FTimerHandle _HeartbeatTimerHandle;
+#if (ENGINE_MAJOR_VERSION < 5)
+	::FDelegateHandle _HeartbeatTickerHandle;
+#else
+	FTSTicker::FDelegateHandle _HeartbeatTickerHandle;
+#endif
 	int32 _ClientsConnected = 0;
 	uint32 _HeartbeatIntervalMS = 100;
 };

--- a/goldenmaster/Plugins/Testbed1/Source/Testbed1/Public/Generated/MsgBus/Testbed1StructArray2InterfaceMsgBusClient.h
+++ b/goldenmaster/Plugins/Testbed1/Source/Testbed1/Public/Generated/MsgBus/Testbed1StructArray2InterfaceMsgBusClient.h
@@ -22,11 +22,7 @@ limitations under the License.
 #include "HAL/CriticalSection.h"
 #include "Async/Future.h"
 #include "Runtime/Launch/Resources/Version.h"
-#if (ENGINE_MAJOR_VERSION < 5)
-#include "Engine/EngineTypes.h"
-#else
-#include "Engine/TimerHandle.h"
-#endif
+#include "Containers/Ticker.h"
 #include "Templates/PimplPtr.h"
 #include "IMessageContext.h"
 #include "Testbed1StructArray2InterfaceMsgBusClient.generated.h"
@@ -150,8 +146,13 @@ private:
 	size_t CurrentPingCounter = 0;
 	float _CalculateAverageRTT() const;
 	FTestbed1StructArray2InterfaceStats Stats;
-	FTimerHandle _HeartbeatTimerHandle;
+#if (ENGINE_MAJOR_VERSION < 5)
+	::FDelegateHandle _HeartbeatTickerHandle;
+#else
+	FTSTicker::FDelegateHandle _HeartbeatTickerHandle;
+#endif
 	void _OnHeartbeat();
+	bool _OnHeartbeatTick(float DeltaTime);
 	uint32 _HeartbeatIntervalMS = 100;
 
 	// connection handling

--- a/goldenmaster/Plugins/Testbed1/Source/Testbed1/Public/Generated/MsgBus/Testbed1StructArrayInterfaceMsgBusAdapter.h
+++ b/goldenmaster/Plugins/Testbed1/Source/Testbed1/Public/Generated/MsgBus/Testbed1StructArrayInterfaceMsgBusAdapter.h
@@ -21,11 +21,7 @@ limitations under the License.
 #include "IMessageContext.h"
 #include "Templates/SharedPointer.h"
 #include "Runtime/Launch/Resources/Version.h"
-#if (ENGINE_MAJOR_VERSION < 5)
-#include "Engine/EngineTypes.h"
-#else
-#include "Engine/TimerHandle.h"
-#endif
+#include "Containers/Ticker.h"
 #include "Testbed1StructArrayInterfaceMsgBusAdapter.generated.h"
 
 class FMessageEndpoint;
@@ -166,9 +162,14 @@ private:
 
 	// Heartbeat handling
 	void _CheckClientTimeouts();
+	bool _CheckClientTimeoutsTick(float DeltaTime);
 	void _UpdateClientsConnected();
 	TMap<FMessageAddress, double> ConnectedClientsTimestamps;
-	FTimerHandle _HeartbeatTimerHandle;
+#if (ENGINE_MAJOR_VERSION < 5)
+	::FDelegateHandle _HeartbeatTickerHandle;
+#else
+	FTSTicker::FDelegateHandle _HeartbeatTickerHandle;
+#endif
 	int32 _ClientsConnected = 0;
 	uint32 _HeartbeatIntervalMS = 100;
 };

--- a/goldenmaster/Plugins/Testbed1/Source/Testbed1/Public/Generated/MsgBus/Testbed1StructArrayInterfaceMsgBusClient.h
+++ b/goldenmaster/Plugins/Testbed1/Source/Testbed1/Public/Generated/MsgBus/Testbed1StructArrayInterfaceMsgBusClient.h
@@ -22,11 +22,7 @@ limitations under the License.
 #include "HAL/CriticalSection.h"
 #include "Async/Future.h"
 #include "Runtime/Launch/Resources/Version.h"
-#if (ENGINE_MAJOR_VERSION < 5)
-#include "Engine/EngineTypes.h"
-#else
-#include "Engine/TimerHandle.h"
-#endif
+#include "Containers/Ticker.h"
 #include "Templates/PimplPtr.h"
 #include "IMessageContext.h"
 #include "Testbed1StructArrayInterfaceMsgBusClient.generated.h"
@@ -151,8 +147,13 @@ private:
 	size_t CurrentPingCounter = 0;
 	float _CalculateAverageRTT() const;
 	FTestbed1StructArrayInterfaceStats Stats;
-	FTimerHandle _HeartbeatTimerHandle;
+#if (ENGINE_MAJOR_VERSION < 5)
+	::FDelegateHandle _HeartbeatTickerHandle;
+#else
+	FTSTicker::FDelegateHandle _HeartbeatTickerHandle;
+#endif
 	void _OnHeartbeat();
+	bool _OnHeartbeatTick(float DeltaTime);
 	uint32 _HeartbeatIntervalMS = 100;
 
 	// connection handling

--- a/goldenmaster/Plugins/Testbed1/Source/Testbed1/Public/Generated/MsgBus/Testbed1StructInterfaceMsgBusAdapter.h
+++ b/goldenmaster/Plugins/Testbed1/Source/Testbed1/Public/Generated/MsgBus/Testbed1StructInterfaceMsgBusAdapter.h
@@ -21,11 +21,7 @@ limitations under the License.
 #include "IMessageContext.h"
 #include "Templates/SharedPointer.h"
 #include "Runtime/Launch/Resources/Version.h"
-#if (ENGINE_MAJOR_VERSION < 5)
-#include "Engine/EngineTypes.h"
-#else
-#include "Engine/TimerHandle.h"
-#endif
+#include "Containers/Ticker.h"
 #include "Testbed1StructInterfaceMsgBusAdapter.generated.h"
 
 class FMessageEndpoint;
@@ -154,9 +150,14 @@ private:
 
 	// Heartbeat handling
 	void _CheckClientTimeouts();
+	bool _CheckClientTimeoutsTick(float DeltaTime);
 	void _UpdateClientsConnected();
 	TMap<FMessageAddress, double> ConnectedClientsTimestamps;
-	FTimerHandle _HeartbeatTimerHandle;
+#if (ENGINE_MAJOR_VERSION < 5)
+	::FDelegateHandle _HeartbeatTickerHandle;
+#else
+	FTSTicker::FDelegateHandle _HeartbeatTickerHandle;
+#endif
 	int32 _ClientsConnected = 0;
 	uint32 _HeartbeatIntervalMS = 100;
 };

--- a/goldenmaster/Plugins/Testbed1/Source/Testbed1/Public/Generated/MsgBus/Testbed1StructInterfaceMsgBusClient.h
+++ b/goldenmaster/Plugins/Testbed1/Source/Testbed1/Public/Generated/MsgBus/Testbed1StructInterfaceMsgBusClient.h
@@ -22,11 +22,7 @@ limitations under the License.
 #include "HAL/CriticalSection.h"
 #include "Async/Future.h"
 #include "Runtime/Launch/Resources/Version.h"
-#if (ENGINE_MAJOR_VERSION < 5)
-#include "Engine/EngineTypes.h"
-#else
-#include "Engine/TimerHandle.h"
-#endif
+#include "Containers/Ticker.h"
 #include "Templates/PimplPtr.h"
 #include "IMessageContext.h"
 #include "Testbed1StructInterfaceMsgBusClient.generated.h"
@@ -143,8 +139,13 @@ private:
 	size_t CurrentPingCounter = 0;
 	float _CalculateAverageRTT() const;
 	FTestbed1StructInterfaceStats Stats;
-	FTimerHandle _HeartbeatTimerHandle;
+#if (ENGINE_MAJOR_VERSION < 5)
+	::FDelegateHandle _HeartbeatTickerHandle;
+#else
+	FTSTicker::FDelegateHandle _HeartbeatTickerHandle;
+#endif
 	void _OnHeartbeat();
+	bool _OnHeartbeatTick(float DeltaTime);
 	uint32 _HeartbeatIntervalMS = 100;
 
 	// connection handling

--- a/goldenmaster/Plugins/Testbed1/Source/Testbed1/Public/Testbed1Settings.h
+++ b/goldenmaster/Plugins/Testbed1/Source/Testbed1/Public/Testbed1Settings.h
@@ -45,4 +45,11 @@ public:
 	/** Choose the olink connection to use */
 	UPROPERTY(EditAnywhere, config, Category = OLinkConnectionSetup)
 	FString OLinkConnectionIdentifier;
+
+	/** Choose the heartbeat interval in milliseconds for the msgbus connection on the service side.
+	 * On the service side this adjusts the heartbeat between client and service. The clients will receive the value from service.
+	 * On the client side this adjusts how often discovery messages are sent until a service is connected.
+	 */
+	UPROPERTY(EditAnywhere, config, Category = MsgBusConnectionSetup, meta = (DisplayName = "Heartbeat interval (in milliseconds)"))
+	uint32 MsgBusHeartbeatIntervalMS = 200;
 };

--- a/goldenmaster/Plugins/Testbed1/Testbed1.uplugin
+++ b/goldenmaster/Plugins/Testbed1/Testbed1.uplugin
@@ -2,7 +2,7 @@
 {
 	"FileVersion": 3,
 	"Version": 1,
-	"VersionName": "1.0.0",
+	"VersionName": "1.0.0+tpl.3.5.2",
 	"FriendlyName": "Testbed1",
 	"Description": "",
 	"Category": "Other",

--- a/goldenmaster/Plugins/Testbed2/Source/Testbed2/Private/Generated/MsgBus/Testbed2ManyParamInterfaceMsgBusAdapter.cpp
+++ b/goldenmaster/Plugins/Testbed2/Source/Testbed2/Private/Generated/MsgBus/Testbed2ManyParamInterfaceMsgBusAdapter.cpp
@@ -25,7 +25,6 @@ limitations under the License.
 #include "Async/Future.h"
 #include "Async/Async.h"
 #include "Engine/World.h"
-#include "TimerManager.h"
 #include "MessageEndpoint.h"
 #include "MessageEndpointBuilder.h"
 #include "Misc/DateTime.h"
@@ -51,13 +50,17 @@ void UTestbed2ManyParamInterfaceMsgBusAdapter::Deinitialize()
 void UTestbed2ManyParamInterfaceMsgBusAdapter::_StartListening()
 {
 
-	if (!_HeartbeatTimerHandle.IsValid() && GetWorld())
+	if (!_HeartbeatTickerHandle.IsValid())
 	{
 		UTestbed2Settings* settings = GetMutableDefault<UTestbed2Settings>();
 		check(settings);
 		_HeartbeatIntervalMS = settings->MsgBusHeartbeatIntervalMS;
 
-		GetWorld()->GetTimerManager().SetTimer(_HeartbeatTimerHandle, this, &UTestbed2ManyParamInterfaceMsgBusAdapter::_CheckClientTimeouts, _HeartbeatIntervalMS / 1000.0f, true);
+#if (ENGINE_MAJOR_VERSION < 5)
+		_HeartbeatTickerHandle = FTicker::GetCoreTicker().AddTicker(FTickerDelegate::CreateUObject(this, &UTestbed2ManyParamInterfaceMsgBusAdapter::_CheckClientTimeoutsTick), _HeartbeatIntervalMS / 1000.0f);
+#else
+		_HeartbeatTickerHandle = FTSTicker::GetCoreTicker().AddTicker(FTickerDelegate::CreateUObject(this, &UTestbed2ManyParamInterfaceMsgBusAdapter::_CheckClientTimeoutsTick), _HeartbeatIntervalMS / 1000.0f);
+#endif
 	}
 
 	if (Testbed2ManyParamInterfaceMsgBusEndpoint.IsValid())
@@ -103,9 +106,13 @@ void UTestbed2ManyParamInterfaceMsgBusAdapter::_AnnounceService()
 
 void UTestbed2ManyParamInterfaceMsgBusAdapter::_StopListening()
 {
-	if (_HeartbeatTimerHandle.IsValid() && GetWorld())
+	if (_HeartbeatTickerHandle.IsValid())
 	{
-		GetWorld()->GetTimerManager().ClearTimer(_HeartbeatTimerHandle);
+#if (ENGINE_MAJOR_VERSION < 5)
+		FTicker::GetCoreTicker().RemoveTicker(_HeartbeatTickerHandle);
+#else
+		FTSTicker::GetCoreTicker().RemoveTicker(_HeartbeatTickerHandle);
+#endif
 	}
 
 	auto msg = new FTestbed2ManyParamInterfaceServiceDisconnectMessage();
@@ -262,6 +269,12 @@ void UTestbed2ManyParamInterfaceMsgBusAdapter::OnClientDisconnected(const FTestb
 	ConnectedClientsTimestamps.Remove(Context->GetSender());
 	_OnClientDisconnected.Broadcast(Context->GetSender().ToString());
 	_UpdateClientsConnected();
+}
+
+bool UTestbed2ManyParamInterfaceMsgBusAdapter::_CheckClientTimeoutsTick(float /*DeltaTime*/)
+{
+	_CheckClientTimeouts();
+	return true;
 }
 
 void UTestbed2ManyParamInterfaceMsgBusAdapter::_CheckClientTimeouts()

--- a/goldenmaster/Plugins/Testbed2/Source/Testbed2/Private/Generated/MsgBus/Testbed2ManyParamInterfaceMsgBusAdapter.cpp
+++ b/goldenmaster/Plugins/Testbed2/Source/Testbed2/Private/Generated/MsgBus/Testbed2ManyParamInterfaceMsgBusAdapter.cpp
@@ -24,12 +24,12 @@ limitations under the License.
 #include "Generated/MsgBus/Testbed2ManyParamInterfaceMsgBusMessages.h"
 #include "Async/Future.h"
 #include "Async/Async.h"
-#include "Async/Async.h"
-#include "Engine/Engine.h"
+#include "Engine/World.h"
 #include "TimerManager.h"
 #include "MessageEndpoint.h"
 #include "MessageEndpointBuilder.h"
 #include "Misc/DateTime.h"
+#include "Testbed2Settings.h"
 
 DEFINE_LOG_CATEGORY(LogTestbed2ManyParamInterfaceMsgBusAdapter);
 UTestbed2ManyParamInterfaceMsgBusAdapter::UTestbed2ManyParamInterfaceMsgBusAdapter()
@@ -53,6 +53,10 @@ void UTestbed2ManyParamInterfaceMsgBusAdapter::_StartListening()
 
 	if (!_HeartbeatTimerHandle.IsValid() && GetWorld())
 	{
+		UTestbed2Settings* settings = GetMutableDefault<UTestbed2Settings>();
+		check(settings);
+		_HeartbeatIntervalMS = settings->MsgBusHeartbeatIntervalMS;
+
 		GetWorld()->GetTimerManager().SetTimer(_HeartbeatTimerHandle, this, &UTestbed2ManyParamInterfaceMsgBusAdapter::_CheckClientTimeouts, _HeartbeatIntervalMS / 1000.0f, true);
 	}
 

--- a/goldenmaster/Plugins/Testbed2/Source/Testbed2/Private/Generated/MsgBus/Testbed2ManyParamInterfaceMsgBusClient.cpp
+++ b/goldenmaster/Plugins/Testbed2/Source/Testbed2/Private/Generated/MsgBus/Testbed2ManyParamInterfaceMsgBusClient.cpp
@@ -24,7 +24,6 @@ limitations under the License.
 #include "Generated/MsgBus/Testbed2ManyParamInterfaceMsgBusMessages.h"
 #include "Async/Async.h"
 #include "Engine/World.h"
-#include "TimerManager.h"
 #include "Misc/DateTime.h"
 #include "GenericPlatform/GenericPlatformMath.h"
 #include "GenericPlatform/GenericPlatformTime.h"
@@ -68,19 +67,25 @@ void UTestbed2ManyParamInterfaceMsgBusClient::Deinitialize()
 
 void UTestbed2ManyParamInterfaceMsgBusClient::_Connect()
 {
-	if (!_HeartbeatTimerHandle.IsValid() && GetWorld())
+	if (_IsConnected())
+	{
+		UE_LOG(LogTestbed2ManyParamInterfaceMsgBusClient, Log, TEXT("Already connected, cannot connect again."));
+		return;
+	}
+
+	if (!_HeartbeatTickerHandle.IsValid())
 	{
 		UTestbed2Settings* settings = GetMutableDefault<UTestbed2Settings>();
 		check(settings);
 		_HeartbeatIntervalMS = settings->MsgBusHeartbeatIntervalMS;
 
-		GetWorld()->GetTimerManager().SetTimer(_HeartbeatTimerHandle, this, &UTestbed2ManyParamInterfaceMsgBusClient::_OnHeartbeat, _HeartbeatIntervalMS / 1000.0f, true);
-	}
-
-	if (_IsConnected())
-	{
-		UE_LOG(LogTestbed2ManyParamInterfaceMsgBusClient, Log, TEXT("Already connected, cannot connect again."));
-		return;
+#if (ENGINE_MAJOR_VERSION < 5)
+		FTicker::GetCoreTicker().RemoveTicker(_HeartbeatTickerHandle);
+		_HeartbeatTickerHandle = FTicker::GetCoreTicker().AddTicker(FTickerDelegate::CreateUObject(this, &UTestbed2ManyParamInterfaceMsgBusClient::_OnHeartbeatTick), _HeartbeatIntervalMS / 1000.0f);
+#else
+		FTSTicker::GetCoreTicker().RemoveTicker(_HeartbeatTickerHandle);
+		_HeartbeatTickerHandle = FTSTicker::GetCoreTicker().AddTicker(FTickerDelegate::CreateUObject(this, &UTestbed2ManyParamInterfaceMsgBusClient::_OnHeartbeatTick), _HeartbeatIntervalMS / 1000.0f);
+#endif
 	}
 
 	if (Testbed2ManyParamInterfaceMsgBusEndpoint.IsValid() && !ServiceAddress.IsValid())
@@ -115,10 +120,12 @@ void UTestbed2ManyParamInterfaceMsgBusClient::_Connect()
 void UTestbed2ManyParamInterfaceMsgBusClient::_Disconnect()
 {
 	_LastHbTimestamp = 0.0f;
-	if (_HeartbeatTimerHandle.IsValid() && GetWorld())
-	{
-		GetWorld()->GetTimerManager().ClearTimer(_HeartbeatTimerHandle);
-	}
+
+#if (ENGINE_MAJOR_VERSION < 5)
+	FTicker::GetCoreTicker().RemoveTicker(_HeartbeatTickerHandle);
+#else
+	FTSTicker::GetCoreTicker().RemoveTicker(_HeartbeatTickerHandle);
+#endif
 
 	if (!_IsConnected())
 	{
@@ -179,15 +186,13 @@ void UTestbed2ManyParamInterfaceMsgBusClient::OnConnectionInit(const FTestbed2Ma
 	{
 		_HeartbeatIntervalMS = InMessage._ClientPingIntervalMS;
 
-		if (_HeartbeatTimerHandle.IsValid() && GetWorld())
-		{
-			GetWorld()->GetTimerManager().ClearTimer(_HeartbeatTimerHandle);
-		}
-
-		if (!_HeartbeatTimerHandle.IsValid() && GetWorld())
-		{
-			GetWorld()->GetTimerManager().SetTimer(_HeartbeatTimerHandle, this, &UTestbed2ManyParamInterfaceMsgBusClient::_OnHeartbeat, _HeartbeatIntervalMS / 1000.0f, true);
-		}
+#if (ENGINE_MAJOR_VERSION < 5)
+		FTicker::GetCoreTicker().RemoveTicker(_HeartbeatTickerHandle);
+		_HeartbeatTickerHandle = FTicker::GetCoreTicker().AddTicker(FTickerDelegate::CreateUObject(this, &UTestbed2ManyParamInterfaceMsgBusClient::_OnHeartbeatTick), _HeartbeatIntervalMS / 1000.0f);
+#else
+		FTSTicker::GetCoreTicker().RemoveTicker(_HeartbeatTickerHandle);
+		_HeartbeatTickerHandle = FTSTicker::GetCoreTicker().AddTicker(FTickerDelegate::CreateUObject(this, &UTestbed2ManyParamInterfaceMsgBusClient::_OnHeartbeatTick), _HeartbeatIntervalMS / 1000.0f);
+#endif
 	}
 	const bool bProp1Changed = InMessage.Prop1 != Prop1;
 	if (bProp1Changed)
@@ -218,6 +223,12 @@ void UTestbed2ManyParamInterfaceMsgBusClient::OnConnectionInit(const FTestbed2Ma
 	}
 
 	_ConnectionStatusChanged.Broadcast(true);
+}
+
+bool UTestbed2ManyParamInterfaceMsgBusClient::_OnHeartbeatTick(float /*DeltaTime*/)
+{
+	_OnHeartbeat();
+	return true;
 }
 
 void UTestbed2ManyParamInterfaceMsgBusClient::_OnHeartbeat()

--- a/goldenmaster/Plugins/Testbed2/Source/Testbed2/Private/Generated/MsgBus/Testbed2ManyParamInterfaceMsgBusClient.cpp
+++ b/goldenmaster/Plugins/Testbed2/Source/Testbed2/Private/Generated/MsgBus/Testbed2ManyParamInterfaceMsgBusClient.cpp
@@ -23,13 +23,14 @@ limitations under the License.
 #include "Generated/MsgBus/Testbed2ManyParamInterfaceMsgBusClient.h"
 #include "Generated/MsgBus/Testbed2ManyParamInterfaceMsgBusMessages.h"
 #include "Async/Async.h"
-#include "Engine/Engine.h"
+#include "Engine/World.h"
 #include "TimerManager.h"
 #include "Misc/DateTime.h"
 #include "GenericPlatform/GenericPlatformMath.h"
 #include "GenericPlatform/GenericPlatformTime.h"
 #include "MessageEndpointBuilder.h"
 #include "MessageEndpoint.h"
+#include "Testbed2Settings.h"
 #include <atomic>
 
 /**
@@ -69,6 +70,10 @@ void UTestbed2ManyParamInterfaceMsgBusClient::_Connect()
 {
 	if (!_HeartbeatTimerHandle.IsValid() && GetWorld())
 	{
+		UTestbed2Settings* settings = GetMutableDefault<UTestbed2Settings>();
+		check(settings);
+		_HeartbeatIntervalMS = settings->MsgBusHeartbeatIntervalMS;
+
 		GetWorld()->GetTimerManager().SetTimer(_HeartbeatTimerHandle, this, &UTestbed2ManyParamInterfaceMsgBusClient::_OnHeartbeat, _HeartbeatIntervalMS / 1000.0f, true);
 	}
 

--- a/goldenmaster/Plugins/Testbed2/Source/Testbed2/Private/Generated/MsgBus/Testbed2NestedStruct1InterfaceMsgBusAdapter.cpp
+++ b/goldenmaster/Plugins/Testbed2/Source/Testbed2/Private/Generated/MsgBus/Testbed2NestedStruct1InterfaceMsgBusAdapter.cpp
@@ -24,12 +24,12 @@ limitations under the License.
 #include "Generated/MsgBus/Testbed2NestedStruct1InterfaceMsgBusMessages.h"
 #include "Async/Future.h"
 #include "Async/Async.h"
-#include "Async/Async.h"
-#include "Engine/Engine.h"
+#include "Engine/World.h"
 #include "TimerManager.h"
 #include "MessageEndpoint.h"
 #include "MessageEndpointBuilder.h"
 #include "Misc/DateTime.h"
+#include "Testbed2Settings.h"
 
 DEFINE_LOG_CATEGORY(LogTestbed2NestedStruct1InterfaceMsgBusAdapter);
 UTestbed2NestedStruct1InterfaceMsgBusAdapter::UTestbed2NestedStruct1InterfaceMsgBusAdapter()
@@ -53,6 +53,10 @@ void UTestbed2NestedStruct1InterfaceMsgBusAdapter::_StartListening()
 
 	if (!_HeartbeatTimerHandle.IsValid() && GetWorld())
 	{
+		UTestbed2Settings* settings = GetMutableDefault<UTestbed2Settings>();
+		check(settings);
+		_HeartbeatIntervalMS = settings->MsgBusHeartbeatIntervalMS;
+
 		GetWorld()->GetTimerManager().SetTimer(_HeartbeatTimerHandle, this, &UTestbed2NestedStruct1InterfaceMsgBusAdapter::_CheckClientTimeouts, _HeartbeatIntervalMS / 1000.0f, true);
 	}
 

--- a/goldenmaster/Plugins/Testbed2/Source/Testbed2/Private/Generated/MsgBus/Testbed2NestedStruct1InterfaceMsgBusAdapter.cpp
+++ b/goldenmaster/Plugins/Testbed2/Source/Testbed2/Private/Generated/MsgBus/Testbed2NestedStruct1InterfaceMsgBusAdapter.cpp
@@ -25,7 +25,6 @@ limitations under the License.
 #include "Async/Future.h"
 #include "Async/Async.h"
 #include "Engine/World.h"
-#include "TimerManager.h"
 #include "MessageEndpoint.h"
 #include "MessageEndpointBuilder.h"
 #include "Misc/DateTime.h"
@@ -51,13 +50,17 @@ void UTestbed2NestedStruct1InterfaceMsgBusAdapter::Deinitialize()
 void UTestbed2NestedStruct1InterfaceMsgBusAdapter::_StartListening()
 {
 
-	if (!_HeartbeatTimerHandle.IsValid() && GetWorld())
+	if (!_HeartbeatTickerHandle.IsValid())
 	{
 		UTestbed2Settings* settings = GetMutableDefault<UTestbed2Settings>();
 		check(settings);
 		_HeartbeatIntervalMS = settings->MsgBusHeartbeatIntervalMS;
 
-		GetWorld()->GetTimerManager().SetTimer(_HeartbeatTimerHandle, this, &UTestbed2NestedStruct1InterfaceMsgBusAdapter::_CheckClientTimeouts, _HeartbeatIntervalMS / 1000.0f, true);
+#if (ENGINE_MAJOR_VERSION < 5)
+		_HeartbeatTickerHandle = FTicker::GetCoreTicker().AddTicker(FTickerDelegate::CreateUObject(this, &UTestbed2NestedStruct1InterfaceMsgBusAdapter::_CheckClientTimeoutsTick), _HeartbeatIntervalMS / 1000.0f);
+#else
+		_HeartbeatTickerHandle = FTSTicker::GetCoreTicker().AddTicker(FTickerDelegate::CreateUObject(this, &UTestbed2NestedStruct1InterfaceMsgBusAdapter::_CheckClientTimeoutsTick), _HeartbeatIntervalMS / 1000.0f);
+#endif
 	}
 
 	if (Testbed2NestedStruct1InterfaceMsgBusEndpoint.IsValid())
@@ -97,9 +100,13 @@ void UTestbed2NestedStruct1InterfaceMsgBusAdapter::_AnnounceService()
 
 void UTestbed2NestedStruct1InterfaceMsgBusAdapter::_StopListening()
 {
-	if (_HeartbeatTimerHandle.IsValid() && GetWorld())
+	if (_HeartbeatTickerHandle.IsValid())
 	{
-		GetWorld()->GetTimerManager().ClearTimer(_HeartbeatTimerHandle);
+#if (ENGINE_MAJOR_VERSION < 5)
+		FTicker::GetCoreTicker().RemoveTicker(_HeartbeatTickerHandle);
+#else
+		FTSTicker::GetCoreTicker().RemoveTicker(_HeartbeatTickerHandle);
+#endif
 	}
 
 	auto msg = new FTestbed2NestedStruct1InterfaceServiceDisconnectMessage();
@@ -241,6 +248,12 @@ void UTestbed2NestedStruct1InterfaceMsgBusAdapter::OnClientDisconnected(const FT
 	ConnectedClientsTimestamps.Remove(Context->GetSender());
 	_OnClientDisconnected.Broadcast(Context->GetSender().ToString());
 	_UpdateClientsConnected();
+}
+
+bool UTestbed2NestedStruct1InterfaceMsgBusAdapter::_CheckClientTimeoutsTick(float /*DeltaTime*/)
+{
+	_CheckClientTimeouts();
+	return true;
 }
 
 void UTestbed2NestedStruct1InterfaceMsgBusAdapter::_CheckClientTimeouts()

--- a/goldenmaster/Plugins/Testbed2/Source/Testbed2/Private/Generated/MsgBus/Testbed2NestedStruct1InterfaceMsgBusClient.cpp
+++ b/goldenmaster/Plugins/Testbed2/Source/Testbed2/Private/Generated/MsgBus/Testbed2NestedStruct1InterfaceMsgBusClient.cpp
@@ -23,13 +23,14 @@ limitations under the License.
 #include "Generated/MsgBus/Testbed2NestedStruct1InterfaceMsgBusClient.h"
 #include "Generated/MsgBus/Testbed2NestedStruct1InterfaceMsgBusMessages.h"
 #include "Async/Async.h"
-#include "Engine/Engine.h"
+#include "Engine/World.h"
 #include "TimerManager.h"
 #include "Misc/DateTime.h"
 #include "GenericPlatform/GenericPlatformMath.h"
 #include "GenericPlatform/GenericPlatformTime.h"
 #include "MessageEndpointBuilder.h"
 #include "MessageEndpoint.h"
+#include "Testbed2Settings.h"
 #include "HAL/CriticalSection.h"
 
 /**
@@ -67,6 +68,10 @@ void UTestbed2NestedStruct1InterfaceMsgBusClient::_Connect()
 {
 	if (!_HeartbeatTimerHandle.IsValid() && GetWorld())
 	{
+		UTestbed2Settings* settings = GetMutableDefault<UTestbed2Settings>();
+		check(settings);
+		_HeartbeatIntervalMS = settings->MsgBusHeartbeatIntervalMS;
+
 		GetWorld()->GetTimerManager().SetTimer(_HeartbeatTimerHandle, this, &UTestbed2NestedStruct1InterfaceMsgBusClient::_OnHeartbeat, _HeartbeatIntervalMS / 1000.0f, true);
 	}
 

--- a/goldenmaster/Plugins/Testbed2/Source/Testbed2/Private/Generated/MsgBus/Testbed2NestedStruct1InterfaceMsgBusClient.cpp
+++ b/goldenmaster/Plugins/Testbed2/Source/Testbed2/Private/Generated/MsgBus/Testbed2NestedStruct1InterfaceMsgBusClient.cpp
@@ -24,7 +24,6 @@ limitations under the License.
 #include "Generated/MsgBus/Testbed2NestedStruct1InterfaceMsgBusMessages.h"
 #include "Async/Async.h"
 #include "Engine/World.h"
-#include "TimerManager.h"
 #include "Misc/DateTime.h"
 #include "GenericPlatform/GenericPlatformMath.h"
 #include "GenericPlatform/GenericPlatformTime.h"
@@ -66,19 +65,25 @@ void UTestbed2NestedStruct1InterfaceMsgBusClient::Deinitialize()
 
 void UTestbed2NestedStruct1InterfaceMsgBusClient::_Connect()
 {
-	if (!_HeartbeatTimerHandle.IsValid() && GetWorld())
+	if (_IsConnected())
+	{
+		UE_LOG(LogTestbed2NestedStruct1InterfaceMsgBusClient, Log, TEXT("Already connected, cannot connect again."));
+		return;
+	}
+
+	if (!_HeartbeatTickerHandle.IsValid())
 	{
 		UTestbed2Settings* settings = GetMutableDefault<UTestbed2Settings>();
 		check(settings);
 		_HeartbeatIntervalMS = settings->MsgBusHeartbeatIntervalMS;
 
-		GetWorld()->GetTimerManager().SetTimer(_HeartbeatTimerHandle, this, &UTestbed2NestedStruct1InterfaceMsgBusClient::_OnHeartbeat, _HeartbeatIntervalMS / 1000.0f, true);
-	}
-
-	if (_IsConnected())
-	{
-		UE_LOG(LogTestbed2NestedStruct1InterfaceMsgBusClient, Log, TEXT("Already connected, cannot connect again."));
-		return;
+#if (ENGINE_MAJOR_VERSION < 5)
+		FTicker::GetCoreTicker().RemoveTicker(_HeartbeatTickerHandle);
+		_HeartbeatTickerHandle = FTicker::GetCoreTicker().AddTicker(FTickerDelegate::CreateUObject(this, &UTestbed2NestedStruct1InterfaceMsgBusClient::_OnHeartbeatTick), _HeartbeatIntervalMS / 1000.0f);
+#else
+		FTSTicker::GetCoreTicker().RemoveTicker(_HeartbeatTickerHandle);
+		_HeartbeatTickerHandle = FTSTicker::GetCoreTicker().AddTicker(FTickerDelegate::CreateUObject(this, &UTestbed2NestedStruct1InterfaceMsgBusClient::_OnHeartbeatTick), _HeartbeatIntervalMS / 1000.0f);
+#endif
 	}
 
 	if (Testbed2NestedStruct1InterfaceMsgBusEndpoint.IsValid() && !ServiceAddress.IsValid())
@@ -104,10 +109,12 @@ void UTestbed2NestedStruct1InterfaceMsgBusClient::_Connect()
 void UTestbed2NestedStruct1InterfaceMsgBusClient::_Disconnect()
 {
 	_LastHbTimestamp = 0.0f;
-	if (_HeartbeatTimerHandle.IsValid() && GetWorld())
-	{
-		GetWorld()->GetTimerManager().ClearTimer(_HeartbeatTimerHandle);
-	}
+
+#if (ENGINE_MAJOR_VERSION < 5)
+	FTicker::GetCoreTicker().RemoveTicker(_HeartbeatTickerHandle);
+#else
+	FTSTicker::GetCoreTicker().RemoveTicker(_HeartbeatTickerHandle);
+#endif
 
 	if (!_IsConnected())
 	{
@@ -168,15 +175,13 @@ void UTestbed2NestedStruct1InterfaceMsgBusClient::OnConnectionInit(const FTestbe
 	{
 		_HeartbeatIntervalMS = InMessage._ClientPingIntervalMS;
 
-		if (_HeartbeatTimerHandle.IsValid() && GetWorld())
-		{
-			GetWorld()->GetTimerManager().ClearTimer(_HeartbeatTimerHandle);
-		}
-
-		if (!_HeartbeatTimerHandle.IsValid() && GetWorld())
-		{
-			GetWorld()->GetTimerManager().SetTimer(_HeartbeatTimerHandle, this, &UTestbed2NestedStruct1InterfaceMsgBusClient::_OnHeartbeat, _HeartbeatIntervalMS / 1000.0f, true);
-		}
+#if (ENGINE_MAJOR_VERSION < 5)
+		FTicker::GetCoreTicker().RemoveTicker(_HeartbeatTickerHandle);
+		_HeartbeatTickerHandle = FTicker::GetCoreTicker().AddTicker(FTickerDelegate::CreateUObject(this, &UTestbed2NestedStruct1InterfaceMsgBusClient::_OnHeartbeatTick), _HeartbeatIntervalMS / 1000.0f);
+#else
+		FTSTicker::GetCoreTicker().RemoveTicker(_HeartbeatTickerHandle);
+		_HeartbeatTickerHandle = FTSTicker::GetCoreTicker().AddTicker(FTickerDelegate::CreateUObject(this, &UTestbed2NestedStruct1InterfaceMsgBusClient::_OnHeartbeatTick), _HeartbeatIntervalMS / 1000.0f);
+#endif
 	}
 	const bool bProp1Changed = InMessage.Prop1 != Prop1;
 	if (bProp1Changed)
@@ -186,6 +191,12 @@ void UTestbed2NestedStruct1InterfaceMsgBusClient::OnConnectionInit(const FTestbe
 	}
 
 	_ConnectionStatusChanged.Broadcast(true);
+}
+
+bool UTestbed2NestedStruct1InterfaceMsgBusClient::_OnHeartbeatTick(float /*DeltaTime*/)
+{
+	_OnHeartbeat();
+	return true;
 }
 
 void UTestbed2NestedStruct1InterfaceMsgBusClient::_OnHeartbeat()

--- a/goldenmaster/Plugins/Testbed2/Source/Testbed2/Private/Generated/MsgBus/Testbed2NestedStruct2InterfaceMsgBusAdapter.cpp
+++ b/goldenmaster/Plugins/Testbed2/Source/Testbed2/Private/Generated/MsgBus/Testbed2NestedStruct2InterfaceMsgBusAdapter.cpp
@@ -24,12 +24,12 @@ limitations under the License.
 #include "Generated/MsgBus/Testbed2NestedStruct2InterfaceMsgBusMessages.h"
 #include "Async/Future.h"
 #include "Async/Async.h"
-#include "Async/Async.h"
-#include "Engine/Engine.h"
+#include "Engine/World.h"
 #include "TimerManager.h"
 #include "MessageEndpoint.h"
 #include "MessageEndpointBuilder.h"
 #include "Misc/DateTime.h"
+#include "Testbed2Settings.h"
 
 DEFINE_LOG_CATEGORY(LogTestbed2NestedStruct2InterfaceMsgBusAdapter);
 UTestbed2NestedStruct2InterfaceMsgBusAdapter::UTestbed2NestedStruct2InterfaceMsgBusAdapter()
@@ -53,6 +53,10 @@ void UTestbed2NestedStruct2InterfaceMsgBusAdapter::_StartListening()
 
 	if (!_HeartbeatTimerHandle.IsValid() && GetWorld())
 	{
+		UTestbed2Settings* settings = GetMutableDefault<UTestbed2Settings>();
+		check(settings);
+		_HeartbeatIntervalMS = settings->MsgBusHeartbeatIntervalMS;
+
 		GetWorld()->GetTimerManager().SetTimer(_HeartbeatTimerHandle, this, &UTestbed2NestedStruct2InterfaceMsgBusAdapter::_CheckClientTimeouts, _HeartbeatIntervalMS / 1000.0f, true);
 	}
 

--- a/goldenmaster/Plugins/Testbed2/Source/Testbed2/Private/Generated/MsgBus/Testbed2NestedStruct2InterfaceMsgBusAdapter.cpp
+++ b/goldenmaster/Plugins/Testbed2/Source/Testbed2/Private/Generated/MsgBus/Testbed2NestedStruct2InterfaceMsgBusAdapter.cpp
@@ -25,7 +25,6 @@ limitations under the License.
 #include "Async/Future.h"
 #include "Async/Async.h"
 #include "Engine/World.h"
-#include "TimerManager.h"
 #include "MessageEndpoint.h"
 #include "MessageEndpointBuilder.h"
 #include "Misc/DateTime.h"
@@ -51,13 +50,17 @@ void UTestbed2NestedStruct2InterfaceMsgBusAdapter::Deinitialize()
 void UTestbed2NestedStruct2InterfaceMsgBusAdapter::_StartListening()
 {
 
-	if (!_HeartbeatTimerHandle.IsValid() && GetWorld())
+	if (!_HeartbeatTickerHandle.IsValid())
 	{
 		UTestbed2Settings* settings = GetMutableDefault<UTestbed2Settings>();
 		check(settings);
 		_HeartbeatIntervalMS = settings->MsgBusHeartbeatIntervalMS;
 
-		GetWorld()->GetTimerManager().SetTimer(_HeartbeatTimerHandle, this, &UTestbed2NestedStruct2InterfaceMsgBusAdapter::_CheckClientTimeouts, _HeartbeatIntervalMS / 1000.0f, true);
+#if (ENGINE_MAJOR_VERSION < 5)
+		_HeartbeatTickerHandle = FTicker::GetCoreTicker().AddTicker(FTickerDelegate::CreateUObject(this, &UTestbed2NestedStruct2InterfaceMsgBusAdapter::_CheckClientTimeoutsTick), _HeartbeatIntervalMS / 1000.0f);
+#else
+		_HeartbeatTickerHandle = FTSTicker::GetCoreTicker().AddTicker(FTickerDelegate::CreateUObject(this, &UTestbed2NestedStruct2InterfaceMsgBusAdapter::_CheckClientTimeoutsTick), _HeartbeatIntervalMS / 1000.0f);
+#endif
 	}
 
 	if (Testbed2NestedStruct2InterfaceMsgBusEndpoint.IsValid())
@@ -99,9 +102,13 @@ void UTestbed2NestedStruct2InterfaceMsgBusAdapter::_AnnounceService()
 
 void UTestbed2NestedStruct2InterfaceMsgBusAdapter::_StopListening()
 {
-	if (_HeartbeatTimerHandle.IsValid() && GetWorld())
+	if (_HeartbeatTickerHandle.IsValid())
 	{
-		GetWorld()->GetTimerManager().ClearTimer(_HeartbeatTimerHandle);
+#if (ENGINE_MAJOR_VERSION < 5)
+		FTicker::GetCoreTicker().RemoveTicker(_HeartbeatTickerHandle);
+#else
+		FTSTicker::GetCoreTicker().RemoveTicker(_HeartbeatTickerHandle);
+#endif
 	}
 
 	auto msg = new FTestbed2NestedStruct2InterfaceServiceDisconnectMessage();
@@ -248,6 +255,12 @@ void UTestbed2NestedStruct2InterfaceMsgBusAdapter::OnClientDisconnected(const FT
 	ConnectedClientsTimestamps.Remove(Context->GetSender());
 	_OnClientDisconnected.Broadcast(Context->GetSender().ToString());
 	_UpdateClientsConnected();
+}
+
+bool UTestbed2NestedStruct2InterfaceMsgBusAdapter::_CheckClientTimeoutsTick(float /*DeltaTime*/)
+{
+	_CheckClientTimeouts();
+	return true;
 }
 
 void UTestbed2NestedStruct2InterfaceMsgBusAdapter::_CheckClientTimeouts()

--- a/goldenmaster/Plugins/Testbed2/Source/Testbed2/Private/Generated/MsgBus/Testbed2NestedStruct2InterfaceMsgBusClient.cpp
+++ b/goldenmaster/Plugins/Testbed2/Source/Testbed2/Private/Generated/MsgBus/Testbed2NestedStruct2InterfaceMsgBusClient.cpp
@@ -23,13 +23,14 @@ limitations under the License.
 #include "Generated/MsgBus/Testbed2NestedStruct2InterfaceMsgBusClient.h"
 #include "Generated/MsgBus/Testbed2NestedStruct2InterfaceMsgBusMessages.h"
 #include "Async/Async.h"
-#include "Engine/Engine.h"
+#include "Engine/World.h"
 #include "TimerManager.h"
 #include "Misc/DateTime.h"
 #include "GenericPlatform/GenericPlatformMath.h"
 #include "GenericPlatform/GenericPlatformTime.h"
 #include "MessageEndpointBuilder.h"
 #include "MessageEndpoint.h"
+#include "Testbed2Settings.h"
 #include "HAL/CriticalSection.h"
 
 /**
@@ -69,6 +70,10 @@ void UTestbed2NestedStruct2InterfaceMsgBusClient::_Connect()
 {
 	if (!_HeartbeatTimerHandle.IsValid() && GetWorld())
 	{
+		UTestbed2Settings* settings = GetMutableDefault<UTestbed2Settings>();
+		check(settings);
+		_HeartbeatIntervalMS = settings->MsgBusHeartbeatIntervalMS;
+
 		GetWorld()->GetTimerManager().SetTimer(_HeartbeatTimerHandle, this, &UTestbed2NestedStruct2InterfaceMsgBusClient::_OnHeartbeat, _HeartbeatIntervalMS / 1000.0f, true);
 	}
 

--- a/goldenmaster/Plugins/Testbed2/Source/Testbed2/Private/Generated/MsgBus/Testbed2NestedStruct2InterfaceMsgBusClient.cpp
+++ b/goldenmaster/Plugins/Testbed2/Source/Testbed2/Private/Generated/MsgBus/Testbed2NestedStruct2InterfaceMsgBusClient.cpp
@@ -24,7 +24,6 @@ limitations under the License.
 #include "Generated/MsgBus/Testbed2NestedStruct2InterfaceMsgBusMessages.h"
 #include "Async/Async.h"
 #include "Engine/World.h"
-#include "TimerManager.h"
 #include "Misc/DateTime.h"
 #include "GenericPlatform/GenericPlatformMath.h"
 #include "GenericPlatform/GenericPlatformTime.h"
@@ -68,19 +67,25 @@ void UTestbed2NestedStruct2InterfaceMsgBusClient::Deinitialize()
 
 void UTestbed2NestedStruct2InterfaceMsgBusClient::_Connect()
 {
-	if (!_HeartbeatTimerHandle.IsValid() && GetWorld())
+	if (_IsConnected())
+	{
+		UE_LOG(LogTestbed2NestedStruct2InterfaceMsgBusClient, Log, TEXT("Already connected, cannot connect again."));
+		return;
+	}
+
+	if (!_HeartbeatTickerHandle.IsValid())
 	{
 		UTestbed2Settings* settings = GetMutableDefault<UTestbed2Settings>();
 		check(settings);
 		_HeartbeatIntervalMS = settings->MsgBusHeartbeatIntervalMS;
 
-		GetWorld()->GetTimerManager().SetTimer(_HeartbeatTimerHandle, this, &UTestbed2NestedStruct2InterfaceMsgBusClient::_OnHeartbeat, _HeartbeatIntervalMS / 1000.0f, true);
-	}
-
-	if (_IsConnected())
-	{
-		UE_LOG(LogTestbed2NestedStruct2InterfaceMsgBusClient, Log, TEXT("Already connected, cannot connect again."));
-		return;
+#if (ENGINE_MAJOR_VERSION < 5)
+		FTicker::GetCoreTicker().RemoveTicker(_HeartbeatTickerHandle);
+		_HeartbeatTickerHandle = FTicker::GetCoreTicker().AddTicker(FTickerDelegate::CreateUObject(this, &UTestbed2NestedStruct2InterfaceMsgBusClient::_OnHeartbeatTick), _HeartbeatIntervalMS / 1000.0f);
+#else
+		FTSTicker::GetCoreTicker().RemoveTicker(_HeartbeatTickerHandle);
+		_HeartbeatTickerHandle = FTSTicker::GetCoreTicker().AddTicker(FTickerDelegate::CreateUObject(this, &UTestbed2NestedStruct2InterfaceMsgBusClient::_OnHeartbeatTick), _HeartbeatIntervalMS / 1000.0f);
+#endif
 	}
 
 	if (Testbed2NestedStruct2InterfaceMsgBusEndpoint.IsValid() && !ServiceAddress.IsValid())
@@ -109,10 +114,12 @@ void UTestbed2NestedStruct2InterfaceMsgBusClient::_Connect()
 void UTestbed2NestedStruct2InterfaceMsgBusClient::_Disconnect()
 {
 	_LastHbTimestamp = 0.0f;
-	if (_HeartbeatTimerHandle.IsValid() && GetWorld())
-	{
-		GetWorld()->GetTimerManager().ClearTimer(_HeartbeatTimerHandle);
-	}
+
+#if (ENGINE_MAJOR_VERSION < 5)
+	FTicker::GetCoreTicker().RemoveTicker(_HeartbeatTickerHandle);
+#else
+	FTSTicker::GetCoreTicker().RemoveTicker(_HeartbeatTickerHandle);
+#endif
 
 	if (!_IsConnected())
 	{
@@ -173,15 +180,13 @@ void UTestbed2NestedStruct2InterfaceMsgBusClient::OnConnectionInit(const FTestbe
 	{
 		_HeartbeatIntervalMS = InMessage._ClientPingIntervalMS;
 
-		if (_HeartbeatTimerHandle.IsValid() && GetWorld())
-		{
-			GetWorld()->GetTimerManager().ClearTimer(_HeartbeatTimerHandle);
-		}
-
-		if (!_HeartbeatTimerHandle.IsValid() && GetWorld())
-		{
-			GetWorld()->GetTimerManager().SetTimer(_HeartbeatTimerHandle, this, &UTestbed2NestedStruct2InterfaceMsgBusClient::_OnHeartbeat, _HeartbeatIntervalMS / 1000.0f, true);
-		}
+#if (ENGINE_MAJOR_VERSION < 5)
+		FTicker::GetCoreTicker().RemoveTicker(_HeartbeatTickerHandle);
+		_HeartbeatTickerHandle = FTicker::GetCoreTicker().AddTicker(FTickerDelegate::CreateUObject(this, &UTestbed2NestedStruct2InterfaceMsgBusClient::_OnHeartbeatTick), _HeartbeatIntervalMS / 1000.0f);
+#else
+		FTSTicker::GetCoreTicker().RemoveTicker(_HeartbeatTickerHandle);
+		_HeartbeatTickerHandle = FTSTicker::GetCoreTicker().AddTicker(FTickerDelegate::CreateUObject(this, &UTestbed2NestedStruct2InterfaceMsgBusClient::_OnHeartbeatTick), _HeartbeatIntervalMS / 1000.0f);
+#endif
 	}
 	const bool bProp1Changed = InMessage.Prop1 != Prop1;
 	if (bProp1Changed)
@@ -198,6 +203,12 @@ void UTestbed2NestedStruct2InterfaceMsgBusClient::OnConnectionInit(const FTestbe
 	}
 
 	_ConnectionStatusChanged.Broadcast(true);
+}
+
+bool UTestbed2NestedStruct2InterfaceMsgBusClient::_OnHeartbeatTick(float /*DeltaTime*/)
+{
+	_OnHeartbeat();
+	return true;
 }
 
 void UTestbed2NestedStruct2InterfaceMsgBusClient::_OnHeartbeat()

--- a/goldenmaster/Plugins/Testbed2/Source/Testbed2/Private/Generated/MsgBus/Testbed2NestedStruct3InterfaceMsgBusAdapter.cpp
+++ b/goldenmaster/Plugins/Testbed2/Source/Testbed2/Private/Generated/MsgBus/Testbed2NestedStruct3InterfaceMsgBusAdapter.cpp
@@ -25,7 +25,6 @@ limitations under the License.
 #include "Async/Future.h"
 #include "Async/Async.h"
 #include "Engine/World.h"
-#include "TimerManager.h"
 #include "MessageEndpoint.h"
 #include "MessageEndpointBuilder.h"
 #include "Misc/DateTime.h"
@@ -51,13 +50,17 @@ void UTestbed2NestedStruct3InterfaceMsgBusAdapter::Deinitialize()
 void UTestbed2NestedStruct3InterfaceMsgBusAdapter::_StartListening()
 {
 
-	if (!_HeartbeatTimerHandle.IsValid() && GetWorld())
+	if (!_HeartbeatTickerHandle.IsValid())
 	{
 		UTestbed2Settings* settings = GetMutableDefault<UTestbed2Settings>();
 		check(settings);
 		_HeartbeatIntervalMS = settings->MsgBusHeartbeatIntervalMS;
 
-		GetWorld()->GetTimerManager().SetTimer(_HeartbeatTimerHandle, this, &UTestbed2NestedStruct3InterfaceMsgBusAdapter::_CheckClientTimeouts, _HeartbeatIntervalMS / 1000.0f, true);
+#if (ENGINE_MAJOR_VERSION < 5)
+		_HeartbeatTickerHandle = FTicker::GetCoreTicker().AddTicker(FTickerDelegate::CreateUObject(this, &UTestbed2NestedStruct3InterfaceMsgBusAdapter::_CheckClientTimeoutsTick), _HeartbeatIntervalMS / 1000.0f);
+#else
+		_HeartbeatTickerHandle = FTSTicker::GetCoreTicker().AddTicker(FTickerDelegate::CreateUObject(this, &UTestbed2NestedStruct3InterfaceMsgBusAdapter::_CheckClientTimeoutsTick), _HeartbeatIntervalMS / 1000.0f);
+#endif
 	}
 
 	if (Testbed2NestedStruct3InterfaceMsgBusEndpoint.IsValid())
@@ -101,9 +104,13 @@ void UTestbed2NestedStruct3InterfaceMsgBusAdapter::_AnnounceService()
 
 void UTestbed2NestedStruct3InterfaceMsgBusAdapter::_StopListening()
 {
-	if (_HeartbeatTimerHandle.IsValid() && GetWorld())
+	if (_HeartbeatTickerHandle.IsValid())
 	{
-		GetWorld()->GetTimerManager().ClearTimer(_HeartbeatTimerHandle);
+#if (ENGINE_MAJOR_VERSION < 5)
+		FTicker::GetCoreTicker().RemoveTicker(_HeartbeatTickerHandle);
+#else
+		FTSTicker::GetCoreTicker().RemoveTicker(_HeartbeatTickerHandle);
+#endif
 	}
 
 	auto msg = new FTestbed2NestedStruct3InterfaceServiceDisconnectMessage();
@@ -255,6 +262,12 @@ void UTestbed2NestedStruct3InterfaceMsgBusAdapter::OnClientDisconnected(const FT
 	ConnectedClientsTimestamps.Remove(Context->GetSender());
 	_OnClientDisconnected.Broadcast(Context->GetSender().ToString());
 	_UpdateClientsConnected();
+}
+
+bool UTestbed2NestedStruct3InterfaceMsgBusAdapter::_CheckClientTimeoutsTick(float /*DeltaTime*/)
+{
+	_CheckClientTimeouts();
+	return true;
 }
 
 void UTestbed2NestedStruct3InterfaceMsgBusAdapter::_CheckClientTimeouts()

--- a/goldenmaster/Plugins/Testbed2/Source/Testbed2/Private/Generated/MsgBus/Testbed2NestedStruct3InterfaceMsgBusAdapter.cpp
+++ b/goldenmaster/Plugins/Testbed2/Source/Testbed2/Private/Generated/MsgBus/Testbed2NestedStruct3InterfaceMsgBusAdapter.cpp
@@ -24,12 +24,12 @@ limitations under the License.
 #include "Generated/MsgBus/Testbed2NestedStruct3InterfaceMsgBusMessages.h"
 #include "Async/Future.h"
 #include "Async/Async.h"
-#include "Async/Async.h"
-#include "Engine/Engine.h"
+#include "Engine/World.h"
 #include "TimerManager.h"
 #include "MessageEndpoint.h"
 #include "MessageEndpointBuilder.h"
 #include "Misc/DateTime.h"
+#include "Testbed2Settings.h"
 
 DEFINE_LOG_CATEGORY(LogTestbed2NestedStruct3InterfaceMsgBusAdapter);
 UTestbed2NestedStruct3InterfaceMsgBusAdapter::UTestbed2NestedStruct3InterfaceMsgBusAdapter()
@@ -53,6 +53,10 @@ void UTestbed2NestedStruct3InterfaceMsgBusAdapter::_StartListening()
 
 	if (!_HeartbeatTimerHandle.IsValid() && GetWorld())
 	{
+		UTestbed2Settings* settings = GetMutableDefault<UTestbed2Settings>();
+		check(settings);
+		_HeartbeatIntervalMS = settings->MsgBusHeartbeatIntervalMS;
+
 		GetWorld()->GetTimerManager().SetTimer(_HeartbeatTimerHandle, this, &UTestbed2NestedStruct3InterfaceMsgBusAdapter::_CheckClientTimeouts, _HeartbeatIntervalMS / 1000.0f, true);
 	}
 

--- a/goldenmaster/Plugins/Testbed2/Source/Testbed2/Private/Generated/MsgBus/Testbed2NestedStruct3InterfaceMsgBusClient.cpp
+++ b/goldenmaster/Plugins/Testbed2/Source/Testbed2/Private/Generated/MsgBus/Testbed2NestedStruct3InterfaceMsgBusClient.cpp
@@ -24,7 +24,6 @@ limitations under the License.
 #include "Generated/MsgBus/Testbed2NestedStruct3InterfaceMsgBusMessages.h"
 #include "Async/Async.h"
 #include "Engine/World.h"
-#include "TimerManager.h"
 #include "Misc/DateTime.h"
 #include "GenericPlatform/GenericPlatformMath.h"
 #include "GenericPlatform/GenericPlatformTime.h"
@@ -70,19 +69,25 @@ void UTestbed2NestedStruct3InterfaceMsgBusClient::Deinitialize()
 
 void UTestbed2NestedStruct3InterfaceMsgBusClient::_Connect()
 {
-	if (!_HeartbeatTimerHandle.IsValid() && GetWorld())
+	if (_IsConnected())
+	{
+		UE_LOG(LogTestbed2NestedStruct3InterfaceMsgBusClient, Log, TEXT("Already connected, cannot connect again."));
+		return;
+	}
+
+	if (!_HeartbeatTickerHandle.IsValid())
 	{
 		UTestbed2Settings* settings = GetMutableDefault<UTestbed2Settings>();
 		check(settings);
 		_HeartbeatIntervalMS = settings->MsgBusHeartbeatIntervalMS;
 
-		GetWorld()->GetTimerManager().SetTimer(_HeartbeatTimerHandle, this, &UTestbed2NestedStruct3InterfaceMsgBusClient::_OnHeartbeat, _HeartbeatIntervalMS / 1000.0f, true);
-	}
-
-	if (_IsConnected())
-	{
-		UE_LOG(LogTestbed2NestedStruct3InterfaceMsgBusClient, Log, TEXT("Already connected, cannot connect again."));
-		return;
+#if (ENGINE_MAJOR_VERSION < 5)
+		FTicker::GetCoreTicker().RemoveTicker(_HeartbeatTickerHandle);
+		_HeartbeatTickerHandle = FTicker::GetCoreTicker().AddTicker(FTickerDelegate::CreateUObject(this, &UTestbed2NestedStruct3InterfaceMsgBusClient::_OnHeartbeatTick), _HeartbeatIntervalMS / 1000.0f);
+#else
+		FTSTicker::GetCoreTicker().RemoveTicker(_HeartbeatTickerHandle);
+		_HeartbeatTickerHandle = FTSTicker::GetCoreTicker().AddTicker(FTickerDelegate::CreateUObject(this, &UTestbed2NestedStruct3InterfaceMsgBusClient::_OnHeartbeatTick), _HeartbeatIntervalMS / 1000.0f);
+#endif
 	}
 
 	if (Testbed2NestedStruct3InterfaceMsgBusEndpoint.IsValid() && !ServiceAddress.IsValid())
@@ -114,10 +119,12 @@ void UTestbed2NestedStruct3InterfaceMsgBusClient::_Connect()
 void UTestbed2NestedStruct3InterfaceMsgBusClient::_Disconnect()
 {
 	_LastHbTimestamp = 0.0f;
-	if (_HeartbeatTimerHandle.IsValid() && GetWorld())
-	{
-		GetWorld()->GetTimerManager().ClearTimer(_HeartbeatTimerHandle);
-	}
+
+#if (ENGINE_MAJOR_VERSION < 5)
+	FTicker::GetCoreTicker().RemoveTicker(_HeartbeatTickerHandle);
+#else
+	FTSTicker::GetCoreTicker().RemoveTicker(_HeartbeatTickerHandle);
+#endif
 
 	if (!_IsConnected())
 	{
@@ -178,15 +185,13 @@ void UTestbed2NestedStruct3InterfaceMsgBusClient::OnConnectionInit(const FTestbe
 	{
 		_HeartbeatIntervalMS = InMessage._ClientPingIntervalMS;
 
-		if (_HeartbeatTimerHandle.IsValid() && GetWorld())
-		{
-			GetWorld()->GetTimerManager().ClearTimer(_HeartbeatTimerHandle);
-		}
-
-		if (!_HeartbeatTimerHandle.IsValid() && GetWorld())
-		{
-			GetWorld()->GetTimerManager().SetTimer(_HeartbeatTimerHandle, this, &UTestbed2NestedStruct3InterfaceMsgBusClient::_OnHeartbeat, _HeartbeatIntervalMS / 1000.0f, true);
-		}
+#if (ENGINE_MAJOR_VERSION < 5)
+		FTicker::GetCoreTicker().RemoveTicker(_HeartbeatTickerHandle);
+		_HeartbeatTickerHandle = FTicker::GetCoreTicker().AddTicker(FTickerDelegate::CreateUObject(this, &UTestbed2NestedStruct3InterfaceMsgBusClient::_OnHeartbeatTick), _HeartbeatIntervalMS / 1000.0f);
+#else
+		FTSTicker::GetCoreTicker().RemoveTicker(_HeartbeatTickerHandle);
+		_HeartbeatTickerHandle = FTSTicker::GetCoreTicker().AddTicker(FTickerDelegate::CreateUObject(this, &UTestbed2NestedStruct3InterfaceMsgBusClient::_OnHeartbeatTick), _HeartbeatIntervalMS / 1000.0f);
+#endif
 	}
 	const bool bProp1Changed = InMessage.Prop1 != Prop1;
 	if (bProp1Changed)
@@ -210,6 +215,12 @@ void UTestbed2NestedStruct3InterfaceMsgBusClient::OnConnectionInit(const FTestbe
 	}
 
 	_ConnectionStatusChanged.Broadcast(true);
+}
+
+bool UTestbed2NestedStruct3InterfaceMsgBusClient::_OnHeartbeatTick(float /*DeltaTime*/)
+{
+	_OnHeartbeat();
+	return true;
 }
 
 void UTestbed2NestedStruct3InterfaceMsgBusClient::_OnHeartbeat()

--- a/goldenmaster/Plugins/Testbed2/Source/Testbed2/Private/Generated/MsgBus/Testbed2NestedStruct3InterfaceMsgBusClient.cpp
+++ b/goldenmaster/Plugins/Testbed2/Source/Testbed2/Private/Generated/MsgBus/Testbed2NestedStruct3InterfaceMsgBusClient.cpp
@@ -23,13 +23,14 @@ limitations under the License.
 #include "Generated/MsgBus/Testbed2NestedStruct3InterfaceMsgBusClient.h"
 #include "Generated/MsgBus/Testbed2NestedStruct3InterfaceMsgBusMessages.h"
 #include "Async/Async.h"
-#include "Engine/Engine.h"
+#include "Engine/World.h"
 #include "TimerManager.h"
 #include "Misc/DateTime.h"
 #include "GenericPlatform/GenericPlatformMath.h"
 #include "GenericPlatform/GenericPlatformTime.h"
 #include "MessageEndpointBuilder.h"
 #include "MessageEndpoint.h"
+#include "Testbed2Settings.h"
 #include "HAL/CriticalSection.h"
 
 /**
@@ -71,6 +72,10 @@ void UTestbed2NestedStruct3InterfaceMsgBusClient::_Connect()
 {
 	if (!_HeartbeatTimerHandle.IsValid() && GetWorld())
 	{
+		UTestbed2Settings* settings = GetMutableDefault<UTestbed2Settings>();
+		check(settings);
+		_HeartbeatIntervalMS = settings->MsgBusHeartbeatIntervalMS;
+
 		GetWorld()->GetTimerManager().SetTimer(_HeartbeatTimerHandle, this, &UTestbed2NestedStruct3InterfaceMsgBusClient::_OnHeartbeat, _HeartbeatIntervalMS / 1000.0f, true);
 	}
 

--- a/goldenmaster/Plugins/Testbed2/Source/Testbed2/Public/Generated/MsgBus/Testbed2ManyParamInterfaceMsgBusAdapter.h
+++ b/goldenmaster/Plugins/Testbed2/Source/Testbed2/Public/Generated/MsgBus/Testbed2ManyParamInterfaceMsgBusAdapter.h
@@ -21,11 +21,7 @@ limitations under the License.
 #include "IMessageContext.h"
 #include "Templates/SharedPointer.h"
 #include "Runtime/Launch/Resources/Version.h"
-#if (ENGINE_MAJOR_VERSION < 5)
-#include "Engine/EngineTypes.h"
-#else
-#include "Engine/TimerHandle.h"
-#endif
+#include "Containers/Ticker.h"
 #include "Testbed2ManyParamInterfaceMsgBusAdapter.generated.h"
 
 class FMessageEndpoint;
@@ -154,9 +150,14 @@ private:
 
 	// Heartbeat handling
 	void _CheckClientTimeouts();
+	bool _CheckClientTimeoutsTick(float DeltaTime);
 	void _UpdateClientsConnected();
 	TMap<FMessageAddress, double> ConnectedClientsTimestamps;
-	FTimerHandle _HeartbeatTimerHandle;
+#if (ENGINE_MAJOR_VERSION < 5)
+	::FDelegateHandle _HeartbeatTickerHandle;
+#else
+	FTSTicker::FDelegateHandle _HeartbeatTickerHandle;
+#endif
 	int32 _ClientsConnected = 0;
 	uint32 _HeartbeatIntervalMS = 100;
 };

--- a/goldenmaster/Plugins/Testbed2/Source/Testbed2/Public/Generated/MsgBus/Testbed2ManyParamInterfaceMsgBusClient.h
+++ b/goldenmaster/Plugins/Testbed2/Source/Testbed2/Public/Generated/MsgBus/Testbed2ManyParamInterfaceMsgBusClient.h
@@ -22,11 +22,7 @@ limitations under the License.
 #include "HAL/CriticalSection.h"
 #include "Async/Future.h"
 #include "Runtime/Launch/Resources/Version.h"
-#if (ENGINE_MAJOR_VERSION < 5)
-#include "Engine/EngineTypes.h"
-#else
-#include "Engine/TimerHandle.h"
-#endif
+#include "Containers/Ticker.h"
 #include "Templates/PimplPtr.h"
 #include "IMessageContext.h"
 #include "Testbed2ManyParamInterfaceMsgBusClient.generated.h"
@@ -143,8 +139,13 @@ private:
 	size_t CurrentPingCounter = 0;
 	float _CalculateAverageRTT() const;
 	FTestbed2ManyParamInterfaceStats Stats;
-	FTimerHandle _HeartbeatTimerHandle;
+#if (ENGINE_MAJOR_VERSION < 5)
+	::FDelegateHandle _HeartbeatTickerHandle;
+#else
+	FTSTicker::FDelegateHandle _HeartbeatTickerHandle;
+#endif
 	void _OnHeartbeat();
+	bool _OnHeartbeatTick(float DeltaTime);
 	uint32 _HeartbeatIntervalMS = 100;
 
 	// connection handling

--- a/goldenmaster/Plugins/Testbed2/Source/Testbed2/Public/Generated/MsgBus/Testbed2NestedStruct1InterfaceMsgBusAdapter.h
+++ b/goldenmaster/Plugins/Testbed2/Source/Testbed2/Public/Generated/MsgBus/Testbed2NestedStruct1InterfaceMsgBusAdapter.h
@@ -21,11 +21,7 @@ limitations under the License.
 #include "IMessageContext.h"
 #include "Templates/SharedPointer.h"
 #include "Runtime/Launch/Resources/Version.h"
-#if (ENGINE_MAJOR_VERSION < 5)
-#include "Engine/EngineTypes.h"
-#else
-#include "Engine/TimerHandle.h"
-#endif
+#include "Containers/Ticker.h"
 #include "Testbed2NestedStruct1InterfaceMsgBusAdapter.generated.h"
 
 class FMessageEndpoint;
@@ -118,9 +114,14 @@ private:
 
 	// Heartbeat handling
 	void _CheckClientTimeouts();
+	bool _CheckClientTimeoutsTick(float DeltaTime);
 	void _UpdateClientsConnected();
 	TMap<FMessageAddress, double> ConnectedClientsTimestamps;
-	FTimerHandle _HeartbeatTimerHandle;
+#if (ENGINE_MAJOR_VERSION < 5)
+	::FDelegateHandle _HeartbeatTickerHandle;
+#else
+	FTSTicker::FDelegateHandle _HeartbeatTickerHandle;
+#endif
 	int32 _ClientsConnected = 0;
 	uint32 _HeartbeatIntervalMS = 100;
 };

--- a/goldenmaster/Plugins/Testbed2/Source/Testbed2/Public/Generated/MsgBus/Testbed2NestedStruct1InterfaceMsgBusClient.h
+++ b/goldenmaster/Plugins/Testbed2/Source/Testbed2/Public/Generated/MsgBus/Testbed2NestedStruct1InterfaceMsgBusClient.h
@@ -22,11 +22,7 @@ limitations under the License.
 #include "HAL/CriticalSection.h"
 #include "Async/Future.h"
 #include "Runtime/Launch/Resources/Version.h"
-#if (ENGINE_MAJOR_VERSION < 5)
-#include "Engine/EngineTypes.h"
-#else
-#include "Engine/TimerHandle.h"
-#endif
+#include "Containers/Ticker.h"
 #include "Templates/PimplPtr.h"
 #include "IMessageContext.h"
 #include "Testbed2NestedStruct1InterfaceMsgBusClient.generated.h"
@@ -119,8 +115,13 @@ private:
 	size_t CurrentPingCounter = 0;
 	float _CalculateAverageRTT() const;
 	FTestbed2NestedStruct1InterfaceStats Stats;
-	FTimerHandle _HeartbeatTimerHandle;
+#if (ENGINE_MAJOR_VERSION < 5)
+	::FDelegateHandle _HeartbeatTickerHandle;
+#else
+	FTSTicker::FDelegateHandle _HeartbeatTickerHandle;
+#endif
 	void _OnHeartbeat();
+	bool _OnHeartbeatTick(float DeltaTime);
 	uint32 _HeartbeatIntervalMS = 100;
 
 	// connection handling

--- a/goldenmaster/Plugins/Testbed2/Source/Testbed2/Public/Generated/MsgBus/Testbed2NestedStruct2InterfaceMsgBusAdapter.h
+++ b/goldenmaster/Plugins/Testbed2/Source/Testbed2/Public/Generated/MsgBus/Testbed2NestedStruct2InterfaceMsgBusAdapter.h
@@ -21,11 +21,7 @@ limitations under the License.
 #include "IMessageContext.h"
 #include "Templates/SharedPointer.h"
 #include "Runtime/Launch/Resources/Version.h"
-#if (ENGINE_MAJOR_VERSION < 5)
-#include "Engine/EngineTypes.h"
-#else
-#include "Engine/TimerHandle.h"
-#endif
+#include "Containers/Ticker.h"
 #include "Testbed2NestedStruct2InterfaceMsgBusAdapter.generated.h"
 
 class FMessageEndpoint;
@@ -130,9 +126,14 @@ private:
 
 	// Heartbeat handling
 	void _CheckClientTimeouts();
+	bool _CheckClientTimeoutsTick(float DeltaTime);
 	void _UpdateClientsConnected();
 	TMap<FMessageAddress, double> ConnectedClientsTimestamps;
-	FTimerHandle _HeartbeatTimerHandle;
+#if (ENGINE_MAJOR_VERSION < 5)
+	::FDelegateHandle _HeartbeatTickerHandle;
+#else
+	FTSTicker::FDelegateHandle _HeartbeatTickerHandle;
+#endif
 	int32 _ClientsConnected = 0;
 	uint32 _HeartbeatIntervalMS = 100;
 };

--- a/goldenmaster/Plugins/Testbed2/Source/Testbed2/Public/Generated/MsgBus/Testbed2NestedStruct2InterfaceMsgBusClient.h
+++ b/goldenmaster/Plugins/Testbed2/Source/Testbed2/Public/Generated/MsgBus/Testbed2NestedStruct2InterfaceMsgBusClient.h
@@ -22,11 +22,7 @@ limitations under the License.
 #include "HAL/CriticalSection.h"
 #include "Async/Future.h"
 #include "Runtime/Launch/Resources/Version.h"
-#if (ENGINE_MAJOR_VERSION < 5)
-#include "Engine/EngineTypes.h"
-#else
-#include "Engine/TimerHandle.h"
-#endif
+#include "Containers/Ticker.h"
 #include "Templates/PimplPtr.h"
 #include "IMessageContext.h"
 #include "Testbed2NestedStruct2InterfaceMsgBusClient.generated.h"
@@ -127,8 +123,13 @@ private:
 	size_t CurrentPingCounter = 0;
 	float _CalculateAverageRTT() const;
 	FTestbed2NestedStruct2InterfaceStats Stats;
-	FTimerHandle _HeartbeatTimerHandle;
+#if (ENGINE_MAJOR_VERSION < 5)
+	::FDelegateHandle _HeartbeatTickerHandle;
+#else
+	FTSTicker::FDelegateHandle _HeartbeatTickerHandle;
+#endif
 	void _OnHeartbeat();
+	bool _OnHeartbeatTick(float DeltaTime);
 	uint32 _HeartbeatIntervalMS = 100;
 
 	// connection handling

--- a/goldenmaster/Plugins/Testbed2/Source/Testbed2/Public/Generated/MsgBus/Testbed2NestedStruct3InterfaceMsgBusAdapter.h
+++ b/goldenmaster/Plugins/Testbed2/Source/Testbed2/Public/Generated/MsgBus/Testbed2NestedStruct3InterfaceMsgBusAdapter.h
@@ -21,11 +21,7 @@ limitations under the License.
 #include "IMessageContext.h"
 #include "Templates/SharedPointer.h"
 #include "Runtime/Launch/Resources/Version.h"
-#if (ENGINE_MAJOR_VERSION < 5)
-#include "Engine/EngineTypes.h"
-#else
-#include "Engine/TimerHandle.h"
-#endif
+#include "Containers/Ticker.h"
 #include "Testbed2NestedStruct3InterfaceMsgBusAdapter.generated.h"
 
 class FMessageEndpoint;
@@ -142,9 +138,14 @@ private:
 
 	// Heartbeat handling
 	void _CheckClientTimeouts();
+	bool _CheckClientTimeoutsTick(float DeltaTime);
 	void _UpdateClientsConnected();
 	TMap<FMessageAddress, double> ConnectedClientsTimestamps;
-	FTimerHandle _HeartbeatTimerHandle;
+#if (ENGINE_MAJOR_VERSION < 5)
+	::FDelegateHandle _HeartbeatTickerHandle;
+#else
+	FTSTicker::FDelegateHandle _HeartbeatTickerHandle;
+#endif
 	int32 _ClientsConnected = 0;
 	uint32 _HeartbeatIntervalMS = 100;
 };

--- a/goldenmaster/Plugins/Testbed2/Source/Testbed2/Public/Generated/MsgBus/Testbed2NestedStruct3InterfaceMsgBusClient.h
+++ b/goldenmaster/Plugins/Testbed2/Source/Testbed2/Public/Generated/MsgBus/Testbed2NestedStruct3InterfaceMsgBusClient.h
@@ -22,11 +22,7 @@ limitations under the License.
 #include "HAL/CriticalSection.h"
 #include "Async/Future.h"
 #include "Runtime/Launch/Resources/Version.h"
-#if (ENGINE_MAJOR_VERSION < 5)
-#include "Engine/EngineTypes.h"
-#else
-#include "Engine/TimerHandle.h"
-#endif
+#include "Containers/Ticker.h"
 #include "Templates/PimplPtr.h"
 #include "IMessageContext.h"
 #include "Testbed2NestedStruct3InterfaceMsgBusClient.generated.h"
@@ -135,8 +131,13 @@ private:
 	size_t CurrentPingCounter = 0;
 	float _CalculateAverageRTT() const;
 	FTestbed2NestedStruct3InterfaceStats Stats;
-	FTimerHandle _HeartbeatTimerHandle;
+#if (ENGINE_MAJOR_VERSION < 5)
+	::FDelegateHandle _HeartbeatTickerHandle;
+#else
+	FTSTicker::FDelegateHandle _HeartbeatTickerHandle;
+#endif
 	void _OnHeartbeat();
+	bool _OnHeartbeatTick(float DeltaTime);
 	uint32 _HeartbeatIntervalMS = 100;
 
 	// connection handling

--- a/goldenmaster/Plugins/Testbed2/Source/Testbed2/Public/Testbed2Settings.h
+++ b/goldenmaster/Plugins/Testbed2/Source/Testbed2/Public/Testbed2Settings.h
@@ -45,4 +45,11 @@ public:
 	/** Choose the olink connection to use */
 	UPROPERTY(EditAnywhere, config, Category = OLinkConnectionSetup)
 	FString OLinkConnectionIdentifier;
+
+	/** Choose the heartbeat interval in milliseconds for the msgbus connection on the service side.
+	 * On the service side this adjusts the heartbeat between client and service. The clients will receive the value from service.
+	 * On the client side this adjusts how often discovery messages are sent until a service is connected.
+	 */
+	UPROPERTY(EditAnywhere, config, Category = MsgBusConnectionSetup, meta = (DisplayName = "Heartbeat interval (in milliseconds)"))
+	uint32 MsgBusHeartbeatIntervalMS = 200;
 };

--- a/goldenmaster/Plugins/Testbed2/Testbed2.uplugin
+++ b/goldenmaster/Plugins/Testbed2/Testbed2.uplugin
@@ -2,7 +2,7 @@
 {
 	"FileVersion": 3,
 	"Version": 1,
-	"VersionName": "1.0.0",
+	"VersionName": "1.0.0+tpl.3.5.2",
 	"FriendlyName": "Testbed2",
 	"Description": "",
 	"Category": "Other",

--- a/rules.yaml
+++ b/rules.yaml
@@ -114,9 +114,8 @@ features:
           - source: "ApiGear/Source/ApiGear/apigear.Build.cs"
             target: "Source/ApiGear/apigear.Build.cs"
             raw: true
-          - source: "ApiGear/apigear.uplugin"
+          - source: "ApiGear/apigear.uplugin.tpl"
             target: "apigear.uplugin"
-            raw: true
           - source: "ApiGear/Config/FilterPlugin.ini"
             target: "Config/FilterPlugin.ini"
             raw: true

--- a/templates/ApiGear/apigear.uplugin.tpl
+++ b/templates/ApiGear/apigear.uplugin.tpl
@@ -1,7 +1,7 @@
 {
 	"FileVersion": 3,
 	"Version": 1,
-	"VersionName": "3.5.1",
+	"VersionName": "{{ template "templateversion" }}",
 	"FriendlyName": "ApiGear",
 	"Description": "ApiGear ThirdParty libraries for tracing, simulation and IPC support",
 	"Category": "Other",

--- a/templates/module/Source/module/Private/Generated/MsgBus/msgbusadapter.cpp.tpl
+++ b/templates/module/Source/module/Private/Generated/MsgBus/msgbusadapter.cpp.tpl
@@ -18,7 +18,6 @@
 #include "Async/Future.h"
 #include "Async/Async.h"
 #include "Engine/World.h"
-#include "TimerManager.h"
 #include "MessageEndpoint.h"
 #include "MessageEndpointBuilder.h"
 #include "Misc/DateTime.h"
@@ -50,13 +49,17 @@ void {{$Class}}::Deinitialize()
 void {{$Class}}::_StartListening()
 {
 
-	if (!_HeartbeatTimerHandle.IsValid() && GetWorld())
+	if (!_HeartbeatTickerHandle.IsValid())
 	{
 		U{{$ModuleName}}Settings* settings = GetMutableDefault<U{{$ModuleName}}Settings>();
 		check(settings);
 		_HeartbeatIntervalMS = settings->MsgBusHeartbeatIntervalMS;
 
-		GetWorld()->GetTimerManager().SetTimer(_HeartbeatTimerHandle, this, &{{$Class}}::_CheckClientTimeouts, _HeartbeatIntervalMS / 1000.0f, true);
+#if (ENGINE_MAJOR_VERSION < 5)
+		_HeartbeatTickerHandle = FTicker::GetCoreTicker().AddTicker(FTickerDelegate::CreateUObject(this, &{{$Class}}::_CheckClientTimeoutsTick), _HeartbeatIntervalMS / 1000.0f);
+#else
+		_HeartbeatTickerHandle = FTSTicker::GetCoreTicker().AddTicker(FTickerDelegate::CreateUObject(this, &{{$Class}}::_CheckClientTimeoutsTick), _HeartbeatIntervalMS / 1000.0f);
+#endif
 	}
 
 	if ({{$Iface}}MsgBusEndpoint.IsValid())
@@ -102,9 +105,13 @@ void {{$Class}}::_AnnounceService()
 
 void {{$Class}}::_StopListening()
 {
-	if (_HeartbeatTimerHandle.IsValid() && GetWorld())
+	if (_HeartbeatTickerHandle.IsValid())
 	{
-		GetWorld()->GetTimerManager().ClearTimer(_HeartbeatTimerHandle);
+#if (ENGINE_MAJOR_VERSION < 5)
+		FTicker::GetCoreTicker().RemoveTicker(_HeartbeatTickerHandle);
+#else
+		FTSTicker::GetCoreTicker().RemoveTicker(_HeartbeatTickerHandle);
+#endif
 	}
 
 	auto msg = new F{{$Iface}}ServiceDisconnectMessage();
@@ -262,6 +269,12 @@ void {{$Class}}::OnClientDisconnected(const F{{$Iface}}ClientDisconnectMessage& 
 	ConnectedClientsTimestamps.Remove(Context->GetSender());
 	_OnClientDisconnected.Broadcast(Context->GetSender().ToString());
 	_UpdateClientsConnected();
+}
+
+bool {{$Class}}::_CheckClientTimeoutsTick(float /*DeltaTime*/)
+{
+	_CheckClientTimeouts();
+	return true;
 }
 
 void {{$Class}}::_CheckClientTimeouts()

--- a/templates/module/Source/module/Private/Generated/MsgBus/msgbusadapter.cpp.tpl
+++ b/templates/module/Source/module/Private/Generated/MsgBus/msgbusadapter.cpp.tpl
@@ -17,12 +17,12 @@
 #include "Generated/MsgBus/{{$Iface}}MsgBusMessages.h"
 #include "Async/Future.h"
 #include "Async/Async.h"
-#include "Async/Async.h"
-#include "Engine/Engine.h"
+#include "Engine/World.h"
 #include "TimerManager.h"
 #include "MessageEndpoint.h"
 #include "MessageEndpointBuilder.h"
 #include "Misc/DateTime.h"
+#include "{{$ModuleName}}Settings.h"
 
 DEFINE_LOG_CATEGORY(Log{{$Iface}}MsgBusAdapter);
 
@@ -52,6 +52,10 @@ void {{$Class}}::_StartListening()
 
 	if (!_HeartbeatTimerHandle.IsValid() && GetWorld())
 	{
+		U{{$ModuleName}}Settings* settings = GetMutableDefault<U{{$ModuleName}}Settings>();
+		check(settings);
+		_HeartbeatIntervalMS = settings->MsgBusHeartbeatIntervalMS;
+
 		GetWorld()->GetTimerManager().SetTimer(_HeartbeatTimerHandle, this, &{{$Class}}::_CheckClientTimeouts, _HeartbeatIntervalMS / 1000.0f, true);
 	}
 

--- a/templates/module/Source/module/Private/Generated/MsgBus/msgbusclient.cpp.tpl
+++ b/templates/module/Source/module/Private/Generated/MsgBus/msgbusclient.cpp.tpl
@@ -18,7 +18,6 @@
 #include "Generated/MsgBus/{{$Iface}}MsgBusMessages.h"
 #include "Async/Async.h"
 #include "Engine/World.h"
-#include "TimerManager.h"
 #include "Misc/DateTime.h"
 #include "GenericPlatform/GenericPlatformMath.h"
 #include "GenericPlatform/GenericPlatformTime.h"
@@ -89,19 +88,25 @@ void {{$Class}}::Deinitialize()
 
 void {{$Class}}::_Connect()
 {
-	if (!_HeartbeatTimerHandle.IsValid() && GetWorld())
+	if (_IsConnected())
+	{
+		UE_LOG(Log{{$Iface}}MsgBusClient, Log, TEXT("Already connected, cannot connect again."));
+		return;
+	}
+
+	if (!_HeartbeatTickerHandle.IsValid())
 	{
 		U{{$ModuleName}}Settings* settings = GetMutableDefault<U{{$ModuleName}}Settings>();
 		check(settings);
 		_HeartbeatIntervalMS = settings->MsgBusHeartbeatIntervalMS;
 
-		GetWorld()->GetTimerManager().SetTimer(_HeartbeatTimerHandle, this, &{{$Class}}::_OnHeartbeat, _HeartbeatIntervalMS / 1000.0f, true);
-	}
-
-	if (_IsConnected())
-	{
-		UE_LOG(Log{{$Iface}}MsgBusClient, Log, TEXT("Already connected, cannot connect again."));
-		return;
+#if (ENGINE_MAJOR_VERSION < 5)
+		FTicker::GetCoreTicker().RemoveTicker(_HeartbeatTickerHandle);
+		_HeartbeatTickerHandle = FTicker::GetCoreTicker().AddTicker(FTickerDelegate::CreateUObject(this, &{{$Class}}::_OnHeartbeatTick), _HeartbeatIntervalMS / 1000.0f);
+#else
+		FTSTicker::GetCoreTicker().RemoveTicker(_HeartbeatTickerHandle);
+		_HeartbeatTickerHandle = FTSTicker::GetCoreTicker().AddTicker(FTickerDelegate::CreateUObject(this, &{{$Class}}::_OnHeartbeatTick), _HeartbeatIntervalMS / 1000.0f);
+#endif
 	}
 
 	if ({{$Iface}}MsgBusEndpoint.IsValid() && !ServiceAddress.IsValid())
@@ -135,10 +140,12 @@ void {{$Class}}::_Connect()
 void {{$Class}}::_Disconnect()
 {
 	_LastHbTimestamp = 0.0f;
-	if (_HeartbeatTimerHandle.IsValid() && GetWorld())
-	{
-		GetWorld()->GetTimerManager().ClearTimer(_HeartbeatTimerHandle);
-	}
+
+#if (ENGINE_MAJOR_VERSION < 5)
+	FTicker::GetCoreTicker().RemoveTicker(_HeartbeatTickerHandle);
+#else
+	FTSTicker::GetCoreTicker().RemoveTicker(_HeartbeatTickerHandle);
+#endif
 
 	if (!_IsConnected())
 	{
@@ -199,15 +206,13 @@ void {{$Class}}::OnConnectionInit(const F{{$Iface}}InitMessage& InMessage, const
 	{
 		_HeartbeatIntervalMS = InMessage._ClientPingIntervalMS;
 
-		if (_HeartbeatTimerHandle.IsValid() && GetWorld())
-		{
-			GetWorld()->GetTimerManager().ClearTimer(_HeartbeatTimerHandle);
-		}
-
-		if (!_HeartbeatTimerHandle.IsValid() && GetWorld())
-		{
-			GetWorld()->GetTimerManager().SetTimer(_HeartbeatTimerHandle, this, &{{$Class}}::_OnHeartbeat, _HeartbeatIntervalMS / 1000.0f, true);
-		}
+#if (ENGINE_MAJOR_VERSION < 5)
+		FTicker::GetCoreTicker().RemoveTicker(_HeartbeatTickerHandle);
+		_HeartbeatTickerHandle = FTicker::GetCoreTicker().AddTicker(FTickerDelegate::CreateUObject(this, &{{$Class}}::_OnHeartbeatTick), _HeartbeatIntervalMS / 1000.0f);
+#else
+		FTSTicker::GetCoreTicker().RemoveTicker(_HeartbeatTickerHandle);
+		_HeartbeatTickerHandle = FTSTicker::GetCoreTicker().AddTicker(FTickerDelegate::CreateUObject(this, &{{$Class}}::_OnHeartbeatTick), _HeartbeatIntervalMS / 1000.0f);
+#endif
 	}
 
 {{- range $i, $e := .Interface.Properties }}
@@ -221,6 +226,12 @@ void {{$Class}}::OnConnectionInit(const F{{$Iface}}InitMessage& InMessage, const
 {{- end }}
 
 	_ConnectionStatusChanged.Broadcast(true);
+}
+
+bool {{$Class}}::_OnHeartbeatTick(float /*DeltaTime*/)
+{
+	_OnHeartbeat();
+	return true;
 }
 
 void {{$Class}}::_OnHeartbeat()

--- a/templates/module/Source/module/Private/Generated/MsgBus/msgbusclient.cpp.tpl
+++ b/templates/module/Source/module/Private/Generated/MsgBus/msgbusclient.cpp.tpl
@@ -17,13 +17,14 @@
 #include "Generated/MsgBus/{{$Iface}}MsgBusClient.h"
 #include "Generated/MsgBus/{{$Iface}}MsgBusMessages.h"
 #include "Async/Async.h"
-#include "Engine/Engine.h"
+#include "Engine/World.h"
 #include "TimerManager.h"
 #include "Misc/DateTime.h"
 #include "GenericPlatform/GenericPlatformMath.h"
 #include "GenericPlatform/GenericPlatformTime.h"
 #include "MessageEndpointBuilder.h"
 #include "MessageEndpoint.h"
+#include "{{$ModuleName}}Settings.h"
 
 {{- if len .Interface.Properties }}
     {{- $shouldIncludeAtomic := 0 -}}
@@ -90,6 +91,10 @@ void {{$Class}}::_Connect()
 {
 	if (!_HeartbeatTimerHandle.IsValid() && GetWorld())
 	{
+		U{{$ModuleName}}Settings* settings = GetMutableDefault<U{{$ModuleName}}Settings>();
+		check(settings);
+		_HeartbeatIntervalMS = settings->MsgBusHeartbeatIntervalMS;
+
 		GetWorld()->GetTimerManager().SetTimer(_HeartbeatTimerHandle, this, &{{$Class}}::_OnHeartbeat, _HeartbeatIntervalMS / 1000.0f, true);
 	}
 

--- a/templates/module/Source/module/Public/Generated/MsgBus/msgbusadapter.h.tpl
+++ b/templates/module/Source/module/Public/Generated/MsgBus/msgbusadapter.h.tpl
@@ -15,11 +15,7 @@
 #include "IMessageContext.h"
 #include "Templates/SharedPointer.h"
 #include "Runtime/Launch/Resources/Version.h"
-#if (ENGINE_MAJOR_VERSION < 5)
-#include "Engine/EngineTypes.h"
-#else
-#include "Engine/TimerHandle.h"
-#endif
+#include "Containers/Ticker.h"
 #include "{{$Iface}}MsgBusAdapter.generated.h"
 
 class FMessageEndpoint;
@@ -130,9 +126,14 @@ private:
 
 	// Heartbeat handling
 	void _CheckClientTimeouts();
+	bool _CheckClientTimeoutsTick(float DeltaTime);
 	void _UpdateClientsConnected();
 	TMap<FMessageAddress, double> ConnectedClientsTimestamps;
-	FTimerHandle _HeartbeatTimerHandle;
+#if (ENGINE_MAJOR_VERSION < 5)
+	::FDelegateHandle _HeartbeatTickerHandle;
+#else
+	FTSTicker::FDelegateHandle _HeartbeatTickerHandle;
+#endif
 	int32 _ClientsConnected = 0;
 	uint32 _HeartbeatIntervalMS = 100;
 };

--- a/templates/module/Source/module/Public/Generated/MsgBus/msgbusclient.h.tpl
+++ b/templates/module/Source/module/Public/Generated/MsgBus/msgbusclient.h.tpl
@@ -17,11 +17,7 @@
 #include "HAL/CriticalSection.h"
 #include "Async/Future.h"
 #include "Runtime/Launch/Resources/Version.h"
-#if (ENGINE_MAJOR_VERSION < 5)
-#include "Engine/EngineTypes.h"
-#else
-#include "Engine/TimerHandle.h"
-#endif
+#include "Containers/Ticker.h"
 #include "Templates/PimplPtr.h"
 #include "IMessageContext.h"
 #include "{{$Iface}}MsgBusClient.generated.h"
@@ -131,8 +127,13 @@ private:
 	size_t CurrentPingCounter = 0;
 	float _CalculateAverageRTT() const;
 	F{{$DisplayName}}Stats Stats;
-	FTimerHandle _HeartbeatTimerHandle;
+#if (ENGINE_MAJOR_VERSION < 5)
+	::FDelegateHandle _HeartbeatTickerHandle;
+#else
+	FTSTicker::FDelegateHandle _HeartbeatTickerHandle;
+#endif
 	void _OnHeartbeat();
+	bool _OnHeartbeatTick(float DeltaTime);
 	uint32 _HeartbeatIntervalMS = 100;
 
 	// connection handling

--- a/templates/module/Source/module/Public/pluginnamesettings.h.tpl
+++ b/templates/module/Source/module/Public/pluginnamesettings.h.tpl
@@ -55,4 +55,14 @@ public:
 	UPROPERTY(EditAnywhere, config, Category = OLinkConnectionSetup)
 	FString OLinkConnectionIdentifier;
 {{- end }}
+
+{{- if $.Features.msgbus }}
+
+	/** Choose the heartbeat interval in milliseconds for the msgbus connection on the service side.
+	 * On the service side this adjusts the heartbeat between client and service. The clients will receive the value from service.
+	 * On the client side this adjusts how often discovery messages are sent until a service is connected.
+	 */
+	UPROPERTY(EditAnywhere, config, Category = MsgBusConnectionSetup, meta = (DisplayName = "Heartbeat interval (in milliseconds)"))
+	uint32 MsgBusHeartbeatIntervalMS = 200;
+{{- end }}
 };

--- a/templates/module/Source/module/pluginname.uplugin.tpl
+++ b/templates/module/Source/module/pluginname.uplugin.tpl
@@ -5,7 +5,7 @@
 {
 	"FileVersion": 3,
 	"Version": 1,
-	"VersionName": "{{.Module.Version}}",
+	"VersionName": "{{.Module.Version}}+tpl.{{ template "templateversion" }}",
 	"FriendlyName": "{{$ModuleName}}",
 	"Description": "",
 	"Category": "Other",

--- a/templates/partials/templateversion.tpl
+++ b/templates/partials/templateversion.tpl
@@ -1,0 +1,3 @@
+{{- define "templateversion" -}}
+3.5.2
+{{- end -}}


### PR DESCRIPTION
## 📑 Description
The heartbeat interval for the MsgBus connection can now be adjusted in the settings. Also we use the ticker instead of the timermanager.

<!-- You can also choose to add a list of changes and if they have been completed or not by using the markdown to-do list syntax
- [ ] Not Completed
- [x] Completed
-->

## ✅ Checks
<!-- Make sure your pr passes the CI checks and do check the following fields as needed - -->
- [ ] My pull request adheres to the code style of this project
- [ ] My code requires changes to the documentation
- [ ] I have updated the documentation as required
- [x] All the tests have passed

## ℹ Additional Information
<!-- Any additional information like breaking changes, dependencies added, screenshots, comparisons between new and old behavior, etc. -->