### PR TITLE
refactor(api): rename enums to pascalcase

### DIFF
--- a/goldenmaster/Plugins/TbEnum/Source/TbEnum/Private/Generated/MsgBus/TbEnumEnumInterfaceMsgBusClient.cpp
+++ b/goldenmaster/Plugins/TbEnum/Source/TbEnum/Private/Generated/MsgBus/TbEnumEnumInterfaceMsgBusClient.cpp
@@ -37,10 +37,10 @@ limitations under the License.
 */
 struct TbEnumEnumInterfacePropertiesMsgBusData
 {
-	std::atomic<ETbEnumEnum0> Prop0{ETbEnumEnum0::TEE0_VALUE0};
-	std::atomic<ETbEnumEnum1> Prop1{ETbEnumEnum1::TEE1_VALUE1};
-	std::atomic<ETbEnumEnum2> Prop2{ETbEnumEnum2::TEE2_VALUE2};
-	std::atomic<ETbEnumEnum3> Prop3{ETbEnumEnum3::TEE3_VALUE3};
+	std::atomic<ETbEnumEnum0> Prop0{ETbEnumEnum0::TEE0_Value0};
+	std::atomic<ETbEnumEnum1> Prop1{ETbEnumEnum1::TEE1_Value1};
+	std::atomic<ETbEnumEnum2> Prop2{ETbEnumEnum2::TEE2_Value2};
+	std::atomic<ETbEnumEnum3> Prop3{ETbEnumEnum3::TEE3_Value3};
 };
 DEFINE_LOG_CATEGORY(LogTbEnumEnumInterfaceMsgBusClient);
 
@@ -482,7 +482,7 @@ ETbEnumEnum0 UTbEnumEnumInterfaceMsgBusClient::Func0_Implementation(ETbEnumEnum0
 	{
 		UE_LOG(LogTbEnumEnumInterfaceMsgBusClient, Error, TEXT("Client has no connection to service."));
 
-		return ETbEnumEnum0::TEE0_VALUE0;
+		return ETbEnumEnum0::TEE0_Value0;
 	}
 
 	auto msg = new FTbEnumEnumInterfaceFunc0RequestMessage();
@@ -511,7 +511,7 @@ ETbEnumEnum1 UTbEnumEnumInterfaceMsgBusClient::Func1_Implementation(ETbEnumEnum1
 	{
 		UE_LOG(LogTbEnumEnumInterfaceMsgBusClient, Error, TEXT("Client has no connection to service."));
 
-		return ETbEnumEnum1::TEE1_VALUE1;
+		return ETbEnumEnum1::TEE1_Value1;
 	}
 
 	auto msg = new FTbEnumEnumInterfaceFunc1RequestMessage();
@@ -540,7 +540,7 @@ ETbEnumEnum2 UTbEnumEnumInterfaceMsgBusClient::Func2_Implementation(ETbEnumEnum2
 	{
 		UE_LOG(LogTbEnumEnumInterfaceMsgBusClient, Error, TEXT("Client has no connection to service."));
 
-		return ETbEnumEnum2::TEE2_VALUE2;
+		return ETbEnumEnum2::TEE2_Value2;
 	}
 
 	auto msg = new FTbEnumEnumInterfaceFunc2RequestMessage();
@@ -569,7 +569,7 @@ ETbEnumEnum3 UTbEnumEnumInterfaceMsgBusClient::Func3_Implementation(ETbEnumEnum3
 	{
 		UE_LOG(LogTbEnumEnumInterfaceMsgBusClient, Error, TEXT("Client has no connection to service."));
 
-		return ETbEnumEnum3::TEE3_VALUE3;
+		return ETbEnumEnum3::TEE3_Value3;
 	}
 
 	auto msg = new FTbEnumEnumInterfaceFunc3RequestMessage();

--- a/goldenmaster/Plugins/TbEnum/Source/TbEnum/Private/Generated/OLink/TbEnumEnumInterfaceOLinkClient.cpp
+++ b/goldenmaster/Plugins/TbEnum/Source/TbEnum/Private/Generated/OLink/TbEnumEnumInterfaceOLinkClient.cpp
@@ -42,10 +42,10 @@ THIRD_PARTY_INCLUDES_END
 */
 struct TbEnumEnumInterfacePropertiesData
 {
-	std::atomic<ETbEnumEnum0> Prop0{ETbEnumEnum0::TEE0_VALUE0};
-	std::atomic<ETbEnumEnum1> Prop1{ETbEnumEnum1::TEE1_VALUE1};
-	std::atomic<ETbEnumEnum2> Prop2{ETbEnumEnum2::TEE2_VALUE2};
-	std::atomic<ETbEnumEnum3> Prop3{ETbEnumEnum3::TEE3_VALUE3};
+	std::atomic<ETbEnumEnum0> Prop0{ETbEnumEnum0::TEE0_Value0};
+	std::atomic<ETbEnumEnum1> Prop1{ETbEnumEnum1::TEE1_Value1};
+	std::atomic<ETbEnumEnum2> Prop2{ETbEnumEnum2::TEE2_Value2};
+	std::atomic<ETbEnumEnum3> Prop3{ETbEnumEnum3::TEE3_Value3};
 };
 DEFINE_LOG_CATEGORY(LogTbEnumEnumInterfaceOLinkClient);
 
@@ -275,7 +275,7 @@ ETbEnumEnum0 UTbEnumEnumInterfaceOLinkClient::Func0_Implementation(ETbEnumEnum0 
 	{
 		UE_LOG(LogTbEnumEnumInterfaceOLinkClient, Error, TEXT("%s has no node. Probably no valid connection or service. Are the ApiGear TbEnum plugin settings correct? Service set up correctly?"), UTF8_TO_TCHAR(m_sink->olinkObjectName().c_str()));
 
-		return ETbEnumEnum0::TEE0_VALUE0;
+		return ETbEnumEnum0::TEE0_Value0;
 	}
 	TPromise<ETbEnumEnum0> Promise;
 	Async(EAsyncExecution::ThreadPool,
@@ -306,7 +306,7 @@ ETbEnumEnum1 UTbEnumEnumInterfaceOLinkClient::Func1_Implementation(ETbEnumEnum1 
 	{
 		UE_LOG(LogTbEnumEnumInterfaceOLinkClient, Error, TEXT("%s has no node. Probably no valid connection or service. Are the ApiGear TbEnum plugin settings correct? Service set up correctly?"), UTF8_TO_TCHAR(m_sink->olinkObjectName().c_str()));
 
-		return ETbEnumEnum1::TEE1_VALUE1;
+		return ETbEnumEnum1::TEE1_Value1;
 	}
 	TPromise<ETbEnumEnum1> Promise;
 	Async(EAsyncExecution::ThreadPool,
@@ -337,7 +337,7 @@ ETbEnumEnum2 UTbEnumEnumInterfaceOLinkClient::Func2_Implementation(ETbEnumEnum2 
 	{
 		UE_LOG(LogTbEnumEnumInterfaceOLinkClient, Error, TEXT("%s has no node. Probably no valid connection or service. Are the ApiGear TbEnum plugin settings correct? Service set up correctly?"), UTF8_TO_TCHAR(m_sink->olinkObjectName().c_str()));
 
-		return ETbEnumEnum2::TEE2_VALUE2;
+		return ETbEnumEnum2::TEE2_Value2;
 	}
 	TPromise<ETbEnumEnum2> Promise;
 	Async(EAsyncExecution::ThreadPool,
@@ -368,7 +368,7 @@ ETbEnumEnum3 UTbEnumEnumInterfaceOLinkClient::Func3_Implementation(ETbEnumEnum3 
 	{
 		UE_LOG(LogTbEnumEnumInterfaceOLinkClient, Error, TEXT("%s has no node. Probably no valid connection or service. Are the ApiGear TbEnum plugin settings correct? Service set up correctly?"), UTF8_TO_TCHAR(m_sink->olinkObjectName().c_str()));
 
-		return ETbEnumEnum3::TEE3_VALUE3;
+		return ETbEnumEnum3::TEE3_Value3;
 	}
 	TPromise<ETbEnumEnum3> Promise;
 	Async(EAsyncExecution::ThreadPool,

--- a/goldenmaster/Plugins/TbEnum/Source/TbEnum/Private/Generated/api/TbEnum_data.cpp
+++ b/goldenmaster/Plugins/TbEnum/Source/TbEnum/Private/Generated/api/TbEnum_data.cpp
@@ -27,19 +27,19 @@ bool UTbEnumLibrary::toTbEnumEnum0(ETbEnumEnum0& ConvertedEnum, uint8 InValue)
 	switch (InValue)
 	{
 	case 0:
-		ConvertedEnum = ETbEnumEnum0::TEE0_VALUE0;
+		ConvertedEnum = ETbEnumEnum0::TEE0_Value0;
 		bSuccessful = true;
 		break;
 	case 1:
-		ConvertedEnum = ETbEnumEnum0::TEE0_VALUE1;
+		ConvertedEnum = ETbEnumEnum0::TEE0_Value1;
 		bSuccessful = true;
 		break;
 	case 2:
-		ConvertedEnum = ETbEnumEnum0::TEE0_VALUE2;
+		ConvertedEnum = ETbEnumEnum0::TEE0_Value2;
 		bSuccessful = true;
 		break;
 	default:
-		ConvertedEnum = ETbEnumEnum0::TEE0_VALUE0;
+		ConvertedEnum = ETbEnumEnum0::TEE0_Value0;
 	}
 	return bSuccessful;
 }
@@ -52,19 +52,19 @@ bool UTbEnumLibrary::toTbEnumEnum1(ETbEnumEnum1& ConvertedEnum, uint8 InValue)
 	switch (InValue)
 	{
 	case 1:
-		ConvertedEnum = ETbEnumEnum1::TEE1_VALUE1;
+		ConvertedEnum = ETbEnumEnum1::TEE1_Value1;
 		bSuccessful = true;
 		break;
 	case 2:
-		ConvertedEnum = ETbEnumEnum1::TEE1_VALUE2;
+		ConvertedEnum = ETbEnumEnum1::TEE1_Value2;
 		bSuccessful = true;
 		break;
 	case 3:
-		ConvertedEnum = ETbEnumEnum1::TEE1_VALUE3;
+		ConvertedEnum = ETbEnumEnum1::TEE1_Value3;
 		bSuccessful = true;
 		break;
 	default:
-		ConvertedEnum = ETbEnumEnum1::TEE1_VALUE1;
+		ConvertedEnum = ETbEnumEnum1::TEE1_Value1;
 	}
 	return bSuccessful;
 }
@@ -77,19 +77,19 @@ bool UTbEnumLibrary::toTbEnumEnum2(ETbEnumEnum2& ConvertedEnum, uint8 InValue)
 	switch (InValue)
 	{
 	case 2:
-		ConvertedEnum = ETbEnumEnum2::TEE2_VALUE2;
+		ConvertedEnum = ETbEnumEnum2::TEE2_Value2;
 		bSuccessful = true;
 		break;
 	case 1:
-		ConvertedEnum = ETbEnumEnum2::TEE2_VALUE1;
+		ConvertedEnum = ETbEnumEnum2::TEE2_Value1;
 		bSuccessful = true;
 		break;
 	case 0:
-		ConvertedEnum = ETbEnumEnum2::TEE2_VALUE0;
+		ConvertedEnum = ETbEnumEnum2::TEE2_Value0;
 		bSuccessful = true;
 		break;
 	default:
-		ConvertedEnum = ETbEnumEnum2::TEE2_VALUE2;
+		ConvertedEnum = ETbEnumEnum2::TEE2_Value2;
 	}
 	return bSuccessful;
 }
@@ -102,19 +102,19 @@ bool UTbEnumLibrary::toTbEnumEnum3(ETbEnumEnum3& ConvertedEnum, uint8 InValue)
 	switch (InValue)
 	{
 	case 3:
-		ConvertedEnum = ETbEnumEnum3::TEE3_VALUE3;
+		ConvertedEnum = ETbEnumEnum3::TEE3_Value3;
 		bSuccessful = true;
 		break;
 	case 2:
-		ConvertedEnum = ETbEnumEnum3::TEE3_VALUE2;
+		ConvertedEnum = ETbEnumEnum3::TEE3_Value2;
 		bSuccessful = true;
 		break;
 	case 1:
-		ConvertedEnum = ETbEnumEnum3::TEE3_VALUE1;
+		ConvertedEnum = ETbEnumEnum3::TEE3_Value1;
 		bSuccessful = true;
 		break;
 	default:
-		ConvertedEnum = ETbEnumEnum3::TEE3_VALUE3;
+		ConvertedEnum = ETbEnumEnum3::TEE3_Value3;
 	}
 	return bSuccessful;
 }

--- a/goldenmaster/Plugins/TbEnum/Source/TbEnum/Private/Implementation/TbEnumEnumInterface.cpp
+++ b/goldenmaster/Plugins/TbEnum/Source/TbEnum/Private/Implementation/TbEnumEnumInterface.cpp
@@ -75,50 +75,50 @@ ETbEnumEnum0 UTbEnumEnumInterface::Func0_Implementation(ETbEnumEnum0 Param0)
 {
 	(void)Param0;
 	// do business logic here
-	return ETbEnumEnum0::TEE0_VALUE0;
+	return ETbEnumEnum0::TEE0_Value0;
 }
 
 ETbEnumEnum1 UTbEnumEnumInterface::Func1_Implementation(ETbEnumEnum1 Param1)
 {
 	(void)Param1;
 	// do business logic here
-	return ETbEnumEnum1::TEE1_VALUE1;
+	return ETbEnumEnum1::TEE1_Value1;
 }
 
 ETbEnumEnum2 UTbEnumEnumInterface::Func2_Implementation(ETbEnumEnum2 Param2)
 {
 	(void)Param2;
 	// do business logic here
-	return ETbEnumEnum2::TEE2_VALUE2;
+	return ETbEnumEnum2::TEE2_Value2;
 }
 
 ETbEnumEnum3 UTbEnumEnumInterface::Func3_Implementation(ETbEnumEnum3 Param3)
 {
 	(void)Param3;
 	// do business logic here
-	return ETbEnumEnum3::TEE3_VALUE3;
+	return ETbEnumEnum3::TEE3_Value3;
 }
 
 void UTbEnumEnumInterface::_ResetProperties()
 {
-	if (Prop0 != ETbEnumEnum0::TEE0_VALUE0)
+	if (Prop0 != ETbEnumEnum0::TEE0_Value0)
 	{
-		Prop0 = ETbEnumEnum0::TEE0_VALUE0;
+		Prop0 = ETbEnumEnum0::TEE0_Value0;
 		Execute__GetSignals(this)->OnProp0Changed.Broadcast(Prop0);
 	}
-	if (Prop1 != ETbEnumEnum1::TEE1_VALUE1)
+	if (Prop1 != ETbEnumEnum1::TEE1_Value1)
 	{
-		Prop1 = ETbEnumEnum1::TEE1_VALUE1;
+		Prop1 = ETbEnumEnum1::TEE1_Value1;
 		Execute__GetSignals(this)->OnProp1Changed.Broadcast(Prop1);
 	}
-	if (Prop2 != ETbEnumEnum2::TEE2_VALUE2)
+	if (Prop2 != ETbEnumEnum2::TEE2_Value2)
 	{
-		Prop2 = ETbEnumEnum2::TEE2_VALUE2;
+		Prop2 = ETbEnumEnum2::TEE2_Value2;
 		Execute__GetSignals(this)->OnProp2Changed.Broadcast(Prop2);
 	}
-	if (Prop3 != ETbEnumEnum3::TEE3_VALUE3)
+	if (Prop3 != ETbEnumEnum3::TEE3_Value3)
 	{
-		Prop3 = ETbEnumEnum3::TEE3_VALUE3;
+		Prop3 = ETbEnumEnum3::TEE3_Value3;
 		Execute__GetSignals(this)->OnProp3Changed.Broadcast(Prop3);
 	}
 }

--- a/goldenmaster/Plugins/TbEnum/Source/TbEnum/Private/Tests/TbEnumEnumInterfaceImpl.spec.cpp
+++ b/goldenmaster/Plugins/TbEnum/Source/TbEnum/Private/Tests/TbEnumEnumInterfaceImpl.spec.cpp
@@ -50,109 +50,109 @@ void UTbEnumEnumInterfaceImplSpec::Define()
 	It("Property.Prop0.Default", [this]()
 		{
 		// Do implement test here
-		ETbEnumEnum0 TestValue = ETbEnumEnum0::TEE0_VALUE0; // default value
+		ETbEnumEnum0 TestValue = ETbEnumEnum0::TEE0_Value0; // default value
 		TestEqual(TEXT("Getter should return the default value"), ImplFixture->GetImplementation()->Execute_GetProp0(ImplFixture->GetImplementation().GetObject()), TestValue);
 	});
 
 	LatentIt("Property.Prop0.Change", EAsyncExecution::ThreadPool, [this](const FDoneDelegate TestDone)
 		{
 		// Do implement test here
-		ETbEnumEnum0 TestValue = ETbEnumEnum0::TEE0_VALUE0; // default value
+		ETbEnumEnum0 TestValue = ETbEnumEnum0::TEE0_Value0; // default value
 		TestEqual(TEXT("Getter should return the default value"), ImplFixture->GetImplementation()->Execute_GetProp0(ImplFixture->GetImplementation().GetObject()), TestValue);
 
 		ImplFixture->GetHelper()->SetTestDone(TestDone);
 		UTbEnumEnumInterfaceSignals* TbEnumEnumInterfaceSignals = ImplFixture->GetImplementation()->Execute__GetSignals(ImplFixture->GetImplementation().GetObject());
 		TbEnumEnumInterfaceSignals->OnProp0Changed.AddDynamic(ImplFixture->GetHelper().Get(), &UTbEnumEnumInterfaceImplHelper::Prop0PropertyCb);
 		// use different test value
-		TestValue = ETbEnumEnum0::TEE0_VALUE1;
+		TestValue = ETbEnumEnum0::TEE0_Value1;
 		ImplFixture->GetImplementation()->Execute_SetProp0(ImplFixture->GetImplementation().GetObject(), TestValue);
 	});
 
 	It("Property.Prop1.Default", [this]()
 		{
 		// Do implement test here
-		ETbEnumEnum1 TestValue = ETbEnumEnum1::TEE1_VALUE1; // default value
+		ETbEnumEnum1 TestValue = ETbEnumEnum1::TEE1_Value1; // default value
 		TestEqual(TEXT("Getter should return the default value"), ImplFixture->GetImplementation()->Execute_GetProp1(ImplFixture->GetImplementation().GetObject()), TestValue);
 	});
 
 	LatentIt("Property.Prop1.Change", EAsyncExecution::ThreadPool, [this](const FDoneDelegate TestDone)
 		{
 		// Do implement test here
-		ETbEnumEnum1 TestValue = ETbEnumEnum1::TEE1_VALUE1; // default value
+		ETbEnumEnum1 TestValue = ETbEnumEnum1::TEE1_Value1; // default value
 		TestEqual(TEXT("Getter should return the default value"), ImplFixture->GetImplementation()->Execute_GetProp1(ImplFixture->GetImplementation().GetObject()), TestValue);
 
 		ImplFixture->GetHelper()->SetTestDone(TestDone);
 		UTbEnumEnumInterfaceSignals* TbEnumEnumInterfaceSignals = ImplFixture->GetImplementation()->Execute__GetSignals(ImplFixture->GetImplementation().GetObject());
 		TbEnumEnumInterfaceSignals->OnProp1Changed.AddDynamic(ImplFixture->GetHelper().Get(), &UTbEnumEnumInterfaceImplHelper::Prop1PropertyCb);
 		// use different test value
-		TestValue = ETbEnumEnum1::TEE1_VALUE2;
+		TestValue = ETbEnumEnum1::TEE1_Value2;
 		ImplFixture->GetImplementation()->Execute_SetProp1(ImplFixture->GetImplementation().GetObject(), TestValue);
 	});
 
 	It("Property.Prop2.Default", [this]()
 		{
 		// Do implement test here
-		ETbEnumEnum2 TestValue = ETbEnumEnum2::TEE2_VALUE2; // default value
+		ETbEnumEnum2 TestValue = ETbEnumEnum2::TEE2_Value2; // default value
 		TestEqual(TEXT("Getter should return the default value"), ImplFixture->GetImplementation()->Execute_GetProp2(ImplFixture->GetImplementation().GetObject()), TestValue);
 	});
 
 	LatentIt("Property.Prop2.Change", EAsyncExecution::ThreadPool, [this](const FDoneDelegate TestDone)
 		{
 		// Do implement test here
-		ETbEnumEnum2 TestValue = ETbEnumEnum2::TEE2_VALUE2; // default value
+		ETbEnumEnum2 TestValue = ETbEnumEnum2::TEE2_Value2; // default value
 		TestEqual(TEXT("Getter should return the default value"), ImplFixture->GetImplementation()->Execute_GetProp2(ImplFixture->GetImplementation().GetObject()), TestValue);
 
 		ImplFixture->GetHelper()->SetTestDone(TestDone);
 		UTbEnumEnumInterfaceSignals* TbEnumEnumInterfaceSignals = ImplFixture->GetImplementation()->Execute__GetSignals(ImplFixture->GetImplementation().GetObject());
 		TbEnumEnumInterfaceSignals->OnProp2Changed.AddDynamic(ImplFixture->GetHelper().Get(), &UTbEnumEnumInterfaceImplHelper::Prop2PropertyCb);
 		// use different test value
-		TestValue = ETbEnumEnum2::TEE2_VALUE1;
+		TestValue = ETbEnumEnum2::TEE2_Value1;
 		ImplFixture->GetImplementation()->Execute_SetProp2(ImplFixture->GetImplementation().GetObject(), TestValue);
 	});
 
 	It("Property.Prop3.Default", [this]()
 		{
 		// Do implement test here
-		ETbEnumEnum3 TestValue = ETbEnumEnum3::TEE3_VALUE3; // default value
+		ETbEnumEnum3 TestValue = ETbEnumEnum3::TEE3_Value3; // default value
 		TestEqual(TEXT("Getter should return the default value"), ImplFixture->GetImplementation()->Execute_GetProp3(ImplFixture->GetImplementation().GetObject()), TestValue);
 	});
 
 	LatentIt("Property.Prop3.Change", EAsyncExecution::ThreadPool, [this](const FDoneDelegate TestDone)
 		{
 		// Do implement test here
-		ETbEnumEnum3 TestValue = ETbEnumEnum3::TEE3_VALUE3; // default value
+		ETbEnumEnum3 TestValue = ETbEnumEnum3::TEE3_Value3; // default value
 		TestEqual(TEXT("Getter should return the default value"), ImplFixture->GetImplementation()->Execute_GetProp3(ImplFixture->GetImplementation().GetObject()), TestValue);
 
 		ImplFixture->GetHelper()->SetTestDone(TestDone);
 		UTbEnumEnumInterfaceSignals* TbEnumEnumInterfaceSignals = ImplFixture->GetImplementation()->Execute__GetSignals(ImplFixture->GetImplementation().GetObject());
 		TbEnumEnumInterfaceSignals->OnProp3Changed.AddDynamic(ImplFixture->GetHelper().Get(), &UTbEnumEnumInterfaceImplHelper::Prop3PropertyCb);
 		// use different test value
-		TestValue = ETbEnumEnum3::TEE3_VALUE2;
+		TestValue = ETbEnumEnum3::TEE3_Value2;
 		ImplFixture->GetImplementation()->Execute_SetProp3(ImplFixture->GetImplementation().GetObject(), TestValue);
 	});
 
 	It("Operation.Func0", [this]()
 		{
 		// Do implement test here
-		ImplFixture->GetImplementation()->Execute_Func0(ImplFixture->GetImplementation().GetObject(), ETbEnumEnum0::TEE0_VALUE0);
+		ImplFixture->GetImplementation()->Execute_Func0(ImplFixture->GetImplementation().GetObject(), ETbEnumEnum0::TEE0_Value0);
 	});
 
 	It("Operation.Func1", [this]()
 		{
 		// Do implement test here
-		ImplFixture->GetImplementation()->Execute_Func1(ImplFixture->GetImplementation().GetObject(), ETbEnumEnum1::TEE1_VALUE1);
+		ImplFixture->GetImplementation()->Execute_Func1(ImplFixture->GetImplementation().GetObject(), ETbEnumEnum1::TEE1_Value1);
 	});
 
 	It("Operation.Func2", [this]()
 		{
 		// Do implement test here
-		ImplFixture->GetImplementation()->Execute_Func2(ImplFixture->GetImplementation().GetObject(), ETbEnumEnum2::TEE2_VALUE2);
+		ImplFixture->GetImplementation()->Execute_Func2(ImplFixture->GetImplementation().GetObject(), ETbEnumEnum2::TEE2_Value2);
 	});
 
 	It("Operation.Func3", [this]()
 		{
 		// Do implement test here
-		ImplFixture->GetImplementation()->Execute_Func3(ImplFixture->GetImplementation().GetObject(), ETbEnumEnum3::TEE3_VALUE3);
+		ImplFixture->GetImplementation()->Execute_Func3(ImplFixture->GetImplementation().GetObject(), ETbEnumEnum3::TEE3_Value3);
 	});
 
 	LatentIt("Signal.Sig0", EAsyncExecution::ThreadPool, [this](const FDoneDelegate TestDone)
@@ -162,7 +162,7 @@ void UTbEnumEnumInterfaceImplSpec::Define()
 		TbEnumEnumInterfaceSignals->OnSig0Signal.AddDynamic(ImplFixture->GetHelper().Get(), &UTbEnumEnumInterfaceImplHelper::Sig0SignalCb);
 
 		// use different test value
-		ETbEnumEnum0 Param0TestValue = ETbEnumEnum0::TEE0_VALUE1;
+		ETbEnumEnum0 Param0TestValue = ETbEnumEnum0::TEE0_Value1;
 		TbEnumEnumInterfaceSignals->BroadcastSig0Signal(Param0TestValue);
 	});
 
@@ -173,7 +173,7 @@ void UTbEnumEnumInterfaceImplSpec::Define()
 		TbEnumEnumInterfaceSignals->OnSig1Signal.AddDynamic(ImplFixture->GetHelper().Get(), &UTbEnumEnumInterfaceImplHelper::Sig1SignalCb);
 
 		// use different test value
-		ETbEnumEnum1 Param1TestValue = ETbEnumEnum1::TEE1_VALUE2;
+		ETbEnumEnum1 Param1TestValue = ETbEnumEnum1::TEE1_Value2;
 		TbEnumEnumInterfaceSignals->BroadcastSig1Signal(Param1TestValue);
 	});
 
@@ -184,7 +184,7 @@ void UTbEnumEnumInterfaceImplSpec::Define()
 		TbEnumEnumInterfaceSignals->OnSig2Signal.AddDynamic(ImplFixture->GetHelper().Get(), &UTbEnumEnumInterfaceImplHelper::Sig2SignalCb);
 
 		// use different test value
-		ETbEnumEnum2 Param2TestValue = ETbEnumEnum2::TEE2_VALUE1;
+		ETbEnumEnum2 Param2TestValue = ETbEnumEnum2::TEE2_Value1;
 		TbEnumEnumInterfaceSignals->BroadcastSig2Signal(Param2TestValue);
 	});
 
@@ -195,7 +195,7 @@ void UTbEnumEnumInterfaceImplSpec::Define()
 		TbEnumEnumInterfaceSignals->OnSig3Signal.AddDynamic(ImplFixture->GetHelper().Get(), &UTbEnumEnumInterfaceImplHelper::Sig3SignalCb);
 
 		// use different test value
-		ETbEnumEnum3 Param3TestValue = ETbEnumEnum3::TEE3_VALUE2;
+		ETbEnumEnum3 Param3TestValue = ETbEnumEnum3::TEE3_Value2;
 		TbEnumEnumInterfaceSignals->BroadcastSig3Signal(Param3TestValue);
 	});
 }

--- a/goldenmaster/Plugins/TbEnum/Source/TbEnum/Private/Tests/TbEnumEnumInterfaceImplFixture.cpp
+++ b/goldenmaster/Plugins/TbEnum/Source/TbEnum/Private/Tests/TbEnumEnumInterfaceImplFixture.cpp
@@ -39,9 +39,9 @@ void UTbEnumEnumInterfaceImplHelper::SetTestDone(const FDoneDelegate& InDone)
 
 void UTbEnumEnumInterfaceImplHelper::Prop0PropertyCb(ETbEnumEnum0 InProp0)
 {
-	ETbEnumEnum0 TestValue = ETbEnumEnum0::TEE0_VALUE0;
+	ETbEnumEnum0 TestValue = ETbEnumEnum0::TEE0_Value0;
 	// use different test value
-	TestValue = ETbEnumEnum0::TEE0_VALUE1;
+	TestValue = ETbEnumEnum0::TEE0_Value1;
 	Spec->TestEqual(TEXT("Delegate parameter should be the same value as set by the setter"), InProp0, TestValue);
 	if (TSharedPtr<FTbEnumEnumInterfaceImplFixture> PinnedImplFixture = ImplFixture.Pin())
 	{
@@ -52,9 +52,9 @@ void UTbEnumEnumInterfaceImplHelper::Prop0PropertyCb(ETbEnumEnum0 InProp0)
 
 void UTbEnumEnumInterfaceImplHelper::Prop1PropertyCb(ETbEnumEnum1 InProp1)
 {
-	ETbEnumEnum1 TestValue = ETbEnumEnum1::TEE1_VALUE1;
+	ETbEnumEnum1 TestValue = ETbEnumEnum1::TEE1_Value1;
 	// use different test value
-	TestValue = ETbEnumEnum1::TEE1_VALUE2;
+	TestValue = ETbEnumEnum1::TEE1_Value2;
 	Spec->TestEqual(TEXT("Delegate parameter should be the same value as set by the setter"), InProp1, TestValue);
 	if (TSharedPtr<FTbEnumEnumInterfaceImplFixture> PinnedImplFixture = ImplFixture.Pin())
 	{
@@ -65,9 +65,9 @@ void UTbEnumEnumInterfaceImplHelper::Prop1PropertyCb(ETbEnumEnum1 InProp1)
 
 void UTbEnumEnumInterfaceImplHelper::Prop2PropertyCb(ETbEnumEnum2 InProp2)
 {
-	ETbEnumEnum2 TestValue = ETbEnumEnum2::TEE2_VALUE2;
+	ETbEnumEnum2 TestValue = ETbEnumEnum2::TEE2_Value2;
 	// use different test value
-	TestValue = ETbEnumEnum2::TEE2_VALUE1;
+	TestValue = ETbEnumEnum2::TEE2_Value1;
 	Spec->TestEqual(TEXT("Delegate parameter should be the same value as set by the setter"), InProp2, TestValue);
 	if (TSharedPtr<FTbEnumEnumInterfaceImplFixture> PinnedImplFixture = ImplFixture.Pin())
 	{
@@ -78,9 +78,9 @@ void UTbEnumEnumInterfaceImplHelper::Prop2PropertyCb(ETbEnumEnum2 InProp2)
 
 void UTbEnumEnumInterfaceImplHelper::Prop3PropertyCb(ETbEnumEnum3 InProp3)
 {
-	ETbEnumEnum3 TestValue = ETbEnumEnum3::TEE3_VALUE3;
+	ETbEnumEnum3 TestValue = ETbEnumEnum3::TEE3_Value3;
 	// use different test value
-	TestValue = ETbEnumEnum3::TEE3_VALUE2;
+	TestValue = ETbEnumEnum3::TEE3_Value2;
 	Spec->TestEqual(TEXT("Delegate parameter should be the same value as set by the setter"), InProp3, TestValue);
 	if (TSharedPtr<FTbEnumEnumInterfaceImplFixture> PinnedImplFixture = ImplFixture.Pin())
 	{
@@ -92,7 +92,7 @@ void UTbEnumEnumInterfaceImplHelper::Prop3PropertyCb(ETbEnumEnum3 InProp3)
 void UTbEnumEnumInterfaceImplHelper::Sig0SignalCb(ETbEnumEnum0 InParam0)
 {
 	// known test value
-	ETbEnumEnum0 Param0TestValue = ETbEnumEnum0::TEE0_VALUE1;
+	ETbEnumEnum0 Param0TestValue = ETbEnumEnum0::TEE0_Value1;
 	Spec->TestEqual(TEXT("Parameter should be the same value as sent by the signal"), InParam0, Param0TestValue);
 	testDoneDelegate.Execute();
 }
@@ -100,7 +100,7 @@ void UTbEnumEnumInterfaceImplHelper::Sig0SignalCb(ETbEnumEnum0 InParam0)
 void UTbEnumEnumInterfaceImplHelper::Sig1SignalCb(ETbEnumEnum1 InParam1)
 {
 	// known test value
-	ETbEnumEnum1 Param1TestValue = ETbEnumEnum1::TEE1_VALUE2;
+	ETbEnumEnum1 Param1TestValue = ETbEnumEnum1::TEE1_Value2;
 	Spec->TestEqual(TEXT("Parameter should be the same value as sent by the signal"), InParam1, Param1TestValue);
 	testDoneDelegate.Execute();
 }
@@ -108,7 +108,7 @@ void UTbEnumEnumInterfaceImplHelper::Sig1SignalCb(ETbEnumEnum1 InParam1)
 void UTbEnumEnumInterfaceImplHelper::Sig2SignalCb(ETbEnumEnum2 InParam2)
 {
 	// known test value
-	ETbEnumEnum2 Param2TestValue = ETbEnumEnum2::TEE2_VALUE1;
+	ETbEnumEnum2 Param2TestValue = ETbEnumEnum2::TEE2_Value1;
 	Spec->TestEqual(TEXT("Parameter should be the same value as sent by the signal"), InParam2, Param2TestValue);
 	testDoneDelegate.Execute();
 }
@@ -116,7 +116,7 @@ void UTbEnumEnumInterfaceImplHelper::Sig2SignalCb(ETbEnumEnum2 InParam2)
 void UTbEnumEnumInterfaceImplHelper::Sig3SignalCb(ETbEnumEnum3 InParam3)
 {
 	// known test value
-	ETbEnumEnum3 Param3TestValue = ETbEnumEnum3::TEE3_VALUE2;
+	ETbEnumEnum3 Param3TestValue = ETbEnumEnum3::TEE3_Value2;
 	Spec->TestEqual(TEXT("Parameter should be the same value as sent by the signal"), InParam3, Param3TestValue);
 	testDoneDelegate.Execute();
 }

--- a/goldenmaster/Plugins/TbEnum/Source/TbEnum/Private/Tests/TbEnumEnumInterfaceMsgBus.spec.cpp
+++ b/goldenmaster/Plugins/TbEnum/Source/TbEnum/Private/Tests/TbEnumEnumInterfaceMsgBus.spec.cpp
@@ -67,35 +67,35 @@ void UTbEnumEnumInterfaceMsgBusSpec::Define()
 	It("Property.Prop0.Default", [this]()
 		{
 		// Do implement test here
-		ETbEnumEnum0 TestValue = ETbEnumEnum0::TEE0_VALUE0; // default value
+		ETbEnumEnum0 TestValue = ETbEnumEnum0::TEE0_Value0; // default value
 		TestEqual(TEXT("Getter should return the default value"), ImplFixture->GetImplementation()->Execute_GetProp0(ImplFixture->GetImplementation().GetObject()), TestValue);
 	});
 
 	LatentIt("Property.Prop0.Change", EAsyncExecution::ThreadPool, [this](const FDoneDelegate TestDone)
 		{
 		// Do implement test here
-		ETbEnumEnum0 TestValue = ETbEnumEnum0::TEE0_VALUE0; // default value
+		ETbEnumEnum0 TestValue = ETbEnumEnum0::TEE0_Value0; // default value
 		TestEqual(TEXT("Getter should return the default value"), ImplFixture->GetImplementation()->Execute_GetProp0(ImplFixture->GetImplementation().GetObject()), TestValue);
 
 		ImplFixture->GetHelper()->SetTestDone(TestDone);
 		UTbEnumEnumInterfaceSignals* TbEnumEnumInterfaceSignals = ImplFixture->GetImplementation()->Execute__GetSignals(ImplFixture->GetImplementation().GetObject());
 		TbEnumEnumInterfaceSignals->OnProp0Changed.AddDynamic(ImplFixture->GetHelper().Get(), &UTbEnumEnumInterfaceMsgBusHelper::Prop0PropertyCb);
 		// use different test value
-		TestValue = ETbEnumEnum0::TEE0_VALUE1;
+		TestValue = ETbEnumEnum0::TEE0_Value1;
 		ImplFixture->GetImplementation()->Execute_SetProp0(ImplFixture->GetImplementation().GetObject(), TestValue);
 	});
 
 	LatentIt("Property.Prop0.ChangeLocalCheckRemote", EAsyncExecution::ThreadPool, [this](const FDoneDelegate TestDone)
 		{
 		// Do implement test here
-		ETbEnumEnum0 TestValue = ETbEnumEnum0::TEE0_VALUE0; // default value
+		ETbEnumEnum0 TestValue = ETbEnumEnum0::TEE0_Value0; // default value
 		TestEqual(TEXT("Getter should return the default value"), ImplFixture->GetImplementation()->Execute_GetProp0(ImplFixture->GetImplementation().GetObject()), TestValue);
 
 		ImplFixture->GetHelper()->SetTestDone(TestDone);
 		UTbEnumEnumInterfaceSignals* TbEnumEnumInterfaceSignals = ImplFixture->GetImplementation()->Execute__GetSignals(ImplFixture->GetImplementation().GetObject());
 		TbEnumEnumInterfaceSignals->OnProp0Changed.AddDynamic(ImplFixture->GetHelper().Get(), &UTbEnumEnumInterfaceMsgBusHelper::Prop0PropertyChangeLocalCheckRemoteCb);
 		// use different test value
-		TestValue = ETbEnumEnum0::TEE0_VALUE1;
+		TestValue = ETbEnumEnum0::TEE0_Value1;
 		auto service = ImplFixture->GetGameInstance()->GetSubsystem<UTbEnumEnumInterface>();
 		service->Execute_SetProp0(service, TestValue);
 	});
@@ -103,14 +103,14 @@ void UTbEnumEnumInterfaceMsgBusSpec::Define()
 	LatentIt("Property.Prop0.ChangeLocalChangeBackRemote", EAsyncExecution::ThreadPool, [this](const FDoneDelegate TestDone)
 		{
 		// Do implement test here
-		ETbEnumEnum0 TestValue = ETbEnumEnum0::TEE0_VALUE0; // default value
+		ETbEnumEnum0 TestValue = ETbEnumEnum0::TEE0_Value0; // default value
 		TestEqual(TEXT("Getter should return the default value"), ImplFixture->GetImplementation()->Execute_GetProp0(ImplFixture->GetImplementation().GetObject()), TestValue);
 
 		ImplFixture->GetHelper()->SetTestDone(TestDone);
 		UTbEnumEnumInterfaceSignals* TbEnumEnumInterfaceSignals = ImplFixture->GetImplementation()->Execute__GetSignals(ImplFixture->GetImplementation().GetObject());
 		TbEnumEnumInterfaceSignals->OnProp0Changed.AddDynamic(ImplFixture->GetHelper().Get(), &UTbEnumEnumInterfaceMsgBusHelper::Prop0PropertyChangeLocalChangeRemoteCb);
 		// use different test value
-		TestValue = ETbEnumEnum0::TEE0_VALUE1;
+		TestValue = ETbEnumEnum0::TEE0_Value1;
 		auto service = ImplFixture->GetGameInstance()->GetSubsystem<UTbEnumEnumInterface>();
 		service->Execute_SetProp0(service, TestValue);
 	});
@@ -118,35 +118,35 @@ void UTbEnumEnumInterfaceMsgBusSpec::Define()
 	It("Property.Prop1.Default", [this]()
 		{
 		// Do implement test here
-		ETbEnumEnum1 TestValue = ETbEnumEnum1::TEE1_VALUE1; // default value
+		ETbEnumEnum1 TestValue = ETbEnumEnum1::TEE1_Value1; // default value
 		TestEqual(TEXT("Getter should return the default value"), ImplFixture->GetImplementation()->Execute_GetProp1(ImplFixture->GetImplementation().GetObject()), TestValue);
 	});
 
 	LatentIt("Property.Prop1.Change", EAsyncExecution::ThreadPool, [this](const FDoneDelegate TestDone)
 		{
 		// Do implement test here
-		ETbEnumEnum1 TestValue = ETbEnumEnum1::TEE1_VALUE1; // default value
+		ETbEnumEnum1 TestValue = ETbEnumEnum1::TEE1_Value1; // default value
 		TestEqual(TEXT("Getter should return the default value"), ImplFixture->GetImplementation()->Execute_GetProp1(ImplFixture->GetImplementation().GetObject()), TestValue);
 
 		ImplFixture->GetHelper()->SetTestDone(TestDone);
 		UTbEnumEnumInterfaceSignals* TbEnumEnumInterfaceSignals = ImplFixture->GetImplementation()->Execute__GetSignals(ImplFixture->GetImplementation().GetObject());
 		TbEnumEnumInterfaceSignals->OnProp1Changed.AddDynamic(ImplFixture->GetHelper().Get(), &UTbEnumEnumInterfaceMsgBusHelper::Prop1PropertyCb);
 		// use different test value
-		TestValue = ETbEnumEnum1::TEE1_VALUE2;
+		TestValue = ETbEnumEnum1::TEE1_Value2;
 		ImplFixture->GetImplementation()->Execute_SetProp1(ImplFixture->GetImplementation().GetObject(), TestValue);
 	});
 
 	LatentIt("Property.Prop1.ChangeLocalCheckRemote", EAsyncExecution::ThreadPool, [this](const FDoneDelegate TestDone)
 		{
 		// Do implement test here
-		ETbEnumEnum1 TestValue = ETbEnumEnum1::TEE1_VALUE1; // default value
+		ETbEnumEnum1 TestValue = ETbEnumEnum1::TEE1_Value1; // default value
 		TestEqual(TEXT("Getter should return the default value"), ImplFixture->GetImplementation()->Execute_GetProp1(ImplFixture->GetImplementation().GetObject()), TestValue);
 
 		ImplFixture->GetHelper()->SetTestDone(TestDone);
 		UTbEnumEnumInterfaceSignals* TbEnumEnumInterfaceSignals = ImplFixture->GetImplementation()->Execute__GetSignals(ImplFixture->GetImplementation().GetObject());
 		TbEnumEnumInterfaceSignals->OnProp1Changed.AddDynamic(ImplFixture->GetHelper().Get(), &UTbEnumEnumInterfaceMsgBusHelper::Prop1PropertyChangeLocalCheckRemoteCb);
 		// use different test value
-		TestValue = ETbEnumEnum1::TEE1_VALUE2;
+		TestValue = ETbEnumEnum1::TEE1_Value2;
 		auto service = ImplFixture->GetGameInstance()->GetSubsystem<UTbEnumEnumInterface>();
 		service->Execute_SetProp1(service, TestValue);
 	});
@@ -154,14 +154,14 @@ void UTbEnumEnumInterfaceMsgBusSpec::Define()
 	LatentIt("Property.Prop1.ChangeLocalChangeBackRemote", EAsyncExecution::ThreadPool, [this](const FDoneDelegate TestDone)
 		{
 		// Do implement test here
-		ETbEnumEnum1 TestValue = ETbEnumEnum1::TEE1_VALUE1; // default value
+		ETbEnumEnum1 TestValue = ETbEnumEnum1::TEE1_Value1; // default value
 		TestEqual(TEXT("Getter should return the default value"), ImplFixture->GetImplementation()->Execute_GetProp1(ImplFixture->GetImplementation().GetObject()), TestValue);
 
 		ImplFixture->GetHelper()->SetTestDone(TestDone);
 		UTbEnumEnumInterfaceSignals* TbEnumEnumInterfaceSignals = ImplFixture->GetImplementation()->Execute__GetSignals(ImplFixture->GetImplementation().GetObject());
 		TbEnumEnumInterfaceSignals->OnProp1Changed.AddDynamic(ImplFixture->GetHelper().Get(), &UTbEnumEnumInterfaceMsgBusHelper::Prop1PropertyChangeLocalChangeRemoteCb);
 		// use different test value
-		TestValue = ETbEnumEnum1::TEE1_VALUE2;
+		TestValue = ETbEnumEnum1::TEE1_Value2;
 		auto service = ImplFixture->GetGameInstance()->GetSubsystem<UTbEnumEnumInterface>();
 		service->Execute_SetProp1(service, TestValue);
 	});
@@ -169,35 +169,35 @@ void UTbEnumEnumInterfaceMsgBusSpec::Define()
 	It("Property.Prop2.Default", [this]()
 		{
 		// Do implement test here
-		ETbEnumEnum2 TestValue = ETbEnumEnum2::TEE2_VALUE2; // default value
+		ETbEnumEnum2 TestValue = ETbEnumEnum2::TEE2_Value2; // default value
 		TestEqual(TEXT("Getter should return the default value"), ImplFixture->GetImplementation()->Execute_GetProp2(ImplFixture->GetImplementation().GetObject()), TestValue);
 	});
 
 	LatentIt("Property.Prop2.Change", EAsyncExecution::ThreadPool, [this](const FDoneDelegate TestDone)
 		{
 		// Do implement test here
-		ETbEnumEnum2 TestValue = ETbEnumEnum2::TEE2_VALUE2; // default value
+		ETbEnumEnum2 TestValue = ETbEnumEnum2::TEE2_Value2; // default value
 		TestEqual(TEXT("Getter should return the default value"), ImplFixture->GetImplementation()->Execute_GetProp2(ImplFixture->GetImplementation().GetObject()), TestValue);
 
 		ImplFixture->GetHelper()->SetTestDone(TestDone);
 		UTbEnumEnumInterfaceSignals* TbEnumEnumInterfaceSignals = ImplFixture->GetImplementation()->Execute__GetSignals(ImplFixture->GetImplementation().GetObject());
 		TbEnumEnumInterfaceSignals->OnProp2Changed.AddDynamic(ImplFixture->GetHelper().Get(), &UTbEnumEnumInterfaceMsgBusHelper::Prop2PropertyCb);
 		// use different test value
-		TestValue = ETbEnumEnum2::TEE2_VALUE1;
+		TestValue = ETbEnumEnum2::TEE2_Value1;
 		ImplFixture->GetImplementation()->Execute_SetProp2(ImplFixture->GetImplementation().GetObject(), TestValue);
 	});
 
 	LatentIt("Property.Prop2.ChangeLocalCheckRemote", EAsyncExecution::ThreadPool, [this](const FDoneDelegate TestDone)
 		{
 		// Do implement test here
-		ETbEnumEnum2 TestValue = ETbEnumEnum2::TEE2_VALUE2; // default value
+		ETbEnumEnum2 TestValue = ETbEnumEnum2::TEE2_Value2; // default value
 		TestEqual(TEXT("Getter should return the default value"), ImplFixture->GetImplementation()->Execute_GetProp2(ImplFixture->GetImplementation().GetObject()), TestValue);
 
 		ImplFixture->GetHelper()->SetTestDone(TestDone);
 		UTbEnumEnumInterfaceSignals* TbEnumEnumInterfaceSignals = ImplFixture->GetImplementation()->Execute__GetSignals(ImplFixture->GetImplementation().GetObject());
 		TbEnumEnumInterfaceSignals->OnProp2Changed.AddDynamic(ImplFixture->GetHelper().Get(), &UTbEnumEnumInterfaceMsgBusHelper::Prop2PropertyChangeLocalCheckRemoteCb);
 		// use different test value
-		TestValue = ETbEnumEnum2::TEE2_VALUE1;
+		TestValue = ETbEnumEnum2::TEE2_Value1;
 		auto service = ImplFixture->GetGameInstance()->GetSubsystem<UTbEnumEnumInterface>();
 		service->Execute_SetProp2(service, TestValue);
 	});
@@ -205,14 +205,14 @@ void UTbEnumEnumInterfaceMsgBusSpec::Define()
 	LatentIt("Property.Prop2.ChangeLocalChangeBackRemote", EAsyncExecution::ThreadPool, [this](const FDoneDelegate TestDone)
 		{
 		// Do implement test here
-		ETbEnumEnum2 TestValue = ETbEnumEnum2::TEE2_VALUE2; // default value
+		ETbEnumEnum2 TestValue = ETbEnumEnum2::TEE2_Value2; // default value
 		TestEqual(TEXT("Getter should return the default value"), ImplFixture->GetImplementation()->Execute_GetProp2(ImplFixture->GetImplementation().GetObject()), TestValue);
 
 		ImplFixture->GetHelper()->SetTestDone(TestDone);
 		UTbEnumEnumInterfaceSignals* TbEnumEnumInterfaceSignals = ImplFixture->GetImplementation()->Execute__GetSignals(ImplFixture->GetImplementation().GetObject());
 		TbEnumEnumInterfaceSignals->OnProp2Changed.AddDynamic(ImplFixture->GetHelper().Get(), &UTbEnumEnumInterfaceMsgBusHelper::Prop2PropertyChangeLocalChangeRemoteCb);
 		// use different test value
-		TestValue = ETbEnumEnum2::TEE2_VALUE1;
+		TestValue = ETbEnumEnum2::TEE2_Value1;
 		auto service = ImplFixture->GetGameInstance()->GetSubsystem<UTbEnumEnumInterface>();
 		service->Execute_SetProp2(service, TestValue);
 	});
@@ -220,35 +220,35 @@ void UTbEnumEnumInterfaceMsgBusSpec::Define()
 	It("Property.Prop3.Default", [this]()
 		{
 		// Do implement test here
-		ETbEnumEnum3 TestValue = ETbEnumEnum3::TEE3_VALUE3; // default value
+		ETbEnumEnum3 TestValue = ETbEnumEnum3::TEE3_Value3; // default value
 		TestEqual(TEXT("Getter should return the default value"), ImplFixture->GetImplementation()->Execute_GetProp3(ImplFixture->GetImplementation().GetObject()), TestValue);
 	});
 
 	LatentIt("Property.Prop3.Change", EAsyncExecution::ThreadPool, [this](const FDoneDelegate TestDone)
 		{
 		// Do implement test here
-		ETbEnumEnum3 TestValue = ETbEnumEnum3::TEE3_VALUE3; // default value
+		ETbEnumEnum3 TestValue = ETbEnumEnum3::TEE3_Value3; // default value
 		TestEqual(TEXT("Getter should return the default value"), ImplFixture->GetImplementation()->Execute_GetProp3(ImplFixture->GetImplementation().GetObject()), TestValue);
 
 		ImplFixture->GetHelper()->SetTestDone(TestDone);
 		UTbEnumEnumInterfaceSignals* TbEnumEnumInterfaceSignals = ImplFixture->GetImplementation()->Execute__GetSignals(ImplFixture->GetImplementation().GetObject());
 		TbEnumEnumInterfaceSignals->OnProp3Changed.AddDynamic(ImplFixture->GetHelper().Get(), &UTbEnumEnumInterfaceMsgBusHelper::Prop3PropertyCb);
 		// use different test value
-		TestValue = ETbEnumEnum3::TEE3_VALUE2;
+		TestValue = ETbEnumEnum3::TEE3_Value2;
 		ImplFixture->GetImplementation()->Execute_SetProp3(ImplFixture->GetImplementation().GetObject(), TestValue);
 	});
 
 	LatentIt("Property.Prop3.ChangeLocalCheckRemote", EAsyncExecution::ThreadPool, [this](const FDoneDelegate TestDone)
 		{
 		// Do implement test here
-		ETbEnumEnum3 TestValue = ETbEnumEnum3::TEE3_VALUE3; // default value
+		ETbEnumEnum3 TestValue = ETbEnumEnum3::TEE3_Value3; // default value
 		TestEqual(TEXT("Getter should return the default value"), ImplFixture->GetImplementation()->Execute_GetProp3(ImplFixture->GetImplementation().GetObject()), TestValue);
 
 		ImplFixture->GetHelper()->SetTestDone(TestDone);
 		UTbEnumEnumInterfaceSignals* TbEnumEnumInterfaceSignals = ImplFixture->GetImplementation()->Execute__GetSignals(ImplFixture->GetImplementation().GetObject());
 		TbEnumEnumInterfaceSignals->OnProp3Changed.AddDynamic(ImplFixture->GetHelper().Get(), &UTbEnumEnumInterfaceMsgBusHelper::Prop3PropertyChangeLocalCheckRemoteCb);
 		// use different test value
-		TestValue = ETbEnumEnum3::TEE3_VALUE2;
+		TestValue = ETbEnumEnum3::TEE3_Value2;
 		auto service = ImplFixture->GetGameInstance()->GetSubsystem<UTbEnumEnumInterface>();
 		service->Execute_SetProp3(service, TestValue);
 	});
@@ -256,14 +256,14 @@ void UTbEnumEnumInterfaceMsgBusSpec::Define()
 	LatentIt("Property.Prop3.ChangeLocalChangeBackRemote", EAsyncExecution::ThreadPool, [this](const FDoneDelegate TestDone)
 		{
 		// Do implement test here
-		ETbEnumEnum3 TestValue = ETbEnumEnum3::TEE3_VALUE3; // default value
+		ETbEnumEnum3 TestValue = ETbEnumEnum3::TEE3_Value3; // default value
 		TestEqual(TEXT("Getter should return the default value"), ImplFixture->GetImplementation()->Execute_GetProp3(ImplFixture->GetImplementation().GetObject()), TestValue);
 
 		ImplFixture->GetHelper()->SetTestDone(TestDone);
 		UTbEnumEnumInterfaceSignals* TbEnumEnumInterfaceSignals = ImplFixture->GetImplementation()->Execute__GetSignals(ImplFixture->GetImplementation().GetObject());
 		TbEnumEnumInterfaceSignals->OnProp3Changed.AddDynamic(ImplFixture->GetHelper().Get(), &UTbEnumEnumInterfaceMsgBusHelper::Prop3PropertyChangeLocalChangeRemoteCb);
 		// use different test value
-		TestValue = ETbEnumEnum3::TEE3_VALUE2;
+		TestValue = ETbEnumEnum3::TEE3_Value2;
 		auto service = ImplFixture->GetGameInstance()->GetSubsystem<UTbEnumEnumInterface>();
 		service->Execute_SetProp3(service, TestValue);
 	});
@@ -273,7 +273,7 @@ void UTbEnumEnumInterfaceMsgBusSpec::Define()
 		// Do implement test here
 		AsyncTask(ENamedThreads::AnyThread, [this, TestDone]()
 			{
-			ImplFixture->GetImplementation()->Execute_Func0(ImplFixture->GetImplementation().GetObject(), ETbEnumEnum0::TEE0_VALUE0);
+			ImplFixture->GetImplementation()->Execute_Func0(ImplFixture->GetImplementation().GetObject(), ETbEnumEnum0::TEE0_Value0);
 			TestDone.Execute();
 		});
 	});
@@ -283,7 +283,7 @@ void UTbEnumEnumInterfaceMsgBusSpec::Define()
 		// Do implement test here
 		AsyncTask(ENamedThreads::AnyThread, [this, TestDone]()
 			{
-			ImplFixture->GetImplementation()->Execute_Func1(ImplFixture->GetImplementation().GetObject(), ETbEnumEnum1::TEE1_VALUE1);
+			ImplFixture->GetImplementation()->Execute_Func1(ImplFixture->GetImplementation().GetObject(), ETbEnumEnum1::TEE1_Value1);
 			TestDone.Execute();
 		});
 	});
@@ -293,7 +293,7 @@ void UTbEnumEnumInterfaceMsgBusSpec::Define()
 		// Do implement test here
 		AsyncTask(ENamedThreads::AnyThread, [this, TestDone]()
 			{
-			ImplFixture->GetImplementation()->Execute_Func2(ImplFixture->GetImplementation().GetObject(), ETbEnumEnum2::TEE2_VALUE2);
+			ImplFixture->GetImplementation()->Execute_Func2(ImplFixture->GetImplementation().GetObject(), ETbEnumEnum2::TEE2_Value2);
 			TestDone.Execute();
 		});
 	});
@@ -303,7 +303,7 @@ void UTbEnumEnumInterfaceMsgBusSpec::Define()
 		// Do implement test here
 		AsyncTask(ENamedThreads::AnyThread, [this, TestDone]()
 			{
-			ImplFixture->GetImplementation()->Execute_Func3(ImplFixture->GetImplementation().GetObject(), ETbEnumEnum3::TEE3_VALUE3);
+			ImplFixture->GetImplementation()->Execute_Func3(ImplFixture->GetImplementation().GetObject(), ETbEnumEnum3::TEE3_Value3);
 			TestDone.Execute();
 		});
 	});
@@ -315,7 +315,7 @@ void UTbEnumEnumInterfaceMsgBusSpec::Define()
 		TbEnumEnumInterfaceSignals->OnSig0Signal.AddDynamic(ImplFixture->GetHelper().Get(), &UTbEnumEnumInterfaceMsgBusHelper::Sig0SignalCb);
 
 		// use different test value
-		ETbEnumEnum0 Param0TestValue = ETbEnumEnum0::TEE0_VALUE1;
+		ETbEnumEnum0 Param0TestValue = ETbEnumEnum0::TEE0_Value1;
 		TbEnumEnumInterfaceSignals->BroadcastSig0Signal(Param0TestValue);
 	});
 
@@ -326,7 +326,7 @@ void UTbEnumEnumInterfaceMsgBusSpec::Define()
 		TbEnumEnumInterfaceSignals->OnSig1Signal.AddDynamic(ImplFixture->GetHelper().Get(), &UTbEnumEnumInterfaceMsgBusHelper::Sig1SignalCb);
 
 		// use different test value
-		ETbEnumEnum1 Param1TestValue = ETbEnumEnum1::TEE1_VALUE2;
+		ETbEnumEnum1 Param1TestValue = ETbEnumEnum1::TEE1_Value2;
 		TbEnumEnumInterfaceSignals->BroadcastSig1Signal(Param1TestValue);
 	});
 
@@ -337,7 +337,7 @@ void UTbEnumEnumInterfaceMsgBusSpec::Define()
 		TbEnumEnumInterfaceSignals->OnSig2Signal.AddDynamic(ImplFixture->GetHelper().Get(), &UTbEnumEnumInterfaceMsgBusHelper::Sig2SignalCb);
 
 		// use different test value
-		ETbEnumEnum2 Param2TestValue = ETbEnumEnum2::TEE2_VALUE1;
+		ETbEnumEnum2 Param2TestValue = ETbEnumEnum2::TEE2_Value1;
 		TbEnumEnumInterfaceSignals->BroadcastSig2Signal(Param2TestValue);
 	});
 
@@ -348,7 +348,7 @@ void UTbEnumEnumInterfaceMsgBusSpec::Define()
 		TbEnumEnumInterfaceSignals->OnSig3Signal.AddDynamic(ImplFixture->GetHelper().Get(), &UTbEnumEnumInterfaceMsgBusHelper::Sig3SignalCb);
 
 		// use different test value
-		ETbEnumEnum3 Param3TestValue = ETbEnumEnum3::TEE3_VALUE2;
+		ETbEnumEnum3 Param3TestValue = ETbEnumEnum3::TEE3_Value2;
 		TbEnumEnumInterfaceSignals->BroadcastSig3Signal(Param3TestValue);
 	});
 }

--- a/goldenmaster/Plugins/TbEnum/Source/TbEnum/Private/Tests/TbEnumEnumInterfaceMsgBusFixture.cpp
+++ b/goldenmaster/Plugins/TbEnum/Source/TbEnum/Private/Tests/TbEnumEnumInterfaceMsgBusFixture.cpp
@@ -45,9 +45,9 @@ void UTbEnumEnumInterfaceMsgBusHelper::SetTestDone(const FDoneDelegate& InDone)
 
 void UTbEnumEnumInterfaceMsgBusHelper::Prop0PropertyCb(ETbEnumEnum0 InProp0)
 {
-	ETbEnumEnum0 TestValue = ETbEnumEnum0::TEE0_VALUE0;
+	ETbEnumEnum0 TestValue = ETbEnumEnum0::TEE0_Value0;
 	// use different test value
-	TestValue = ETbEnumEnum0::TEE0_VALUE1;
+	TestValue = ETbEnumEnum0::TEE0_Value1;
 	Spec->TestEqual(TEXT("Delegate parameter should be the same value as set by the setter"), InProp0, TestValue);
 	if (TSharedPtr<FTbEnumEnumInterfaceMsgBusFixture> PinnedImplFixture = ImplFixture.Pin())
 	{
@@ -58,9 +58,9 @@ void UTbEnumEnumInterfaceMsgBusHelper::Prop0PropertyCb(ETbEnumEnum0 InProp0)
 
 void UTbEnumEnumInterfaceMsgBusHelper::Prop0PropertyChangeLocalCheckRemoteCb(ETbEnumEnum0 InProp0)
 {
-	ETbEnumEnum0 TestValue = ETbEnumEnum0::TEE0_VALUE0;
+	ETbEnumEnum0 TestValue = ETbEnumEnum0::TEE0_Value0;
 	// use different test value
-	TestValue = ETbEnumEnum0::TEE0_VALUE1;
+	TestValue = ETbEnumEnum0::TEE0_Value1;
 	Spec->TestEqual(TEXT("Delegate parameter should be the same value as set by the setter"), InProp0, TestValue);
 	if (TSharedPtr<FTbEnumEnumInterfaceMsgBusFixture> PinnedImplFixture = ImplFixture.Pin())
 	{
@@ -79,9 +79,9 @@ void UTbEnumEnumInterfaceMsgBusHelper::Prop0PropertyChangeLocalChangeRemoteCb(ET
 
 	if (count % 2 != 0)
 	{
-		ETbEnumEnum0 TestValue = ETbEnumEnum0::TEE0_VALUE0;
+		ETbEnumEnum0 TestValue = ETbEnumEnum0::TEE0_Value0;
 		// use different test value
-		TestValue = ETbEnumEnum0::TEE0_VALUE1;
+		TestValue = ETbEnumEnum0::TEE0_Value1;
 		Spec->TestEqual(TEXT("Delegate parameter should be the same value as set by the setter"), InProp0, TestValue);
 		if (TSharedPtr<FTbEnumEnumInterfaceMsgBusFixture> PinnedImplFixture = ImplFixture.Pin())
 		{
@@ -89,7 +89,7 @@ void UTbEnumEnumInterfaceMsgBusHelper::Prop0PropertyChangeLocalChangeRemoteCb(ET
 		}
 
 		// now set it to the default value
-		TestValue = ETbEnumEnum0::TEE0_VALUE0; // default value
+		TestValue = ETbEnumEnum0::TEE0_Value0; // default value
 		if (TSharedPtr<FTbEnumEnumInterfaceMsgBusFixture> PinnedImplFixture = ImplFixture.Pin())
 		{
 			PinnedImplFixture->GetImplementation()->Execute_SetProp0(PinnedImplFixture->GetImplementation().GetObject(), TestValue);
@@ -97,7 +97,7 @@ void UTbEnumEnumInterfaceMsgBusHelper::Prop0PropertyChangeLocalChangeRemoteCb(ET
 	}
 	else
 	{
-		ETbEnumEnum0 TestValue = ETbEnumEnum0::TEE0_VALUE0; // default value
+		ETbEnumEnum0 TestValue = ETbEnumEnum0::TEE0_Value0; // default value
 		Spec->TestEqual(TEXT("Delegate parameter should be the same value as set by the setter"), InProp0, TestValue);
 		if (TSharedPtr<FTbEnumEnumInterfaceMsgBusFixture> PinnedImplFixture = ImplFixture.Pin())
 		{
@@ -109,9 +109,9 @@ void UTbEnumEnumInterfaceMsgBusHelper::Prop0PropertyChangeLocalChangeRemoteCb(ET
 
 void UTbEnumEnumInterfaceMsgBusHelper::Prop1PropertyCb(ETbEnumEnum1 InProp1)
 {
-	ETbEnumEnum1 TestValue = ETbEnumEnum1::TEE1_VALUE1;
+	ETbEnumEnum1 TestValue = ETbEnumEnum1::TEE1_Value1;
 	// use different test value
-	TestValue = ETbEnumEnum1::TEE1_VALUE2;
+	TestValue = ETbEnumEnum1::TEE1_Value2;
 	Spec->TestEqual(TEXT("Delegate parameter should be the same value as set by the setter"), InProp1, TestValue);
 	if (TSharedPtr<FTbEnumEnumInterfaceMsgBusFixture> PinnedImplFixture = ImplFixture.Pin())
 	{
@@ -122,9 +122,9 @@ void UTbEnumEnumInterfaceMsgBusHelper::Prop1PropertyCb(ETbEnumEnum1 InProp1)
 
 void UTbEnumEnumInterfaceMsgBusHelper::Prop1PropertyChangeLocalCheckRemoteCb(ETbEnumEnum1 InProp1)
 {
-	ETbEnumEnum1 TestValue = ETbEnumEnum1::TEE1_VALUE1;
+	ETbEnumEnum1 TestValue = ETbEnumEnum1::TEE1_Value1;
 	// use different test value
-	TestValue = ETbEnumEnum1::TEE1_VALUE2;
+	TestValue = ETbEnumEnum1::TEE1_Value2;
 	Spec->TestEqual(TEXT("Delegate parameter should be the same value as set by the setter"), InProp1, TestValue);
 	if (TSharedPtr<FTbEnumEnumInterfaceMsgBusFixture> PinnedImplFixture = ImplFixture.Pin())
 	{
@@ -143,9 +143,9 @@ void UTbEnumEnumInterfaceMsgBusHelper::Prop1PropertyChangeLocalChangeRemoteCb(ET
 
 	if (count % 2 != 0)
 	{
-		ETbEnumEnum1 TestValue = ETbEnumEnum1::TEE1_VALUE1;
+		ETbEnumEnum1 TestValue = ETbEnumEnum1::TEE1_Value1;
 		// use different test value
-		TestValue = ETbEnumEnum1::TEE1_VALUE2;
+		TestValue = ETbEnumEnum1::TEE1_Value2;
 		Spec->TestEqual(TEXT("Delegate parameter should be the same value as set by the setter"), InProp1, TestValue);
 		if (TSharedPtr<FTbEnumEnumInterfaceMsgBusFixture> PinnedImplFixture = ImplFixture.Pin())
 		{
@@ -153,7 +153,7 @@ void UTbEnumEnumInterfaceMsgBusHelper::Prop1PropertyChangeLocalChangeRemoteCb(ET
 		}
 
 		// now set it to the default value
-		TestValue = ETbEnumEnum1::TEE1_VALUE1; // default value
+		TestValue = ETbEnumEnum1::TEE1_Value1; // default value
 		if (TSharedPtr<FTbEnumEnumInterfaceMsgBusFixture> PinnedImplFixture = ImplFixture.Pin())
 		{
 			PinnedImplFixture->GetImplementation()->Execute_SetProp1(PinnedImplFixture->GetImplementation().GetObject(), TestValue);
@@ -161,7 +161,7 @@ void UTbEnumEnumInterfaceMsgBusHelper::Prop1PropertyChangeLocalChangeRemoteCb(ET
 	}
 	else
 	{
-		ETbEnumEnum1 TestValue = ETbEnumEnum1::TEE1_VALUE1; // default value
+		ETbEnumEnum1 TestValue = ETbEnumEnum1::TEE1_Value1; // default value
 		Spec->TestEqual(TEXT("Delegate parameter should be the same value as set by the setter"), InProp1, TestValue);
 		if (TSharedPtr<FTbEnumEnumInterfaceMsgBusFixture> PinnedImplFixture = ImplFixture.Pin())
 		{
@@ -173,9 +173,9 @@ void UTbEnumEnumInterfaceMsgBusHelper::Prop1PropertyChangeLocalChangeRemoteCb(ET
 
 void UTbEnumEnumInterfaceMsgBusHelper::Prop2PropertyCb(ETbEnumEnum2 InProp2)
 {
-	ETbEnumEnum2 TestValue = ETbEnumEnum2::TEE2_VALUE2;
+	ETbEnumEnum2 TestValue = ETbEnumEnum2::TEE2_Value2;
 	// use different test value
-	TestValue = ETbEnumEnum2::TEE2_VALUE1;
+	TestValue = ETbEnumEnum2::TEE2_Value1;
 	Spec->TestEqual(TEXT("Delegate parameter should be the same value as set by the setter"), InProp2, TestValue);
 	if (TSharedPtr<FTbEnumEnumInterfaceMsgBusFixture> PinnedImplFixture = ImplFixture.Pin())
 	{
@@ -186,9 +186,9 @@ void UTbEnumEnumInterfaceMsgBusHelper::Prop2PropertyCb(ETbEnumEnum2 InProp2)
 
 void UTbEnumEnumInterfaceMsgBusHelper::Prop2PropertyChangeLocalCheckRemoteCb(ETbEnumEnum2 InProp2)
 {
-	ETbEnumEnum2 TestValue = ETbEnumEnum2::TEE2_VALUE2;
+	ETbEnumEnum2 TestValue = ETbEnumEnum2::TEE2_Value2;
 	// use different test value
-	TestValue = ETbEnumEnum2::TEE2_VALUE1;
+	TestValue = ETbEnumEnum2::TEE2_Value1;
 	Spec->TestEqual(TEXT("Delegate parameter should be the same value as set by the setter"), InProp2, TestValue);
 	if (TSharedPtr<FTbEnumEnumInterfaceMsgBusFixture> PinnedImplFixture = ImplFixture.Pin())
 	{
@@ -207,9 +207,9 @@ void UTbEnumEnumInterfaceMsgBusHelper::Prop2PropertyChangeLocalChangeRemoteCb(ET
 
 	if (count % 2 != 0)
 	{
-		ETbEnumEnum2 TestValue = ETbEnumEnum2::TEE2_VALUE2;
+		ETbEnumEnum2 TestValue = ETbEnumEnum2::TEE2_Value2;
 		// use different test value
-		TestValue = ETbEnumEnum2::TEE2_VALUE1;
+		TestValue = ETbEnumEnum2::TEE2_Value1;
 		Spec->TestEqual(TEXT("Delegate parameter should be the same value as set by the setter"), InProp2, TestValue);
 		if (TSharedPtr<FTbEnumEnumInterfaceMsgBusFixture> PinnedImplFixture = ImplFixture.Pin())
 		{
@@ -217,7 +217,7 @@ void UTbEnumEnumInterfaceMsgBusHelper::Prop2PropertyChangeLocalChangeRemoteCb(ET
 		}
 
 		// now set it to the default value
-		TestValue = ETbEnumEnum2::TEE2_VALUE2; // default value
+		TestValue = ETbEnumEnum2::TEE2_Value2; // default value
 		if (TSharedPtr<FTbEnumEnumInterfaceMsgBusFixture> PinnedImplFixture = ImplFixture.Pin())
 		{
 			PinnedImplFixture->GetImplementation()->Execute_SetProp2(PinnedImplFixture->GetImplementation().GetObject(), TestValue);
@@ -225,7 +225,7 @@ void UTbEnumEnumInterfaceMsgBusHelper::Prop2PropertyChangeLocalChangeRemoteCb(ET
 	}
 	else
 	{
-		ETbEnumEnum2 TestValue = ETbEnumEnum2::TEE2_VALUE2; // default value
+		ETbEnumEnum2 TestValue = ETbEnumEnum2::TEE2_Value2; // default value
 		Spec->TestEqual(TEXT("Delegate parameter should be the same value as set by the setter"), InProp2, TestValue);
 		if (TSharedPtr<FTbEnumEnumInterfaceMsgBusFixture> PinnedImplFixture = ImplFixture.Pin())
 		{
@@ -237,9 +237,9 @@ void UTbEnumEnumInterfaceMsgBusHelper::Prop2PropertyChangeLocalChangeRemoteCb(ET
 
 void UTbEnumEnumInterfaceMsgBusHelper::Prop3PropertyCb(ETbEnumEnum3 InProp3)
 {
-	ETbEnumEnum3 TestValue = ETbEnumEnum3::TEE3_VALUE3;
+	ETbEnumEnum3 TestValue = ETbEnumEnum3::TEE3_Value3;
 	// use different test value
-	TestValue = ETbEnumEnum3::TEE3_VALUE2;
+	TestValue = ETbEnumEnum3::TEE3_Value2;
 	Spec->TestEqual(TEXT("Delegate parameter should be the same value as set by the setter"), InProp3, TestValue);
 	if (TSharedPtr<FTbEnumEnumInterfaceMsgBusFixture> PinnedImplFixture = ImplFixture.Pin())
 	{
@@ -250,9 +250,9 @@ void UTbEnumEnumInterfaceMsgBusHelper::Prop3PropertyCb(ETbEnumEnum3 InProp3)
 
 void UTbEnumEnumInterfaceMsgBusHelper::Prop3PropertyChangeLocalCheckRemoteCb(ETbEnumEnum3 InProp3)
 {
-	ETbEnumEnum3 TestValue = ETbEnumEnum3::TEE3_VALUE3;
+	ETbEnumEnum3 TestValue = ETbEnumEnum3::TEE3_Value3;
 	// use different test value
-	TestValue = ETbEnumEnum3::TEE3_VALUE2;
+	TestValue = ETbEnumEnum3::TEE3_Value2;
 	Spec->TestEqual(TEXT("Delegate parameter should be the same value as set by the setter"), InProp3, TestValue);
 	if (TSharedPtr<FTbEnumEnumInterfaceMsgBusFixture> PinnedImplFixture = ImplFixture.Pin())
 	{
@@ -271,9 +271,9 @@ void UTbEnumEnumInterfaceMsgBusHelper::Prop3PropertyChangeLocalChangeRemoteCb(ET
 
 	if (count % 2 != 0)
 	{
-		ETbEnumEnum3 TestValue = ETbEnumEnum3::TEE3_VALUE3;
+		ETbEnumEnum3 TestValue = ETbEnumEnum3::TEE3_Value3;
 		// use different test value
-		TestValue = ETbEnumEnum3::TEE3_VALUE2;
+		TestValue = ETbEnumEnum3::TEE3_Value2;
 		Spec->TestEqual(TEXT("Delegate parameter should be the same value as set by the setter"), InProp3, TestValue);
 		if (TSharedPtr<FTbEnumEnumInterfaceMsgBusFixture> PinnedImplFixture = ImplFixture.Pin())
 		{
@@ -281,7 +281,7 @@ void UTbEnumEnumInterfaceMsgBusHelper::Prop3PropertyChangeLocalChangeRemoteCb(ET
 		}
 
 		// now set it to the default value
-		TestValue = ETbEnumEnum3::TEE3_VALUE3; // default value
+		TestValue = ETbEnumEnum3::TEE3_Value3; // default value
 		if (TSharedPtr<FTbEnumEnumInterfaceMsgBusFixture> PinnedImplFixture = ImplFixture.Pin())
 		{
 			PinnedImplFixture->GetImplementation()->Execute_SetProp3(PinnedImplFixture->GetImplementation().GetObject(), TestValue);
@@ -289,7 +289,7 @@ void UTbEnumEnumInterfaceMsgBusHelper::Prop3PropertyChangeLocalChangeRemoteCb(ET
 	}
 	else
 	{
-		ETbEnumEnum3 TestValue = ETbEnumEnum3::TEE3_VALUE3; // default value
+		ETbEnumEnum3 TestValue = ETbEnumEnum3::TEE3_Value3; // default value
 		Spec->TestEqual(TEXT("Delegate parameter should be the same value as set by the setter"), InProp3, TestValue);
 		if (TSharedPtr<FTbEnumEnumInterfaceMsgBusFixture> PinnedImplFixture = ImplFixture.Pin())
 		{
@@ -302,7 +302,7 @@ void UTbEnumEnumInterfaceMsgBusHelper::Prop3PropertyChangeLocalChangeRemoteCb(ET
 void UTbEnumEnumInterfaceMsgBusHelper::Sig0SignalCb(ETbEnumEnum0 InParam0)
 {
 	// known test value
-	ETbEnumEnum0 Param0TestValue = ETbEnumEnum0::TEE0_VALUE1;
+	ETbEnumEnum0 Param0TestValue = ETbEnumEnum0::TEE0_Value1;
 	Spec->TestEqual(TEXT("Parameter should be the same value as sent by the signal"), InParam0, Param0TestValue);
 	testDoneDelegate.Execute();
 }
@@ -310,7 +310,7 @@ void UTbEnumEnumInterfaceMsgBusHelper::Sig0SignalCb(ETbEnumEnum0 InParam0)
 void UTbEnumEnumInterfaceMsgBusHelper::Sig1SignalCb(ETbEnumEnum1 InParam1)
 {
 	// known test value
-	ETbEnumEnum1 Param1TestValue = ETbEnumEnum1::TEE1_VALUE2;
+	ETbEnumEnum1 Param1TestValue = ETbEnumEnum1::TEE1_Value2;
 	Spec->TestEqual(TEXT("Parameter should be the same value as sent by the signal"), InParam1, Param1TestValue);
 	testDoneDelegate.Execute();
 }
@@ -318,7 +318,7 @@ void UTbEnumEnumInterfaceMsgBusHelper::Sig1SignalCb(ETbEnumEnum1 InParam1)
 void UTbEnumEnumInterfaceMsgBusHelper::Sig2SignalCb(ETbEnumEnum2 InParam2)
 {
 	// known test value
-	ETbEnumEnum2 Param2TestValue = ETbEnumEnum2::TEE2_VALUE1;
+	ETbEnumEnum2 Param2TestValue = ETbEnumEnum2::TEE2_Value1;
 	Spec->TestEqual(TEXT("Parameter should be the same value as sent by the signal"), InParam2, Param2TestValue);
 	testDoneDelegate.Execute();
 }
@@ -326,7 +326,7 @@ void UTbEnumEnumInterfaceMsgBusHelper::Sig2SignalCb(ETbEnumEnum2 InParam2)
 void UTbEnumEnumInterfaceMsgBusHelper::Sig3SignalCb(ETbEnumEnum3 InParam3)
 {
 	// known test value
-	ETbEnumEnum3 Param3TestValue = ETbEnumEnum3::TEE3_VALUE2;
+	ETbEnumEnum3 Param3TestValue = ETbEnumEnum3::TEE3_Value2;
 	Spec->TestEqual(TEXT("Parameter should be the same value as sent by the signal"), InParam3, Param3TestValue);
 	testDoneDelegate.Execute();
 }

--- a/goldenmaster/Plugins/TbEnum/Source/TbEnum/Private/Tests/TbEnumEnumInterfaceOLink.spec.cpp
+++ b/goldenmaster/Plugins/TbEnum/Source/TbEnum/Private/Tests/TbEnumEnumInterfaceOLink.spec.cpp
@@ -85,35 +85,35 @@ void UTbEnumEnumInterfaceOLinkSpec::Define()
 	It("Property.Prop0.Default", [this]()
 		{
 		// Do implement test here
-		ETbEnumEnum0 TestValue = ETbEnumEnum0::TEE0_VALUE0; // default value
+		ETbEnumEnum0 TestValue = ETbEnumEnum0::TEE0_Value0; // default value
 		TestEqual(TEXT("Getter should return the default value"), ImplFixture->GetImplementation()->Execute_GetProp0(ImplFixture->GetImplementation().GetObject()), TestValue);
 	});
 
 	LatentIt("Property.Prop0.Change", EAsyncExecution::ThreadPool, [this](const FDoneDelegate TestDone)
 		{
 		// Do implement test here
-		ETbEnumEnum0 TestValue = ETbEnumEnum0::TEE0_VALUE0; // default value
+		ETbEnumEnum0 TestValue = ETbEnumEnum0::TEE0_Value0; // default value
 		TestEqual(TEXT("Getter should return the default value"), ImplFixture->GetImplementation()->Execute_GetProp0(ImplFixture->GetImplementation().GetObject()), TestValue);
 
 		ImplFixture->GetHelper()->SetTestDone(TestDone);
 		UTbEnumEnumInterfaceSignals* TbEnumEnumInterfaceSignals = ImplFixture->GetImplementation()->Execute__GetSignals(ImplFixture->GetImplementation().GetObject());
 		TbEnumEnumInterfaceSignals->OnProp0Changed.AddDynamic(ImplFixture->GetHelper().Get(), &UTbEnumEnumInterfaceOLinkHelper::Prop0PropertyCb);
 		// use different test value
-		TestValue = ETbEnumEnum0::TEE0_VALUE1;
+		TestValue = ETbEnumEnum0::TEE0_Value1;
 		ImplFixture->GetImplementation()->Execute_SetProp0(ImplFixture->GetImplementation().GetObject(), TestValue);
 	});
 
 	LatentIt("Property.Prop0.ChangeLocalCheckRemote", EAsyncExecution::ThreadPool, [this](const FDoneDelegate TestDone)
 		{
 		// Do implement test here
-		ETbEnumEnum0 TestValue = ETbEnumEnum0::TEE0_VALUE0; // default value
+		ETbEnumEnum0 TestValue = ETbEnumEnum0::TEE0_Value0; // default value
 		TestEqual(TEXT("Getter should return the default value"), ImplFixture->GetImplementation()->Execute_GetProp0(ImplFixture->GetImplementation().GetObject()), TestValue);
 
 		ImplFixture->GetHelper()->SetTestDone(TestDone);
 		UTbEnumEnumInterfaceSignals* TbEnumEnumInterfaceSignals = ImplFixture->GetImplementation()->Execute__GetSignals(ImplFixture->GetImplementation().GetObject());
 		TbEnumEnumInterfaceSignals->OnProp0Changed.AddDynamic(ImplFixture->GetHelper().Get(), &UTbEnumEnumInterfaceOLinkHelper::Prop0PropertyChangeLocalCheckRemoteCb);
 		// use different test value
-		TestValue = ETbEnumEnum0::TEE0_VALUE1;
+		TestValue = ETbEnumEnum0::TEE0_Value1;
 		auto service = ImplFixture->GetGameInstance()->GetSubsystem<UTbEnumEnumInterface>();
 		service->Execute_SetProp0(service, TestValue);
 	});
@@ -121,14 +121,14 @@ void UTbEnumEnumInterfaceOLinkSpec::Define()
 	LatentIt("Property.Prop0.ChangeLocalChangeBackRemote", EAsyncExecution::ThreadPool, [this](const FDoneDelegate TestDone)
 		{
 		// Do implement test here
-		ETbEnumEnum0 TestValue = ETbEnumEnum0::TEE0_VALUE0; // default value
+		ETbEnumEnum0 TestValue = ETbEnumEnum0::TEE0_Value0; // default value
 		TestEqual(TEXT("Getter should return the default value"), ImplFixture->GetImplementation()->Execute_GetProp0(ImplFixture->GetImplementation().GetObject()), TestValue);
 
 		ImplFixture->GetHelper()->SetTestDone(TestDone);
 		UTbEnumEnumInterfaceSignals* TbEnumEnumInterfaceSignals = ImplFixture->GetImplementation()->Execute__GetSignals(ImplFixture->GetImplementation().GetObject());
 		TbEnumEnumInterfaceSignals->OnProp0Changed.AddDynamic(ImplFixture->GetHelper().Get(), &UTbEnumEnumInterfaceOLinkHelper::Prop0PropertyChangeLocalChangeRemoteCb);
 		// use different test value
-		TestValue = ETbEnumEnum0::TEE0_VALUE1;
+		TestValue = ETbEnumEnum0::TEE0_Value1;
 		auto service = ImplFixture->GetGameInstance()->GetSubsystem<UTbEnumEnumInterface>();
 		service->Execute_SetProp0(service, TestValue);
 	});
@@ -136,35 +136,35 @@ void UTbEnumEnumInterfaceOLinkSpec::Define()
 	It("Property.Prop1.Default", [this]()
 		{
 		// Do implement test here
-		ETbEnumEnum1 TestValue = ETbEnumEnum1::TEE1_VALUE1; // default value
+		ETbEnumEnum1 TestValue = ETbEnumEnum1::TEE1_Value1; // default value
 		TestEqual(TEXT("Getter should return the default value"), ImplFixture->GetImplementation()->Execute_GetProp1(ImplFixture->GetImplementation().GetObject()), TestValue);
 	});
 
 	LatentIt("Property.Prop1.Change", EAsyncExecution::ThreadPool, [this](const FDoneDelegate TestDone)
 		{
 		// Do implement test here
-		ETbEnumEnum1 TestValue = ETbEnumEnum1::TEE1_VALUE1; // default value
+		ETbEnumEnum1 TestValue = ETbEnumEnum1::TEE1_Value1; // default value
 		TestEqual(TEXT("Getter should return the default value"), ImplFixture->GetImplementation()->Execute_GetProp1(ImplFixture->GetImplementation().GetObject()), TestValue);
 
 		ImplFixture->GetHelper()->SetTestDone(TestDone);
 		UTbEnumEnumInterfaceSignals* TbEnumEnumInterfaceSignals = ImplFixture->GetImplementation()->Execute__GetSignals(ImplFixture->GetImplementation().GetObject());
 		TbEnumEnumInterfaceSignals->OnProp1Changed.AddDynamic(ImplFixture->GetHelper().Get(), &UTbEnumEnumInterfaceOLinkHelper::Prop1PropertyCb);
 		// use different test value
-		TestValue = ETbEnumEnum1::TEE1_VALUE2;
+		TestValue = ETbEnumEnum1::TEE1_Value2;
 		ImplFixture->GetImplementation()->Execute_SetProp1(ImplFixture->GetImplementation().GetObject(), TestValue);
 	});
 
 	LatentIt("Property.Prop1.ChangeLocalCheckRemote", EAsyncExecution::ThreadPool, [this](const FDoneDelegate TestDone)
 		{
 		// Do implement test here
-		ETbEnumEnum1 TestValue = ETbEnumEnum1::TEE1_VALUE1; // default value
+		ETbEnumEnum1 TestValue = ETbEnumEnum1::TEE1_Value1; // default value
 		TestEqual(TEXT("Getter should return the default value"), ImplFixture->GetImplementation()->Execute_GetProp1(ImplFixture->GetImplementation().GetObject()), TestValue);
 
 		ImplFixture->GetHelper()->SetTestDone(TestDone);
 		UTbEnumEnumInterfaceSignals* TbEnumEnumInterfaceSignals = ImplFixture->GetImplementation()->Execute__GetSignals(ImplFixture->GetImplementation().GetObject());
 		TbEnumEnumInterfaceSignals->OnProp1Changed.AddDynamic(ImplFixture->GetHelper().Get(), &UTbEnumEnumInterfaceOLinkHelper::Prop1PropertyChangeLocalCheckRemoteCb);
 		// use different test value
-		TestValue = ETbEnumEnum1::TEE1_VALUE2;
+		TestValue = ETbEnumEnum1::TEE1_Value2;
 		auto service = ImplFixture->GetGameInstance()->GetSubsystem<UTbEnumEnumInterface>();
 		service->Execute_SetProp1(service, TestValue);
 	});
@@ -172,14 +172,14 @@ void UTbEnumEnumInterfaceOLinkSpec::Define()
 	LatentIt("Property.Prop1.ChangeLocalChangeBackRemote", EAsyncExecution::ThreadPool, [this](const FDoneDelegate TestDone)
 		{
 		// Do implement test here
-		ETbEnumEnum1 TestValue = ETbEnumEnum1::TEE1_VALUE1; // default value
+		ETbEnumEnum1 TestValue = ETbEnumEnum1::TEE1_Value1; // default value
 		TestEqual(TEXT("Getter should return the default value"), ImplFixture->GetImplementation()->Execute_GetProp1(ImplFixture->GetImplementation().GetObject()), TestValue);
 
 		ImplFixture->GetHelper()->SetTestDone(TestDone);
 		UTbEnumEnumInterfaceSignals* TbEnumEnumInterfaceSignals = ImplFixture->GetImplementation()->Execute__GetSignals(ImplFixture->GetImplementation().GetObject());
 		TbEnumEnumInterfaceSignals->OnProp1Changed.AddDynamic(ImplFixture->GetHelper().Get(), &UTbEnumEnumInterfaceOLinkHelper::Prop1PropertyChangeLocalChangeRemoteCb);
 		// use different test value
-		TestValue = ETbEnumEnum1::TEE1_VALUE2;
+		TestValue = ETbEnumEnum1::TEE1_Value2;
 		auto service = ImplFixture->GetGameInstance()->GetSubsystem<UTbEnumEnumInterface>();
 		service->Execute_SetProp1(service, TestValue);
 	});
@@ -187,35 +187,35 @@ void UTbEnumEnumInterfaceOLinkSpec::Define()
 	It("Property.Prop2.Default", [this]()
 		{
 		// Do implement test here
-		ETbEnumEnum2 TestValue = ETbEnumEnum2::TEE2_VALUE2; // default value
+		ETbEnumEnum2 TestValue = ETbEnumEnum2::TEE2_Value2; // default value
 		TestEqual(TEXT("Getter should return the default value"), ImplFixture->GetImplementation()->Execute_GetProp2(ImplFixture->GetImplementation().GetObject()), TestValue);
 	});
 
 	LatentIt("Property.Prop2.Change", EAsyncExecution::ThreadPool, [this](const FDoneDelegate TestDone)
 		{
 		// Do implement test here
-		ETbEnumEnum2 TestValue = ETbEnumEnum2::TEE2_VALUE2; // default value
+		ETbEnumEnum2 TestValue = ETbEnumEnum2::TEE2_Value2; // default value
 		TestEqual(TEXT("Getter should return the default value"), ImplFixture->GetImplementation()->Execute_GetProp2(ImplFixture->GetImplementation().GetObject()), TestValue);
 
 		ImplFixture->GetHelper()->SetTestDone(TestDone);
 		UTbEnumEnumInterfaceSignals* TbEnumEnumInterfaceSignals = ImplFixture->GetImplementation()->Execute__GetSignals(ImplFixture->GetImplementation().GetObject());
 		TbEnumEnumInterfaceSignals->OnProp2Changed.AddDynamic(ImplFixture->GetHelper().Get(), &UTbEnumEnumInterfaceOLinkHelper::Prop2PropertyCb);
 		// use different test value
-		TestValue = ETbEnumEnum2::TEE2_VALUE1;
+		TestValue = ETbEnumEnum2::TEE2_Value1;
 		ImplFixture->GetImplementation()->Execute_SetProp2(ImplFixture->GetImplementation().GetObject(), TestValue);
 	});
 
 	LatentIt("Property.Prop2.ChangeLocalCheckRemote", EAsyncExecution::ThreadPool, [this](const FDoneDelegate TestDone)
 		{
 		// Do implement test here
-		ETbEnumEnum2 TestValue = ETbEnumEnum2::TEE2_VALUE2; // default value
+		ETbEnumEnum2 TestValue = ETbEnumEnum2::TEE2_Value2; // default value
 		TestEqual(TEXT("Getter should return the default value"), ImplFixture->GetImplementation()->Execute_GetProp2(ImplFixture->GetImplementation().GetObject()), TestValue);
 
 		ImplFixture->GetHelper()->SetTestDone(TestDone);
 		UTbEnumEnumInterfaceSignals* TbEnumEnumInterfaceSignals = ImplFixture->GetImplementation()->Execute__GetSignals(ImplFixture->GetImplementation().GetObject());
 		TbEnumEnumInterfaceSignals->OnProp2Changed.AddDynamic(ImplFixture->GetHelper().Get(), &UTbEnumEnumInterfaceOLinkHelper::Prop2PropertyChangeLocalCheckRemoteCb);
 		// use different test value
-		TestValue = ETbEnumEnum2::TEE2_VALUE1;
+		TestValue = ETbEnumEnum2::TEE2_Value1;
 		auto service = ImplFixture->GetGameInstance()->GetSubsystem<UTbEnumEnumInterface>();
 		service->Execute_SetProp2(service, TestValue);
 	});
@@ -223,14 +223,14 @@ void UTbEnumEnumInterfaceOLinkSpec::Define()
 	LatentIt("Property.Prop2.ChangeLocalChangeBackRemote", EAsyncExecution::ThreadPool, [this](const FDoneDelegate TestDone)
 		{
 		// Do implement test here
-		ETbEnumEnum2 TestValue = ETbEnumEnum2::TEE2_VALUE2; // default value
+		ETbEnumEnum2 TestValue = ETbEnumEnum2::TEE2_Value2; // default value
 		TestEqual(TEXT("Getter should return the default value"), ImplFixture->GetImplementation()->Execute_GetProp2(ImplFixture->GetImplementation().GetObject()), TestValue);
 
 		ImplFixture->GetHelper()->SetTestDone(TestDone);
 		UTbEnumEnumInterfaceSignals* TbEnumEnumInterfaceSignals = ImplFixture->GetImplementation()->Execute__GetSignals(ImplFixture->GetImplementation().GetObject());
 		TbEnumEnumInterfaceSignals->OnProp2Changed.AddDynamic(ImplFixture->GetHelper().Get(), &UTbEnumEnumInterfaceOLinkHelper::Prop2PropertyChangeLocalChangeRemoteCb);
 		// use different test value
-		TestValue = ETbEnumEnum2::TEE2_VALUE1;
+		TestValue = ETbEnumEnum2::TEE2_Value1;
 		auto service = ImplFixture->GetGameInstance()->GetSubsystem<UTbEnumEnumInterface>();
 		service->Execute_SetProp2(service, TestValue);
 	});
@@ -238,35 +238,35 @@ void UTbEnumEnumInterfaceOLinkSpec::Define()
 	It("Property.Prop3.Default", [this]()
 		{
 		// Do implement test here
-		ETbEnumEnum3 TestValue = ETbEnumEnum3::TEE3_VALUE3; // default value
+		ETbEnumEnum3 TestValue = ETbEnumEnum3::TEE3_Value3; // default value
 		TestEqual(TEXT("Getter should return the default value"), ImplFixture->GetImplementation()->Execute_GetProp3(ImplFixture->GetImplementation().GetObject()), TestValue);
 	});
 
 	LatentIt("Property.Prop3.Change", EAsyncExecution::ThreadPool, [this](const FDoneDelegate TestDone)
 		{
 		// Do implement test here
-		ETbEnumEnum3 TestValue = ETbEnumEnum3::TEE3_VALUE3; // default value
+		ETbEnumEnum3 TestValue = ETbEnumEnum3::TEE3_Value3; // default value
 		TestEqual(TEXT("Getter should return the default value"), ImplFixture->GetImplementation()->Execute_GetProp3(ImplFixture->GetImplementation().GetObject()), TestValue);
 
 		ImplFixture->GetHelper()->SetTestDone(TestDone);
 		UTbEnumEnumInterfaceSignals* TbEnumEnumInterfaceSignals = ImplFixture->GetImplementation()->Execute__GetSignals(ImplFixture->GetImplementation().GetObject());
 		TbEnumEnumInterfaceSignals->OnProp3Changed.AddDynamic(ImplFixture->GetHelper().Get(), &UTbEnumEnumInterfaceOLinkHelper::Prop3PropertyCb);
 		// use different test value
-		TestValue = ETbEnumEnum3::TEE3_VALUE2;
+		TestValue = ETbEnumEnum3::TEE3_Value2;
 		ImplFixture->GetImplementation()->Execute_SetProp3(ImplFixture->GetImplementation().GetObject(), TestValue);
 	});
 
 	LatentIt("Property.Prop3.ChangeLocalCheckRemote", EAsyncExecution::ThreadPool, [this](const FDoneDelegate TestDone)
 		{
 		// Do implement test here
-		ETbEnumEnum3 TestValue = ETbEnumEnum3::TEE3_VALUE3; // default value
+		ETbEnumEnum3 TestValue = ETbEnumEnum3::TEE3_Value3; // default value
 		TestEqual(TEXT("Getter should return the default value"), ImplFixture->GetImplementation()->Execute_GetProp3(ImplFixture->GetImplementation().GetObject()), TestValue);
 
 		ImplFixture->GetHelper()->SetTestDone(TestDone);
 		UTbEnumEnumInterfaceSignals* TbEnumEnumInterfaceSignals = ImplFixture->GetImplementation()->Execute__GetSignals(ImplFixture->GetImplementation().GetObject());
 		TbEnumEnumInterfaceSignals->OnProp3Changed.AddDynamic(ImplFixture->GetHelper().Get(), &UTbEnumEnumInterfaceOLinkHelper::Prop3PropertyChangeLocalCheckRemoteCb);
 		// use different test value
-		TestValue = ETbEnumEnum3::TEE3_VALUE2;
+		TestValue = ETbEnumEnum3::TEE3_Value2;
 		auto service = ImplFixture->GetGameInstance()->GetSubsystem<UTbEnumEnumInterface>();
 		service->Execute_SetProp3(service, TestValue);
 	});
@@ -274,14 +274,14 @@ void UTbEnumEnumInterfaceOLinkSpec::Define()
 	LatentIt("Property.Prop3.ChangeLocalChangeBackRemote", EAsyncExecution::ThreadPool, [this](const FDoneDelegate TestDone)
 		{
 		// Do implement test here
-		ETbEnumEnum3 TestValue = ETbEnumEnum3::TEE3_VALUE3; // default value
+		ETbEnumEnum3 TestValue = ETbEnumEnum3::TEE3_Value3; // default value
 		TestEqual(TEXT("Getter should return the default value"), ImplFixture->GetImplementation()->Execute_GetProp3(ImplFixture->GetImplementation().GetObject()), TestValue);
 
 		ImplFixture->GetHelper()->SetTestDone(TestDone);
 		UTbEnumEnumInterfaceSignals* TbEnumEnumInterfaceSignals = ImplFixture->GetImplementation()->Execute__GetSignals(ImplFixture->GetImplementation().GetObject());
 		TbEnumEnumInterfaceSignals->OnProp3Changed.AddDynamic(ImplFixture->GetHelper().Get(), &UTbEnumEnumInterfaceOLinkHelper::Prop3PropertyChangeLocalChangeRemoteCb);
 		// use different test value
-		TestValue = ETbEnumEnum3::TEE3_VALUE2;
+		TestValue = ETbEnumEnum3::TEE3_Value2;
 		auto service = ImplFixture->GetGameInstance()->GetSubsystem<UTbEnumEnumInterface>();
 		service->Execute_SetProp3(service, TestValue);
 	});
@@ -291,7 +291,7 @@ void UTbEnumEnumInterfaceOLinkSpec::Define()
 		// Do implement test here
 		AsyncTask(ENamedThreads::AnyThread, [this, TestDone]()
 			{
-			ImplFixture->GetImplementation()->Execute_Func0(ImplFixture->GetImplementation().GetObject(), ETbEnumEnum0::TEE0_VALUE0);
+			ImplFixture->GetImplementation()->Execute_Func0(ImplFixture->GetImplementation().GetObject(), ETbEnumEnum0::TEE0_Value0);
 			TestDone.Execute();
 		});
 	});
@@ -301,7 +301,7 @@ void UTbEnumEnumInterfaceOLinkSpec::Define()
 		// Do implement test here
 		AsyncTask(ENamedThreads::AnyThread, [this, TestDone]()
 			{
-			ImplFixture->GetImplementation()->Execute_Func1(ImplFixture->GetImplementation().GetObject(), ETbEnumEnum1::TEE1_VALUE1);
+			ImplFixture->GetImplementation()->Execute_Func1(ImplFixture->GetImplementation().GetObject(), ETbEnumEnum1::TEE1_Value1);
 			TestDone.Execute();
 		});
 	});
@@ -311,7 +311,7 @@ void UTbEnumEnumInterfaceOLinkSpec::Define()
 		// Do implement test here
 		AsyncTask(ENamedThreads::AnyThread, [this, TestDone]()
 			{
-			ImplFixture->GetImplementation()->Execute_Func2(ImplFixture->GetImplementation().GetObject(), ETbEnumEnum2::TEE2_VALUE2);
+			ImplFixture->GetImplementation()->Execute_Func2(ImplFixture->GetImplementation().GetObject(), ETbEnumEnum2::TEE2_Value2);
 			TestDone.Execute();
 		});
 	});
@@ -321,7 +321,7 @@ void UTbEnumEnumInterfaceOLinkSpec::Define()
 		// Do implement test here
 		AsyncTask(ENamedThreads::AnyThread, [this, TestDone]()
 			{
-			ImplFixture->GetImplementation()->Execute_Func3(ImplFixture->GetImplementation().GetObject(), ETbEnumEnum3::TEE3_VALUE3);
+			ImplFixture->GetImplementation()->Execute_Func3(ImplFixture->GetImplementation().GetObject(), ETbEnumEnum3::TEE3_Value3);
 			TestDone.Execute();
 		});
 	});
@@ -333,7 +333,7 @@ void UTbEnumEnumInterfaceOLinkSpec::Define()
 		TbEnumEnumInterfaceSignals->OnSig0Signal.AddDynamic(ImplFixture->GetHelper().Get(), &UTbEnumEnumInterfaceOLinkHelper::Sig0SignalCb);
 
 		// use different test value
-		ETbEnumEnum0 Param0TestValue = ETbEnumEnum0::TEE0_VALUE1;
+		ETbEnumEnum0 Param0TestValue = ETbEnumEnum0::TEE0_Value1;
 		TbEnumEnumInterfaceSignals->BroadcastSig0Signal(Param0TestValue);
 	});
 
@@ -344,7 +344,7 @@ void UTbEnumEnumInterfaceOLinkSpec::Define()
 		TbEnumEnumInterfaceSignals->OnSig1Signal.AddDynamic(ImplFixture->GetHelper().Get(), &UTbEnumEnumInterfaceOLinkHelper::Sig1SignalCb);
 
 		// use different test value
-		ETbEnumEnum1 Param1TestValue = ETbEnumEnum1::TEE1_VALUE2;
+		ETbEnumEnum1 Param1TestValue = ETbEnumEnum1::TEE1_Value2;
 		TbEnumEnumInterfaceSignals->BroadcastSig1Signal(Param1TestValue);
 	});
 
@@ -355,7 +355,7 @@ void UTbEnumEnumInterfaceOLinkSpec::Define()
 		TbEnumEnumInterfaceSignals->OnSig2Signal.AddDynamic(ImplFixture->GetHelper().Get(), &UTbEnumEnumInterfaceOLinkHelper::Sig2SignalCb);
 
 		// use different test value
-		ETbEnumEnum2 Param2TestValue = ETbEnumEnum2::TEE2_VALUE1;
+		ETbEnumEnum2 Param2TestValue = ETbEnumEnum2::TEE2_Value1;
 		TbEnumEnumInterfaceSignals->BroadcastSig2Signal(Param2TestValue);
 	});
 
@@ -366,7 +366,7 @@ void UTbEnumEnumInterfaceOLinkSpec::Define()
 		TbEnumEnumInterfaceSignals->OnSig3Signal.AddDynamic(ImplFixture->GetHelper().Get(), &UTbEnumEnumInterfaceOLinkHelper::Sig3SignalCb);
 
 		// use different test value
-		ETbEnumEnum3 Param3TestValue = ETbEnumEnum3::TEE3_VALUE2;
+		ETbEnumEnum3 Param3TestValue = ETbEnumEnum3::TEE3_Value2;
 		TbEnumEnumInterfaceSignals->BroadcastSig3Signal(Param3TestValue);
 	});
 }

--- a/goldenmaster/Plugins/TbEnum/Source/TbEnum/Private/Tests/TbEnumEnumInterfaceOLinkFixture.cpp
+++ b/goldenmaster/Plugins/TbEnum/Source/TbEnum/Private/Tests/TbEnumEnumInterfaceOLinkFixture.cpp
@@ -42,9 +42,9 @@ void UTbEnumEnumInterfaceOLinkHelper::SetTestDone(const FDoneDelegate& InDone)
 
 void UTbEnumEnumInterfaceOLinkHelper::Prop0PropertyCb(ETbEnumEnum0 InProp0)
 {
-	ETbEnumEnum0 TestValue = ETbEnumEnum0::TEE0_VALUE0;
+	ETbEnumEnum0 TestValue = ETbEnumEnum0::TEE0_Value0;
 	// use different test value
-	TestValue = ETbEnumEnum0::TEE0_VALUE1;
+	TestValue = ETbEnumEnum0::TEE0_Value1;
 	Spec->TestEqual(TEXT("Delegate parameter should be the same value as set by the setter"), InProp0, TestValue);
 	if (TSharedPtr<FTbEnumEnumInterfaceOLinkFixture> PinnedImplFixture = ImplFixture.Pin())
 	{
@@ -55,9 +55,9 @@ void UTbEnumEnumInterfaceOLinkHelper::Prop0PropertyCb(ETbEnumEnum0 InProp0)
 
 void UTbEnumEnumInterfaceOLinkHelper::Prop0PropertyChangeLocalCheckRemoteCb(ETbEnumEnum0 InProp0)
 {
-	ETbEnumEnum0 TestValue = ETbEnumEnum0::TEE0_VALUE0;
+	ETbEnumEnum0 TestValue = ETbEnumEnum0::TEE0_Value0;
 	// use different test value
-	TestValue = ETbEnumEnum0::TEE0_VALUE1;
+	TestValue = ETbEnumEnum0::TEE0_Value1;
 	Spec->TestEqual(TEXT("Delegate parameter should be the same value as set by the setter"), InProp0, TestValue);
 	if (TSharedPtr<FTbEnumEnumInterfaceOLinkFixture> PinnedImplFixture = ImplFixture.Pin())
 	{
@@ -76,9 +76,9 @@ void UTbEnumEnumInterfaceOLinkHelper::Prop0PropertyChangeLocalChangeRemoteCb(ETb
 
 	if (count % 2 != 0)
 	{
-		ETbEnumEnum0 TestValue = ETbEnumEnum0::TEE0_VALUE0;
+		ETbEnumEnum0 TestValue = ETbEnumEnum0::TEE0_Value0;
 		// use different test value
-		TestValue = ETbEnumEnum0::TEE0_VALUE1;
+		TestValue = ETbEnumEnum0::TEE0_Value1;
 		Spec->TestEqual(TEXT("Delegate parameter should be the same value as set by the setter"), InProp0, TestValue);
 		if (TSharedPtr<FTbEnumEnumInterfaceOLinkFixture> PinnedImplFixture = ImplFixture.Pin())
 		{
@@ -86,7 +86,7 @@ void UTbEnumEnumInterfaceOLinkHelper::Prop0PropertyChangeLocalChangeRemoteCb(ETb
 		}
 
 		// now set it to the default value
-		TestValue = ETbEnumEnum0::TEE0_VALUE0; // default value
+		TestValue = ETbEnumEnum0::TEE0_Value0; // default value
 		if (TSharedPtr<FTbEnumEnumInterfaceOLinkFixture> PinnedImplFixture = ImplFixture.Pin())
 		{
 			PinnedImplFixture->GetImplementation()->Execute_SetProp0(PinnedImplFixture->GetImplementation().GetObject(), TestValue);
@@ -94,7 +94,7 @@ void UTbEnumEnumInterfaceOLinkHelper::Prop0PropertyChangeLocalChangeRemoteCb(ETb
 	}
 	else
 	{
-		ETbEnumEnum0 TestValue = ETbEnumEnum0::TEE0_VALUE0; // default value
+		ETbEnumEnum0 TestValue = ETbEnumEnum0::TEE0_Value0; // default value
 		Spec->TestEqual(TEXT("Delegate parameter should be the same value as set by the setter"), InProp0, TestValue);
 		if (TSharedPtr<FTbEnumEnumInterfaceOLinkFixture> PinnedImplFixture = ImplFixture.Pin())
 		{
@@ -106,9 +106,9 @@ void UTbEnumEnumInterfaceOLinkHelper::Prop0PropertyChangeLocalChangeRemoteCb(ETb
 
 void UTbEnumEnumInterfaceOLinkHelper::Prop1PropertyCb(ETbEnumEnum1 InProp1)
 {
-	ETbEnumEnum1 TestValue = ETbEnumEnum1::TEE1_VALUE1;
+	ETbEnumEnum1 TestValue = ETbEnumEnum1::TEE1_Value1;
 	// use different test value
-	TestValue = ETbEnumEnum1::TEE1_VALUE2;
+	TestValue = ETbEnumEnum1::TEE1_Value2;
 	Spec->TestEqual(TEXT("Delegate parameter should be the same value as set by the setter"), InProp1, TestValue);
 	if (TSharedPtr<FTbEnumEnumInterfaceOLinkFixture> PinnedImplFixture = ImplFixture.Pin())
 	{
@@ -119,9 +119,9 @@ void UTbEnumEnumInterfaceOLinkHelper::Prop1PropertyCb(ETbEnumEnum1 InProp1)
 
 void UTbEnumEnumInterfaceOLinkHelper::Prop1PropertyChangeLocalCheckRemoteCb(ETbEnumEnum1 InProp1)
 {
-	ETbEnumEnum1 TestValue = ETbEnumEnum1::TEE1_VALUE1;
+	ETbEnumEnum1 TestValue = ETbEnumEnum1::TEE1_Value1;
 	// use different test value
-	TestValue = ETbEnumEnum1::TEE1_VALUE2;
+	TestValue = ETbEnumEnum1::TEE1_Value2;
 	Spec->TestEqual(TEXT("Delegate parameter should be the same value as set by the setter"), InProp1, TestValue);
 	if (TSharedPtr<FTbEnumEnumInterfaceOLinkFixture> PinnedImplFixture = ImplFixture.Pin())
 	{
@@ -140,9 +140,9 @@ void UTbEnumEnumInterfaceOLinkHelper::Prop1PropertyChangeLocalChangeRemoteCb(ETb
 
 	if (count % 2 != 0)
 	{
-		ETbEnumEnum1 TestValue = ETbEnumEnum1::TEE1_VALUE1;
+		ETbEnumEnum1 TestValue = ETbEnumEnum1::TEE1_Value1;
 		// use different test value
-		TestValue = ETbEnumEnum1::TEE1_VALUE2;
+		TestValue = ETbEnumEnum1::TEE1_Value2;
 		Spec->TestEqual(TEXT("Delegate parameter should be the same value as set by the setter"), InProp1, TestValue);
 		if (TSharedPtr<FTbEnumEnumInterfaceOLinkFixture> PinnedImplFixture = ImplFixture.Pin())
 		{
@@ -150,7 +150,7 @@ void UTbEnumEnumInterfaceOLinkHelper::Prop1PropertyChangeLocalChangeRemoteCb(ETb
 		}
 
 		// now set it to the default value
-		TestValue = ETbEnumEnum1::TEE1_VALUE1; // default value
+		TestValue = ETbEnumEnum1::TEE1_Value1; // default value
 		if (TSharedPtr<FTbEnumEnumInterfaceOLinkFixture> PinnedImplFixture = ImplFixture.Pin())
 		{
 			PinnedImplFixture->GetImplementation()->Execute_SetProp1(PinnedImplFixture->GetImplementation().GetObject(), TestValue);
@@ -158,7 +158,7 @@ void UTbEnumEnumInterfaceOLinkHelper::Prop1PropertyChangeLocalChangeRemoteCb(ETb
 	}
 	else
 	{
-		ETbEnumEnum1 TestValue = ETbEnumEnum1::TEE1_VALUE1; // default value
+		ETbEnumEnum1 TestValue = ETbEnumEnum1::TEE1_Value1; // default value
 		Spec->TestEqual(TEXT("Delegate parameter should be the same value as set by the setter"), InProp1, TestValue);
 		if (TSharedPtr<FTbEnumEnumInterfaceOLinkFixture> PinnedImplFixture = ImplFixture.Pin())
 		{
@@ -170,9 +170,9 @@ void UTbEnumEnumInterfaceOLinkHelper::Prop1PropertyChangeLocalChangeRemoteCb(ETb
 
 void UTbEnumEnumInterfaceOLinkHelper::Prop2PropertyCb(ETbEnumEnum2 InProp2)
 {
-	ETbEnumEnum2 TestValue = ETbEnumEnum2::TEE2_VALUE2;
+	ETbEnumEnum2 TestValue = ETbEnumEnum2::TEE2_Value2;
 	// use different test value
-	TestValue = ETbEnumEnum2::TEE2_VALUE1;
+	TestValue = ETbEnumEnum2::TEE2_Value1;
 	Spec->TestEqual(TEXT("Delegate parameter should be the same value as set by the setter"), InProp2, TestValue);
 	if (TSharedPtr<FTbEnumEnumInterfaceOLinkFixture> PinnedImplFixture = ImplFixture.Pin())
 	{
@@ -183,9 +183,9 @@ void UTbEnumEnumInterfaceOLinkHelper::Prop2PropertyCb(ETbEnumEnum2 InProp2)
 
 void UTbEnumEnumInterfaceOLinkHelper::Prop2PropertyChangeLocalCheckRemoteCb(ETbEnumEnum2 InProp2)
 {
-	ETbEnumEnum2 TestValue = ETbEnumEnum2::TEE2_VALUE2;
+	ETbEnumEnum2 TestValue = ETbEnumEnum2::TEE2_Value2;
 	// use different test value
-	TestValue = ETbEnumEnum2::TEE2_VALUE1;
+	TestValue = ETbEnumEnum2::TEE2_Value1;
 	Spec->TestEqual(TEXT("Delegate parameter should be the same value as set by the setter"), InProp2, TestValue);
 	if (TSharedPtr<FTbEnumEnumInterfaceOLinkFixture> PinnedImplFixture = ImplFixture.Pin())
 	{
@@ -204,9 +204,9 @@ void UTbEnumEnumInterfaceOLinkHelper::Prop2PropertyChangeLocalChangeRemoteCb(ETb
 
 	if (count % 2 != 0)
 	{
-		ETbEnumEnum2 TestValue = ETbEnumEnum2::TEE2_VALUE2;
+		ETbEnumEnum2 TestValue = ETbEnumEnum2::TEE2_Value2;
 		// use different test value
-		TestValue = ETbEnumEnum2::TEE2_VALUE1;
+		TestValue = ETbEnumEnum2::TEE2_Value1;
 		Spec->TestEqual(TEXT("Delegate parameter should be the same value as set by the setter"), InProp2, TestValue);
 		if (TSharedPtr<FTbEnumEnumInterfaceOLinkFixture> PinnedImplFixture = ImplFixture.Pin())
 		{
@@ -214,7 +214,7 @@ void UTbEnumEnumInterfaceOLinkHelper::Prop2PropertyChangeLocalChangeRemoteCb(ETb
 		}
 
 		// now set it to the default value
-		TestValue = ETbEnumEnum2::TEE2_VALUE2; // default value
+		TestValue = ETbEnumEnum2::TEE2_Value2; // default value
 		if (TSharedPtr<FTbEnumEnumInterfaceOLinkFixture> PinnedImplFixture = ImplFixture.Pin())
 		{
 			PinnedImplFixture->GetImplementation()->Execute_SetProp2(PinnedImplFixture->GetImplementation().GetObject(), TestValue);
@@ -222,7 +222,7 @@ void UTbEnumEnumInterfaceOLinkHelper::Prop2PropertyChangeLocalChangeRemoteCb(ETb
 	}
 	else
 	{
-		ETbEnumEnum2 TestValue = ETbEnumEnum2::TEE2_VALUE2; // default value
+		ETbEnumEnum2 TestValue = ETbEnumEnum2::TEE2_Value2; // default value
 		Spec->TestEqual(TEXT("Delegate parameter should be the same value as set by the setter"), InProp2, TestValue);
 		if (TSharedPtr<FTbEnumEnumInterfaceOLinkFixture> PinnedImplFixture = ImplFixture.Pin())
 		{
@@ -234,9 +234,9 @@ void UTbEnumEnumInterfaceOLinkHelper::Prop2PropertyChangeLocalChangeRemoteCb(ETb
 
 void UTbEnumEnumInterfaceOLinkHelper::Prop3PropertyCb(ETbEnumEnum3 InProp3)
 {
-	ETbEnumEnum3 TestValue = ETbEnumEnum3::TEE3_VALUE3;
+	ETbEnumEnum3 TestValue = ETbEnumEnum3::TEE3_Value3;
 	// use different test value
-	TestValue = ETbEnumEnum3::TEE3_VALUE2;
+	TestValue = ETbEnumEnum3::TEE3_Value2;
 	Spec->TestEqual(TEXT("Delegate parameter should be the same value as set by the setter"), InProp3, TestValue);
 	if (TSharedPtr<FTbEnumEnumInterfaceOLinkFixture> PinnedImplFixture = ImplFixture.Pin())
 	{
@@ -247,9 +247,9 @@ void UTbEnumEnumInterfaceOLinkHelper::Prop3PropertyCb(ETbEnumEnum3 InProp3)
 
 void UTbEnumEnumInterfaceOLinkHelper::Prop3PropertyChangeLocalCheckRemoteCb(ETbEnumEnum3 InProp3)
 {
-	ETbEnumEnum3 TestValue = ETbEnumEnum3::TEE3_VALUE3;
+	ETbEnumEnum3 TestValue = ETbEnumEnum3::TEE3_Value3;
 	// use different test value
-	TestValue = ETbEnumEnum3::TEE3_VALUE2;
+	TestValue = ETbEnumEnum3::TEE3_Value2;
 	Spec->TestEqual(TEXT("Delegate parameter should be the same value as set by the setter"), InProp3, TestValue);
 	if (TSharedPtr<FTbEnumEnumInterfaceOLinkFixture> PinnedImplFixture = ImplFixture.Pin())
 	{
@@ -268,9 +268,9 @@ void UTbEnumEnumInterfaceOLinkHelper::Prop3PropertyChangeLocalChangeRemoteCb(ETb
 
 	if (count % 2 != 0)
 	{
-		ETbEnumEnum3 TestValue = ETbEnumEnum3::TEE3_VALUE3;
+		ETbEnumEnum3 TestValue = ETbEnumEnum3::TEE3_Value3;
 		// use different test value
-		TestValue = ETbEnumEnum3::TEE3_VALUE2;
+		TestValue = ETbEnumEnum3::TEE3_Value2;
 		Spec->TestEqual(TEXT("Delegate parameter should be the same value as set by the setter"), InProp3, TestValue);
 		if (TSharedPtr<FTbEnumEnumInterfaceOLinkFixture> PinnedImplFixture = ImplFixture.Pin())
 		{
@@ -278,7 +278,7 @@ void UTbEnumEnumInterfaceOLinkHelper::Prop3PropertyChangeLocalChangeRemoteCb(ETb
 		}
 
 		// now set it to the default value
-		TestValue = ETbEnumEnum3::TEE3_VALUE3; // default value
+		TestValue = ETbEnumEnum3::TEE3_Value3; // default value
 		if (TSharedPtr<FTbEnumEnumInterfaceOLinkFixture> PinnedImplFixture = ImplFixture.Pin())
 		{
 			PinnedImplFixture->GetImplementation()->Execute_SetProp3(PinnedImplFixture->GetImplementation().GetObject(), TestValue);
@@ -286,7 +286,7 @@ void UTbEnumEnumInterfaceOLinkHelper::Prop3PropertyChangeLocalChangeRemoteCb(ETb
 	}
 	else
 	{
-		ETbEnumEnum3 TestValue = ETbEnumEnum3::TEE3_VALUE3; // default value
+		ETbEnumEnum3 TestValue = ETbEnumEnum3::TEE3_Value3; // default value
 		Spec->TestEqual(TEXT("Delegate parameter should be the same value as set by the setter"), InProp3, TestValue);
 		if (TSharedPtr<FTbEnumEnumInterfaceOLinkFixture> PinnedImplFixture = ImplFixture.Pin())
 		{
@@ -299,7 +299,7 @@ void UTbEnumEnumInterfaceOLinkHelper::Prop3PropertyChangeLocalChangeRemoteCb(ETb
 void UTbEnumEnumInterfaceOLinkHelper::Sig0SignalCb(ETbEnumEnum0 InParam0)
 {
 	// known test value
-	ETbEnumEnum0 Param0TestValue = ETbEnumEnum0::TEE0_VALUE1;
+	ETbEnumEnum0 Param0TestValue = ETbEnumEnum0::TEE0_Value1;
 	Spec->TestEqual(TEXT("Parameter should be the same value as sent by the signal"), InParam0, Param0TestValue);
 	testDoneDelegate.Execute();
 }
@@ -307,7 +307,7 @@ void UTbEnumEnumInterfaceOLinkHelper::Sig0SignalCb(ETbEnumEnum0 InParam0)
 void UTbEnumEnumInterfaceOLinkHelper::Sig1SignalCb(ETbEnumEnum1 InParam1)
 {
 	// known test value
-	ETbEnumEnum1 Param1TestValue = ETbEnumEnum1::TEE1_VALUE2;
+	ETbEnumEnum1 Param1TestValue = ETbEnumEnum1::TEE1_Value2;
 	Spec->TestEqual(TEXT("Parameter should be the same value as sent by the signal"), InParam1, Param1TestValue);
 	testDoneDelegate.Execute();
 }
@@ -315,7 +315,7 @@ void UTbEnumEnumInterfaceOLinkHelper::Sig1SignalCb(ETbEnumEnum1 InParam1)
 void UTbEnumEnumInterfaceOLinkHelper::Sig2SignalCb(ETbEnumEnum2 InParam2)
 {
 	// known test value
-	ETbEnumEnum2 Param2TestValue = ETbEnumEnum2::TEE2_VALUE1;
+	ETbEnumEnum2 Param2TestValue = ETbEnumEnum2::TEE2_Value1;
 	Spec->TestEqual(TEXT("Parameter should be the same value as sent by the signal"), InParam2, Param2TestValue);
 	testDoneDelegate.Execute();
 }
@@ -323,7 +323,7 @@ void UTbEnumEnumInterfaceOLinkHelper::Sig2SignalCb(ETbEnumEnum2 InParam2)
 void UTbEnumEnumInterfaceOLinkHelper::Sig3SignalCb(ETbEnumEnum3 InParam3)
 {
 	// known test value
-	ETbEnumEnum3 Param3TestValue = ETbEnumEnum3::TEE3_VALUE2;
+	ETbEnumEnum3 Param3TestValue = ETbEnumEnum3::TEE3_Value2;
 	Spec->TestEqual(TEXT("Parameter should be the same value as sent by the signal"), InParam3, Param3TestValue);
 	testDoneDelegate.Execute();
 }

--- a/goldenmaster/Plugins/TbEnum/Source/TbEnum/Public/Generated/MsgBus/TbEnumEnumInterfaceMsgBusMessages.h
+++ b/goldenmaster/Plugins/TbEnum/Source/TbEnum/Public/Generated/MsgBus/TbEnumEnumInterfaceMsgBusMessages.h
@@ -52,16 +52,16 @@ struct FTbEnumEnumInterfaceInitMessage
 	int32 _ClientPingIntervalMS = 100;
 
 	UPROPERTY()
-	ETbEnumEnum0 Prop0 = ETbEnumEnum0::TEE0_VALUE0;
+	ETbEnumEnum0 Prop0 = ETbEnumEnum0::TEE0_Value0;
 
 	UPROPERTY()
-	ETbEnumEnum1 Prop1 = ETbEnumEnum1::TEE1_VALUE1;
+	ETbEnumEnum1 Prop1 = ETbEnumEnum1::TEE1_Value1;
 
 	UPROPERTY()
-	ETbEnumEnum2 Prop2 = ETbEnumEnum2::TEE2_VALUE2;
+	ETbEnumEnum2 Prop2 = ETbEnumEnum2::TEE2_Value2;
 
 	UPROPERTY()
-	ETbEnumEnum3 Prop3 = ETbEnumEnum3::TEE3_VALUE3;
+	ETbEnumEnum3 Prop3 = ETbEnumEnum3::TEE3_Value3;
 };
 
 USTRUCT()
@@ -100,7 +100,7 @@ struct FTbEnumEnumInterfaceSig0SignalMessage
 	GENERATED_BODY()
 
 	UPROPERTY()
-	ETbEnumEnum0 Param0 = ETbEnumEnum0::TEE0_VALUE0;
+	ETbEnumEnum0 Param0 = ETbEnumEnum0::TEE0_Value0;
 };
 
 USTRUCT()
@@ -109,7 +109,7 @@ struct FTbEnumEnumInterfaceSig1SignalMessage
 	GENERATED_BODY()
 
 	UPROPERTY()
-	ETbEnumEnum1 Param1 = ETbEnumEnum1::TEE1_VALUE1;
+	ETbEnumEnum1 Param1 = ETbEnumEnum1::TEE1_Value1;
 };
 
 USTRUCT()
@@ -118,7 +118,7 @@ struct FTbEnumEnumInterfaceSig2SignalMessage
 	GENERATED_BODY()
 
 	UPROPERTY()
-	ETbEnumEnum2 Param2 = ETbEnumEnum2::TEE2_VALUE2;
+	ETbEnumEnum2 Param2 = ETbEnumEnum2::TEE2_Value2;
 };
 
 USTRUCT()
@@ -127,7 +127,7 @@ struct FTbEnumEnumInterfaceSig3SignalMessage
 	GENERATED_BODY()
 
 	UPROPERTY()
-	ETbEnumEnum3 Param3 = ETbEnumEnum3::TEE3_VALUE3;
+	ETbEnumEnum3 Param3 = ETbEnumEnum3::TEE3_Value3;
 };
 
 USTRUCT()
@@ -136,7 +136,7 @@ struct FTbEnumEnumInterfaceSetProp0RequestMessage
 	GENERATED_BODY()
 
 	UPROPERTY()
-	ETbEnumEnum0 Prop0 = ETbEnumEnum0::TEE0_VALUE0;
+	ETbEnumEnum0 Prop0 = ETbEnumEnum0::TEE0_Value0;
 };
 
 USTRUCT()
@@ -145,7 +145,7 @@ struct FTbEnumEnumInterfaceProp0ChangedMessage
 	GENERATED_BODY()
 
 	UPROPERTY()
-	ETbEnumEnum0 Prop0 = ETbEnumEnum0::TEE0_VALUE0;
+	ETbEnumEnum0 Prop0 = ETbEnumEnum0::TEE0_Value0;
 };
 
 USTRUCT()
@@ -154,7 +154,7 @@ struct FTbEnumEnumInterfaceSetProp1RequestMessage
 	GENERATED_BODY()
 
 	UPROPERTY()
-	ETbEnumEnum1 Prop1 = ETbEnumEnum1::TEE1_VALUE1;
+	ETbEnumEnum1 Prop1 = ETbEnumEnum1::TEE1_Value1;
 };
 
 USTRUCT()
@@ -163,7 +163,7 @@ struct FTbEnumEnumInterfaceProp1ChangedMessage
 	GENERATED_BODY()
 
 	UPROPERTY()
-	ETbEnumEnum1 Prop1 = ETbEnumEnum1::TEE1_VALUE1;
+	ETbEnumEnum1 Prop1 = ETbEnumEnum1::TEE1_Value1;
 };
 
 USTRUCT()
@@ -172,7 +172,7 @@ struct FTbEnumEnumInterfaceSetProp2RequestMessage
 	GENERATED_BODY()
 
 	UPROPERTY()
-	ETbEnumEnum2 Prop2 = ETbEnumEnum2::TEE2_VALUE2;
+	ETbEnumEnum2 Prop2 = ETbEnumEnum2::TEE2_Value2;
 };
 
 USTRUCT()
@@ -181,7 +181,7 @@ struct FTbEnumEnumInterfaceProp2ChangedMessage
 	GENERATED_BODY()
 
 	UPROPERTY()
-	ETbEnumEnum2 Prop2 = ETbEnumEnum2::TEE2_VALUE2;
+	ETbEnumEnum2 Prop2 = ETbEnumEnum2::TEE2_Value2;
 };
 
 USTRUCT()
@@ -190,7 +190,7 @@ struct FTbEnumEnumInterfaceSetProp3RequestMessage
 	GENERATED_BODY()
 
 	UPROPERTY()
-	ETbEnumEnum3 Prop3 = ETbEnumEnum3::TEE3_VALUE3;
+	ETbEnumEnum3 Prop3 = ETbEnumEnum3::TEE3_Value3;
 };
 
 USTRUCT()
@@ -199,7 +199,7 @@ struct FTbEnumEnumInterfaceProp3ChangedMessage
 	GENERATED_BODY()
 
 	UPROPERTY()
-	ETbEnumEnum3 Prop3 = ETbEnumEnum3::TEE3_VALUE3;
+	ETbEnumEnum3 Prop3 = ETbEnumEnum3::TEE3_Value3;
 };
 
 USTRUCT()
@@ -211,7 +211,7 @@ struct FTbEnumEnumInterfaceFunc0RequestMessage
 	FGuid ResponseId;
 
 	UPROPERTY()
-	ETbEnumEnum0 Param0 = ETbEnumEnum0::TEE0_VALUE0;
+	ETbEnumEnum0 Param0 = ETbEnumEnum0::TEE0_Value0;
 };
 
 USTRUCT()
@@ -223,7 +223,7 @@ struct FTbEnumEnumInterfaceFunc0ReplyMessage
 	FGuid ResponseId;
 
 	UPROPERTY()
-	ETbEnumEnum0 Result = ETbEnumEnum0::TEE0_VALUE0;
+	ETbEnumEnum0 Result = ETbEnumEnum0::TEE0_Value0;
 };
 
 USTRUCT()
@@ -235,7 +235,7 @@ struct FTbEnumEnumInterfaceFunc1RequestMessage
 	FGuid ResponseId;
 
 	UPROPERTY()
-	ETbEnumEnum1 Param1 = ETbEnumEnum1::TEE1_VALUE1;
+	ETbEnumEnum1 Param1 = ETbEnumEnum1::TEE1_Value1;
 };
 
 USTRUCT()
@@ -247,7 +247,7 @@ struct FTbEnumEnumInterfaceFunc1ReplyMessage
 	FGuid ResponseId;
 
 	UPROPERTY()
-	ETbEnumEnum1 Result = ETbEnumEnum1::TEE1_VALUE1;
+	ETbEnumEnum1 Result = ETbEnumEnum1::TEE1_Value1;
 };
 
 USTRUCT()
@@ -259,7 +259,7 @@ struct FTbEnumEnumInterfaceFunc2RequestMessage
 	FGuid ResponseId;
 
 	UPROPERTY()
-	ETbEnumEnum2 Param2 = ETbEnumEnum2::TEE2_VALUE2;
+	ETbEnumEnum2 Param2 = ETbEnumEnum2::TEE2_Value2;
 };
 
 USTRUCT()
@@ -271,7 +271,7 @@ struct FTbEnumEnumInterfaceFunc2ReplyMessage
 	FGuid ResponseId;
 
 	UPROPERTY()
-	ETbEnumEnum2 Result = ETbEnumEnum2::TEE2_VALUE2;
+	ETbEnumEnum2 Result = ETbEnumEnum2::TEE2_Value2;
 };
 
 USTRUCT()
@@ -283,7 +283,7 @@ struct FTbEnumEnumInterfaceFunc3RequestMessage
 	FGuid ResponseId;
 
 	UPROPERTY()
-	ETbEnumEnum3 Param3 = ETbEnumEnum3::TEE3_VALUE3;
+	ETbEnumEnum3 Param3 = ETbEnumEnum3::TEE3_Value3;
 };
 
 USTRUCT()
@@ -295,5 +295,5 @@ struct FTbEnumEnumInterfaceFunc3ReplyMessage
 	FGuid ResponseId;
 
 	UPROPERTY()
-	ETbEnumEnum3 Result = ETbEnumEnum3::TEE3_VALUE3;
+	ETbEnumEnum3 Result = ETbEnumEnum3::TEE3_Value3;
 };

--- a/goldenmaster/Plugins/TbEnum/Source/TbEnum/Public/Generated/api/AbstractTbEnumEnumInterface.h
+++ b/goldenmaster/Plugins/TbEnum/Source/TbEnum/Public/Generated/api/AbstractTbEnumEnumInterface.h
@@ -42,28 +42,28 @@ public:
 
 	// methods
 	virtual void Func0Async_Implementation(UObject* WorldContextObject, FLatentActionInfo LatentInfo, ETbEnumEnum0& Result, ETbEnumEnum0 Param0) override;
-	virtual ETbEnumEnum0 Func0_Implementation(ETbEnumEnum0 Param0) override PURE_VIRTUAL(UAbstractTbEnumEnumInterface::Func0_Implementation, return ETbEnumEnum0::TEE0_VALUE0;);
+	virtual ETbEnumEnum0 Func0_Implementation(ETbEnumEnum0 Param0) override PURE_VIRTUAL(UAbstractTbEnumEnumInterface::Func0_Implementation, return ETbEnumEnum0::TEE0_Value0;);
 
 	virtual void Func1Async_Implementation(UObject* WorldContextObject, FLatentActionInfo LatentInfo, ETbEnumEnum1& Result, ETbEnumEnum1 Param1) override;
-	virtual ETbEnumEnum1 Func1_Implementation(ETbEnumEnum1 Param1) override PURE_VIRTUAL(UAbstractTbEnumEnumInterface::Func1_Implementation, return ETbEnumEnum1::TEE1_VALUE1;);
+	virtual ETbEnumEnum1 Func1_Implementation(ETbEnumEnum1 Param1) override PURE_VIRTUAL(UAbstractTbEnumEnumInterface::Func1_Implementation, return ETbEnumEnum1::TEE1_Value1;);
 
 	virtual void Func2Async_Implementation(UObject* WorldContextObject, FLatentActionInfo LatentInfo, ETbEnumEnum2& Result, ETbEnumEnum2 Param2) override;
-	virtual ETbEnumEnum2 Func2_Implementation(ETbEnumEnum2 Param2) override PURE_VIRTUAL(UAbstractTbEnumEnumInterface::Func2_Implementation, return ETbEnumEnum2::TEE2_VALUE2;);
+	virtual ETbEnumEnum2 Func2_Implementation(ETbEnumEnum2 Param2) override PURE_VIRTUAL(UAbstractTbEnumEnumInterface::Func2_Implementation, return ETbEnumEnum2::TEE2_Value2;);
 
 	virtual void Func3Async_Implementation(UObject* WorldContextObject, FLatentActionInfo LatentInfo, ETbEnumEnum3& Result, ETbEnumEnum3 Param3) override;
-	virtual ETbEnumEnum3 Func3_Implementation(ETbEnumEnum3 Param3) override PURE_VIRTUAL(UAbstractTbEnumEnumInterface::Func3_Implementation, return ETbEnumEnum3::TEE3_VALUE3;);
+	virtual ETbEnumEnum3 Func3_Implementation(ETbEnumEnum3 Param3) override PURE_VIRTUAL(UAbstractTbEnumEnumInterface::Func3_Implementation, return ETbEnumEnum3::TEE3_Value3;);
 
 	// properties
-	virtual ETbEnumEnum0 GetProp0_Implementation() const override PURE_VIRTUAL(UAbstractTbEnumEnumInterface::GetProp0_Implementation, return ETbEnumEnum0::TEE0_VALUE0;);
+	virtual ETbEnumEnum0 GetProp0_Implementation() const override PURE_VIRTUAL(UAbstractTbEnumEnumInterface::GetProp0_Implementation, return ETbEnumEnum0::TEE0_Value0;);
 	virtual void SetProp0_Implementation(ETbEnumEnum0 InProp0) override PURE_VIRTUAL(UAbstractTbEnumEnumInterface::SetProp0_Implementation, return;);
 
-	virtual ETbEnumEnum1 GetProp1_Implementation() const override PURE_VIRTUAL(UAbstractTbEnumEnumInterface::GetProp1_Implementation, return ETbEnumEnum1::TEE1_VALUE1;);
+	virtual ETbEnumEnum1 GetProp1_Implementation() const override PURE_VIRTUAL(UAbstractTbEnumEnumInterface::GetProp1_Implementation, return ETbEnumEnum1::TEE1_Value1;);
 	virtual void SetProp1_Implementation(ETbEnumEnum1 InProp1) override PURE_VIRTUAL(UAbstractTbEnumEnumInterface::SetProp1_Implementation, return;);
 
-	virtual ETbEnumEnum2 GetProp2_Implementation() const override PURE_VIRTUAL(UAbstractTbEnumEnumInterface::GetProp2_Implementation, return ETbEnumEnum2::TEE2_VALUE2;);
+	virtual ETbEnumEnum2 GetProp2_Implementation() const override PURE_VIRTUAL(UAbstractTbEnumEnumInterface::GetProp2_Implementation, return ETbEnumEnum2::TEE2_Value2;);
 	virtual void SetProp2_Implementation(ETbEnumEnum2 InProp2) override PURE_VIRTUAL(UAbstractTbEnumEnumInterface::SetProp2_Implementation, return;);
 
-	virtual ETbEnumEnum3 GetProp3_Implementation() const override PURE_VIRTUAL(UAbstractTbEnumEnumInterface::GetProp3_Implementation, return ETbEnumEnum3::TEE3_VALUE3;);
+	virtual ETbEnumEnum3 GetProp3_Implementation() const override PURE_VIRTUAL(UAbstractTbEnumEnumInterface::GetProp3_Implementation, return ETbEnumEnum3::TEE3_Value3;);
 	virtual void SetProp3_Implementation(ETbEnumEnum3 InProp3) override PURE_VIRTUAL(UAbstractTbEnumEnumInterface::SetProp3_Implementation, return;);
 
 	virtual bool IsInitialized() const;
@@ -73,7 +73,7 @@ protected:
 
 	// properties - local copy
 	UPROPERTY(EditAnywhere, BlueprintGetter = GetProp0_Private, BlueprintSetter = SetProp0_Private, Category = "ApiGear|TbEnum|EnumInterface")
-	ETbEnumEnum0 Prop0{ETbEnumEnum0::TEE0_VALUE0};
+	ETbEnumEnum0 Prop0{ETbEnumEnum0::TEE0_Value0};
 
 	UFUNCTION(BlueprintGetter, Category = "ApiGear|TbEnum|EnumInterface|Properties", BlueprintInternalUseOnly)
 	ETbEnumEnum0 GetProp0_Private() const;
@@ -82,7 +82,7 @@ protected:
 	void SetProp0_Private(ETbEnumEnum0 InProp0);
 
 	UPROPERTY(EditAnywhere, BlueprintGetter = GetProp1_Private, BlueprintSetter = SetProp1_Private, Category = "ApiGear|TbEnum|EnumInterface")
-	ETbEnumEnum1 Prop1{ETbEnumEnum1::TEE1_VALUE1};
+	ETbEnumEnum1 Prop1{ETbEnumEnum1::TEE1_Value1};
 
 	UFUNCTION(BlueprintGetter, Category = "ApiGear|TbEnum|EnumInterface|Properties", BlueprintInternalUseOnly)
 	ETbEnumEnum1 GetProp1_Private() const;
@@ -91,7 +91,7 @@ protected:
 	void SetProp1_Private(ETbEnumEnum1 InProp1);
 
 	UPROPERTY(EditAnywhere, BlueprintGetter = GetProp2_Private, BlueprintSetter = SetProp2_Private, Category = "ApiGear|TbEnum|EnumInterface")
-	ETbEnumEnum2 Prop2{ETbEnumEnum2::TEE2_VALUE2};
+	ETbEnumEnum2 Prop2{ETbEnumEnum2::TEE2_Value2};
 
 	UFUNCTION(BlueprintGetter, Category = "ApiGear|TbEnum|EnumInterface|Properties", BlueprintInternalUseOnly)
 	ETbEnumEnum2 GetProp2_Private() const;
@@ -100,7 +100,7 @@ protected:
 	void SetProp2_Private(ETbEnumEnum2 InProp2);
 
 	UPROPERTY(EditAnywhere, BlueprintGetter = GetProp3_Private, BlueprintSetter = SetProp3_Private, Category = "ApiGear|TbEnum|EnumInterface")
-	ETbEnumEnum3 Prop3{ETbEnumEnum3::TEE3_VALUE3};
+	ETbEnumEnum3 Prop3{ETbEnumEnum3::TEE3_Value3};
 
 	UFUNCTION(BlueprintGetter, Category = "ApiGear|TbEnum|EnumInterface|Properties", BlueprintInternalUseOnly)
 	ETbEnumEnum3 GetProp3_Private() const;

--- a/goldenmaster/Plugins/TbEnum/Source/TbEnum/Public/Generated/api/TbEnum_data.h
+++ b/goldenmaster/Plugins/TbEnum/Source/TbEnum/Public/Generated/api/TbEnum_data.h
@@ -28,9 +28,9 @@ limitations under the License.
 UENUM(BlueprintType)
 enum class ETbEnumEnum0 : uint8
 {
-	TEE0_VALUE0 = 0 UMETA(Displayname = "value0"),
-	TEE0_VALUE1 = 1 UMETA(Displayname = "value1"),
-	TEE0_VALUE2 = 2 UMETA(Displayname = "value2")
+	TEE0_Value0 = 0 UMETA(Displayname = "value0"),
+	TEE0_Value1 = 1 UMETA(Displayname = "value1"),
+	TEE0_Value2 = 2 UMETA(Displayname = "value2")
 };
 
 /**
@@ -39,10 +39,10 @@ enum class ETbEnumEnum0 : uint8
 UENUM(BlueprintType)
 enum class ETbEnumEnum1 : uint8
 {
-	TEE1_VALUE1 = 1 UMETA(Displayname = "value1"),
-	TEE1_VALUE2 = 2 UMETA(Displayname = "value2"),
-	TEE1_VALUE3 = 3 UMETA(Displayname = "value3"),
-	UNSPECIFIED = 0 UMETA(Hidden)
+	TEE1_Value1 = 1 UMETA(Displayname = "value1"),
+	TEE1_Value2 = 2 UMETA(Displayname = "value2"),
+	TEE1_Value3 = 3 UMETA(Displayname = "value3"),
+	Unspecified = 0 UMETA(Hidden)
 };
 
 /**
@@ -51,9 +51,9 @@ enum class ETbEnumEnum1 : uint8
 UENUM(BlueprintType)
 enum class ETbEnumEnum2 : uint8
 {
-	TEE2_VALUE2 = 2 UMETA(Displayname = "value2"),
-	TEE2_VALUE1 = 1 UMETA(Displayname = "value1"),
-	TEE2_VALUE0 = 0 UMETA(Displayname = "value0")
+	TEE2_Value2 = 2 UMETA(Displayname = "value2"),
+	TEE2_Value1 = 1 UMETA(Displayname = "value1"),
+	TEE2_Value0 = 0 UMETA(Displayname = "value0")
 };
 
 /**
@@ -62,10 +62,10 @@ enum class ETbEnumEnum2 : uint8
 UENUM(BlueprintType)
 enum class ETbEnumEnum3 : uint8
 {
-	TEE3_VALUE3 = 3 UMETA(Displayname = "value3"),
-	TEE3_VALUE2 = 2 UMETA(Displayname = "value2"),
-	TEE3_VALUE1 = 1 UMETA(Displayname = "value1"),
-	UNSPECIFIED = 0 UMETA(Hidden)
+	TEE3_Value3 = 3 UMETA(Displayname = "value3"),
+	TEE3_Value2 = 2 UMETA(Displayname = "value2"),
+	TEE3_Value1 = 1 UMETA(Displayname = "value1"),
+	Unspecified = 0 UMETA(Hidden)
 };
 
 /**

--- a/goldenmaster/Plugins/TbNames/Source/TbNames/Private/Generated/MsgBus/TbNamesNamEsMsgBusClient.cpp
+++ b/goldenmaster/Plugins/TbNames/Source/TbNames/Private/Generated/MsgBus/TbNamesNamEsMsgBusClient.cpp
@@ -40,7 +40,7 @@ struct TbNamesNamEsPropertiesMsgBusData
 	std::atomic<bool> bSwitch{false};
 	std::atomic<int32> SomeProperty{0};
 	std::atomic<int32> SomePoperty2{0};
-	std::atomic<ETbNamesEnum_With_Under_scores> EnumProperty{ETbNamesEnum_With_Under_scores::TNEWUS_FIRSTVALUE};
+	std::atomic<ETbNamesEnum_With_Under_scores> EnumProperty{ETbNamesEnum_With_Under_scores::TNEWUS_FirstValue};
 };
 DEFINE_LOG_CATEGORY(LogTbNamesNamEsMsgBusClient);
 

--- a/goldenmaster/Plugins/TbNames/Source/TbNames/Private/Generated/OLink/TbNamesNamEsOLinkClient.cpp
+++ b/goldenmaster/Plugins/TbNames/Source/TbNames/Private/Generated/OLink/TbNamesNamEsOLinkClient.cpp
@@ -45,7 +45,7 @@ struct TbNamesNamEsPropertiesData
 	std::atomic<bool> bSwitch{false};
 	std::atomic<int32> SomeProperty{0};
 	std::atomic<int32> SomePoperty2{0};
-	std::atomic<ETbNamesEnum_With_Under_scores> EnumProperty{ETbNamesEnum_With_Under_scores::TNEWUS_FIRSTVALUE};
+	std::atomic<ETbNamesEnum_With_Under_scores> EnumProperty{ETbNamesEnum_With_Under_scores::TNEWUS_FirstValue};
 };
 DEFINE_LOG_CATEGORY(LogTbNamesNamEsOLinkClient);
 

--- a/goldenmaster/Plugins/TbNames/Source/TbNames/Private/Generated/api/TbNames_data.cpp
+++ b/goldenmaster/Plugins/TbNames/Source/TbNames/Private/Generated/api/TbNames_data.cpp
@@ -27,19 +27,19 @@ bool UTbNamesLibrary::toTbNamesEnum_With_Under_scores(ETbNamesEnum_With_Under_sc
 	switch (InValue)
 	{
 	case 0:
-		ConvertedEnum = ETbNamesEnum_With_Under_scores::TNEWUS_FIRSTVALUE;
+		ConvertedEnum = ETbNamesEnum_With_Under_scores::TNEWUS_FirstValue;
 		bSuccessful = true;
 		break;
 	case 1:
-		ConvertedEnum = ETbNamesEnum_With_Under_scores::TNEWUS_SECONDVALUE;
+		ConvertedEnum = ETbNamesEnum_With_Under_scores::TNEWUS_SecondValue;
 		bSuccessful = true;
 		break;
 	case 2:
-		ConvertedEnum = ETbNamesEnum_With_Under_scores::TNEWUS_THIRDVALUE;
+		ConvertedEnum = ETbNamesEnum_With_Under_scores::TNEWUS_ThirdValue;
 		bSuccessful = true;
 		break;
 	default:
-		ConvertedEnum = ETbNamesEnum_With_Under_scores::TNEWUS_FIRSTVALUE;
+		ConvertedEnum = ETbNamesEnum_With_Under_scores::TNEWUS_FirstValue;
 	}
 	return bSuccessful;
 }

--- a/goldenmaster/Plugins/TbNames/Source/TbNames/Private/Implementation/TbNamesNamEs.cpp
+++ b/goldenmaster/Plugins/TbNames/Source/TbNames/Private/Implementation/TbNamesNamEs.cpp
@@ -100,9 +100,9 @@ void UTbNamesNamEs::_ResetProperties()
 		SomePoperty2 = 0;
 		Execute__GetSignals(this)->OnSomePoperty2Changed.Broadcast(SomePoperty2);
 	}
-	if (EnumProperty != ETbNamesEnum_With_Under_scores::TNEWUS_FIRSTVALUE)
+	if (EnumProperty != ETbNamesEnum_With_Under_scores::TNEWUS_FirstValue)
 	{
-		EnumProperty = ETbNamesEnum_With_Under_scores::TNEWUS_FIRSTVALUE;
+		EnumProperty = ETbNamesEnum_With_Under_scores::TNEWUS_FirstValue;
 		Execute__GetSignals(this)->OnEnumPropertyChanged.Broadcast(EnumProperty);
 	}
 }

--- a/goldenmaster/Plugins/TbNames/Source/TbNames/Private/Tests/TbNamesNamEsImpl.spec.cpp
+++ b/goldenmaster/Plugins/TbNames/Source/TbNames/Private/Tests/TbNamesNamEsImpl.spec.cpp
@@ -113,21 +113,21 @@ void UTbNamesNamEsImplSpec::Define()
 	It("Property.EnumProperty.Default", [this]()
 		{
 		// Do implement test here
-		ETbNamesEnum_With_Under_scores TestValue = ETbNamesEnum_With_Under_scores::TNEWUS_FIRSTVALUE; // default value
+		ETbNamesEnum_With_Under_scores TestValue = ETbNamesEnum_With_Under_scores::TNEWUS_FirstValue; // default value
 		TestEqual(TEXT("Getter should return the default value"), ImplFixture->GetImplementation()->Execute_GetEnumProperty(ImplFixture->GetImplementation().GetObject()), TestValue);
 	});
 
 	LatentIt("Property.EnumProperty.Change", EAsyncExecution::ThreadPool, [this](const FDoneDelegate TestDone)
 		{
 		// Do implement test here
-		ETbNamesEnum_With_Under_scores TestValue = ETbNamesEnum_With_Under_scores::TNEWUS_FIRSTVALUE; // default value
+		ETbNamesEnum_With_Under_scores TestValue = ETbNamesEnum_With_Under_scores::TNEWUS_FirstValue; // default value
 		TestEqual(TEXT("Getter should return the default value"), ImplFixture->GetImplementation()->Execute_GetEnumProperty(ImplFixture->GetImplementation().GetObject()), TestValue);
 
 		ImplFixture->GetHelper()->SetTestDone(TestDone);
 		UTbNamesNamEsSignals* TbNamesNamEsSignals = ImplFixture->GetImplementation()->Execute__GetSignals(ImplFixture->GetImplementation().GetObject());
 		TbNamesNamEsSignals->OnEnumPropertyChanged.AddDynamic(ImplFixture->GetHelper().Get(), &UTbNamesNamEsImplHelper::EnumPropertyPropertyCb);
 		// use different test value
-		TestValue = ETbNamesEnum_With_Under_scores::TNEWUS_SECONDVALUE;
+		TestValue = ETbNamesEnum_With_Under_scores::TNEWUS_SecondValue;
 		ImplFixture->GetImplementation()->Execute_SetEnumProperty(ImplFixture->GetImplementation().GetObject(), TestValue);
 	});
 

--- a/goldenmaster/Plugins/TbNames/Source/TbNames/Private/Tests/TbNamesNamEsImplFixture.cpp
+++ b/goldenmaster/Plugins/TbNames/Source/TbNames/Private/Tests/TbNamesNamEsImplFixture.cpp
@@ -78,9 +78,9 @@ void UTbNamesNamEsImplHelper::SomePoperty2PropertyCb(int32 InSomePoperty2)
 
 void UTbNamesNamEsImplHelper::EnumPropertyPropertyCb(ETbNamesEnum_With_Under_scores InEnumProperty)
 {
-	ETbNamesEnum_With_Under_scores TestValue = ETbNamesEnum_With_Under_scores::TNEWUS_FIRSTVALUE;
+	ETbNamesEnum_With_Under_scores TestValue = ETbNamesEnum_With_Under_scores::TNEWUS_FirstValue;
 	// use different test value
-	TestValue = ETbNamesEnum_With_Under_scores::TNEWUS_SECONDVALUE;
+	TestValue = ETbNamesEnum_With_Under_scores::TNEWUS_SecondValue;
 	Spec->TestEqual(TEXT("Delegate parameter should be the same value as set by the setter"), InEnumProperty, TestValue);
 	if (TSharedPtr<FTbNamesNamEsImplFixture> PinnedImplFixture = ImplFixture.Pin())
 	{

--- a/goldenmaster/Plugins/TbNames/Source/TbNames/Private/Tests/TbNamesNamEsMsgBus.spec.cpp
+++ b/goldenmaster/Plugins/TbNames/Source/TbNames/Private/Tests/TbNamesNamEsMsgBus.spec.cpp
@@ -220,35 +220,35 @@ void UTbNamesNamEsMsgBusSpec::Define()
 	It("Property.EnumProperty.Default", [this]()
 		{
 		// Do implement test here
-		ETbNamesEnum_With_Under_scores TestValue = ETbNamesEnum_With_Under_scores::TNEWUS_FIRSTVALUE; // default value
+		ETbNamesEnum_With_Under_scores TestValue = ETbNamesEnum_With_Under_scores::TNEWUS_FirstValue; // default value
 		TestEqual(TEXT("Getter should return the default value"), ImplFixture->GetImplementation()->Execute_GetEnumProperty(ImplFixture->GetImplementation().GetObject()), TestValue);
 	});
 
 	LatentIt("Property.EnumProperty.Change", EAsyncExecution::ThreadPool, [this](const FDoneDelegate TestDone)
 		{
 		// Do implement test here
-		ETbNamesEnum_With_Under_scores TestValue = ETbNamesEnum_With_Under_scores::TNEWUS_FIRSTVALUE; // default value
+		ETbNamesEnum_With_Under_scores TestValue = ETbNamesEnum_With_Under_scores::TNEWUS_FirstValue; // default value
 		TestEqual(TEXT("Getter should return the default value"), ImplFixture->GetImplementation()->Execute_GetEnumProperty(ImplFixture->GetImplementation().GetObject()), TestValue);
 
 		ImplFixture->GetHelper()->SetTestDone(TestDone);
 		UTbNamesNamEsSignals* TbNamesNamEsSignals = ImplFixture->GetImplementation()->Execute__GetSignals(ImplFixture->GetImplementation().GetObject());
 		TbNamesNamEsSignals->OnEnumPropertyChanged.AddDynamic(ImplFixture->GetHelper().Get(), &UTbNamesNamEsMsgBusHelper::EnumPropertyPropertyCb);
 		// use different test value
-		TestValue = ETbNamesEnum_With_Under_scores::TNEWUS_SECONDVALUE;
+		TestValue = ETbNamesEnum_With_Under_scores::TNEWUS_SecondValue;
 		ImplFixture->GetImplementation()->Execute_SetEnumProperty(ImplFixture->GetImplementation().GetObject(), TestValue);
 	});
 
 	LatentIt("Property.EnumProperty.ChangeLocalCheckRemote", EAsyncExecution::ThreadPool, [this](const FDoneDelegate TestDone)
 		{
 		// Do implement test here
-		ETbNamesEnum_With_Under_scores TestValue = ETbNamesEnum_With_Under_scores::TNEWUS_FIRSTVALUE; // default value
+		ETbNamesEnum_With_Under_scores TestValue = ETbNamesEnum_With_Under_scores::TNEWUS_FirstValue; // default value
 		TestEqual(TEXT("Getter should return the default value"), ImplFixture->GetImplementation()->Execute_GetEnumProperty(ImplFixture->GetImplementation().GetObject()), TestValue);
 
 		ImplFixture->GetHelper()->SetTestDone(TestDone);
 		UTbNamesNamEsSignals* TbNamesNamEsSignals = ImplFixture->GetImplementation()->Execute__GetSignals(ImplFixture->GetImplementation().GetObject());
 		TbNamesNamEsSignals->OnEnumPropertyChanged.AddDynamic(ImplFixture->GetHelper().Get(), &UTbNamesNamEsMsgBusHelper::EnumPropertyPropertyChangeLocalCheckRemoteCb);
 		// use different test value
-		TestValue = ETbNamesEnum_With_Under_scores::TNEWUS_SECONDVALUE;
+		TestValue = ETbNamesEnum_With_Under_scores::TNEWUS_SecondValue;
 		auto service = ImplFixture->GetGameInstance()->GetSubsystem<UTbNamesNamEs>();
 		service->Execute_SetEnumProperty(service, TestValue);
 	});
@@ -256,14 +256,14 @@ void UTbNamesNamEsMsgBusSpec::Define()
 	LatentIt("Property.EnumProperty.ChangeLocalChangeBackRemote", EAsyncExecution::ThreadPool, [this](const FDoneDelegate TestDone)
 		{
 		// Do implement test here
-		ETbNamesEnum_With_Under_scores TestValue = ETbNamesEnum_With_Under_scores::TNEWUS_FIRSTVALUE; // default value
+		ETbNamesEnum_With_Under_scores TestValue = ETbNamesEnum_With_Under_scores::TNEWUS_FirstValue; // default value
 		TestEqual(TEXT("Getter should return the default value"), ImplFixture->GetImplementation()->Execute_GetEnumProperty(ImplFixture->GetImplementation().GetObject()), TestValue);
 
 		ImplFixture->GetHelper()->SetTestDone(TestDone);
 		UTbNamesNamEsSignals* TbNamesNamEsSignals = ImplFixture->GetImplementation()->Execute__GetSignals(ImplFixture->GetImplementation().GetObject());
 		TbNamesNamEsSignals->OnEnumPropertyChanged.AddDynamic(ImplFixture->GetHelper().Get(), &UTbNamesNamEsMsgBusHelper::EnumPropertyPropertyChangeLocalChangeRemoteCb);
 		// use different test value
-		TestValue = ETbNamesEnum_With_Under_scores::TNEWUS_SECONDVALUE;
+		TestValue = ETbNamesEnum_With_Under_scores::TNEWUS_SecondValue;
 		auto service = ImplFixture->GetGameInstance()->GetSubsystem<UTbNamesNamEs>();
 		service->Execute_SetEnumProperty(service, TestValue);
 	});

--- a/goldenmaster/Plugins/TbNames/Source/TbNames/Private/Tests/TbNamesNamEsMsgBusFixture.cpp
+++ b/goldenmaster/Plugins/TbNames/Source/TbNames/Private/Tests/TbNamesNamEsMsgBusFixture.cpp
@@ -237,9 +237,9 @@ void UTbNamesNamEsMsgBusHelper::SomePoperty2PropertyChangeLocalChangeRemoteCb(in
 
 void UTbNamesNamEsMsgBusHelper::EnumPropertyPropertyCb(ETbNamesEnum_With_Under_scores InEnumProperty)
 {
-	ETbNamesEnum_With_Under_scores TestValue = ETbNamesEnum_With_Under_scores::TNEWUS_FIRSTVALUE;
+	ETbNamesEnum_With_Under_scores TestValue = ETbNamesEnum_With_Under_scores::TNEWUS_FirstValue;
 	// use different test value
-	TestValue = ETbNamesEnum_With_Under_scores::TNEWUS_SECONDVALUE;
+	TestValue = ETbNamesEnum_With_Under_scores::TNEWUS_SecondValue;
 	Spec->TestEqual(TEXT("Delegate parameter should be the same value as set by the setter"), InEnumProperty, TestValue);
 	if (TSharedPtr<FTbNamesNamEsMsgBusFixture> PinnedImplFixture = ImplFixture.Pin())
 	{
@@ -250,9 +250,9 @@ void UTbNamesNamEsMsgBusHelper::EnumPropertyPropertyCb(ETbNamesEnum_With_Under_s
 
 void UTbNamesNamEsMsgBusHelper::EnumPropertyPropertyChangeLocalCheckRemoteCb(ETbNamesEnum_With_Under_scores InEnumProperty)
 {
-	ETbNamesEnum_With_Under_scores TestValue = ETbNamesEnum_With_Under_scores::TNEWUS_FIRSTVALUE;
+	ETbNamesEnum_With_Under_scores TestValue = ETbNamesEnum_With_Under_scores::TNEWUS_FirstValue;
 	// use different test value
-	TestValue = ETbNamesEnum_With_Under_scores::TNEWUS_SECONDVALUE;
+	TestValue = ETbNamesEnum_With_Under_scores::TNEWUS_SecondValue;
 	Spec->TestEqual(TEXT("Delegate parameter should be the same value as set by the setter"), InEnumProperty, TestValue);
 	if (TSharedPtr<FTbNamesNamEsMsgBusFixture> PinnedImplFixture = ImplFixture.Pin())
 	{
@@ -271,9 +271,9 @@ void UTbNamesNamEsMsgBusHelper::EnumPropertyPropertyChangeLocalChangeRemoteCb(ET
 
 	if (count % 2 != 0)
 	{
-		ETbNamesEnum_With_Under_scores TestValue = ETbNamesEnum_With_Under_scores::TNEWUS_FIRSTVALUE;
+		ETbNamesEnum_With_Under_scores TestValue = ETbNamesEnum_With_Under_scores::TNEWUS_FirstValue;
 		// use different test value
-		TestValue = ETbNamesEnum_With_Under_scores::TNEWUS_SECONDVALUE;
+		TestValue = ETbNamesEnum_With_Under_scores::TNEWUS_SecondValue;
 		Spec->TestEqual(TEXT("Delegate parameter should be the same value as set by the setter"), InEnumProperty, TestValue);
 		if (TSharedPtr<FTbNamesNamEsMsgBusFixture> PinnedImplFixture = ImplFixture.Pin())
 		{
@@ -281,7 +281,7 @@ void UTbNamesNamEsMsgBusHelper::EnumPropertyPropertyChangeLocalChangeRemoteCb(ET
 		}
 
 		// now set it to the default value
-		TestValue = ETbNamesEnum_With_Under_scores::TNEWUS_FIRSTVALUE; // default value
+		TestValue = ETbNamesEnum_With_Under_scores::TNEWUS_FirstValue; // default value
 		if (TSharedPtr<FTbNamesNamEsMsgBusFixture> PinnedImplFixture = ImplFixture.Pin())
 		{
 			PinnedImplFixture->GetImplementation()->Execute_SetEnumProperty(PinnedImplFixture->GetImplementation().GetObject(), TestValue);
@@ -289,7 +289,7 @@ void UTbNamesNamEsMsgBusHelper::EnumPropertyPropertyChangeLocalChangeRemoteCb(ET
 	}
 	else
 	{
-		ETbNamesEnum_With_Under_scores TestValue = ETbNamesEnum_With_Under_scores::TNEWUS_FIRSTVALUE; // default value
+		ETbNamesEnum_With_Under_scores TestValue = ETbNamesEnum_With_Under_scores::TNEWUS_FirstValue; // default value
 		Spec->TestEqual(TEXT("Delegate parameter should be the same value as set by the setter"), InEnumProperty, TestValue);
 		if (TSharedPtr<FTbNamesNamEsMsgBusFixture> PinnedImplFixture = ImplFixture.Pin())
 		{

--- a/goldenmaster/Plugins/TbNames/Source/TbNames/Private/Tests/TbNamesNamEsOLink.spec.cpp
+++ b/goldenmaster/Plugins/TbNames/Source/TbNames/Private/Tests/TbNamesNamEsOLink.spec.cpp
@@ -238,35 +238,35 @@ void UTbNamesNamEsOLinkSpec::Define()
 	It("Property.EnumProperty.Default", [this]()
 		{
 		// Do implement test here
-		ETbNamesEnum_With_Under_scores TestValue = ETbNamesEnum_With_Under_scores::TNEWUS_FIRSTVALUE; // default value
+		ETbNamesEnum_With_Under_scores TestValue = ETbNamesEnum_With_Under_scores::TNEWUS_FirstValue; // default value
 		TestEqual(TEXT("Getter should return the default value"), ImplFixture->GetImplementation()->Execute_GetEnumProperty(ImplFixture->GetImplementation().GetObject()), TestValue);
 	});
 
 	LatentIt("Property.EnumProperty.Change", EAsyncExecution::ThreadPool, [this](const FDoneDelegate TestDone)
 		{
 		// Do implement test here
-		ETbNamesEnum_With_Under_scores TestValue = ETbNamesEnum_With_Under_scores::TNEWUS_FIRSTVALUE; // default value
+		ETbNamesEnum_With_Under_scores TestValue = ETbNamesEnum_With_Under_scores::TNEWUS_FirstValue; // default value
 		TestEqual(TEXT("Getter should return the default value"), ImplFixture->GetImplementation()->Execute_GetEnumProperty(ImplFixture->GetImplementation().GetObject()), TestValue);
 
 		ImplFixture->GetHelper()->SetTestDone(TestDone);
 		UTbNamesNamEsSignals* TbNamesNamEsSignals = ImplFixture->GetImplementation()->Execute__GetSignals(ImplFixture->GetImplementation().GetObject());
 		TbNamesNamEsSignals->OnEnumPropertyChanged.AddDynamic(ImplFixture->GetHelper().Get(), &UTbNamesNamEsOLinkHelper::EnumPropertyPropertyCb);
 		// use different test value
-		TestValue = ETbNamesEnum_With_Under_scores::TNEWUS_SECONDVALUE;
+		TestValue = ETbNamesEnum_With_Under_scores::TNEWUS_SecondValue;
 		ImplFixture->GetImplementation()->Execute_SetEnumProperty(ImplFixture->GetImplementation().GetObject(), TestValue);
 	});
 
 	LatentIt("Property.EnumProperty.ChangeLocalCheckRemote", EAsyncExecution::ThreadPool, [this](const FDoneDelegate TestDone)
 		{
 		// Do implement test here
-		ETbNamesEnum_With_Under_scores TestValue = ETbNamesEnum_With_Under_scores::TNEWUS_FIRSTVALUE; // default value
+		ETbNamesEnum_With_Under_scores TestValue = ETbNamesEnum_With_Under_scores::TNEWUS_FirstValue; // default value
 		TestEqual(TEXT("Getter should return the default value"), ImplFixture->GetImplementation()->Execute_GetEnumProperty(ImplFixture->GetImplementation().GetObject()), TestValue);
 
 		ImplFixture->GetHelper()->SetTestDone(TestDone);
 		UTbNamesNamEsSignals* TbNamesNamEsSignals = ImplFixture->GetImplementation()->Execute__GetSignals(ImplFixture->GetImplementation().GetObject());
 		TbNamesNamEsSignals->OnEnumPropertyChanged.AddDynamic(ImplFixture->GetHelper().Get(), &UTbNamesNamEsOLinkHelper::EnumPropertyPropertyChangeLocalCheckRemoteCb);
 		// use different test value
-		TestValue = ETbNamesEnum_With_Under_scores::TNEWUS_SECONDVALUE;
+		TestValue = ETbNamesEnum_With_Under_scores::TNEWUS_SecondValue;
 		auto service = ImplFixture->GetGameInstance()->GetSubsystem<UTbNamesNamEs>();
 		service->Execute_SetEnumProperty(service, TestValue);
 	});
@@ -274,14 +274,14 @@ void UTbNamesNamEsOLinkSpec::Define()
 	LatentIt("Property.EnumProperty.ChangeLocalChangeBackRemote", EAsyncExecution::ThreadPool, [this](const FDoneDelegate TestDone)
 		{
 		// Do implement test here
-		ETbNamesEnum_With_Under_scores TestValue = ETbNamesEnum_With_Under_scores::TNEWUS_FIRSTVALUE; // default value
+		ETbNamesEnum_With_Under_scores TestValue = ETbNamesEnum_With_Under_scores::TNEWUS_FirstValue; // default value
 		TestEqual(TEXT("Getter should return the default value"), ImplFixture->GetImplementation()->Execute_GetEnumProperty(ImplFixture->GetImplementation().GetObject()), TestValue);
 
 		ImplFixture->GetHelper()->SetTestDone(TestDone);
 		UTbNamesNamEsSignals* TbNamesNamEsSignals = ImplFixture->GetImplementation()->Execute__GetSignals(ImplFixture->GetImplementation().GetObject());
 		TbNamesNamEsSignals->OnEnumPropertyChanged.AddDynamic(ImplFixture->GetHelper().Get(), &UTbNamesNamEsOLinkHelper::EnumPropertyPropertyChangeLocalChangeRemoteCb);
 		// use different test value
-		TestValue = ETbNamesEnum_With_Under_scores::TNEWUS_SECONDVALUE;
+		TestValue = ETbNamesEnum_With_Under_scores::TNEWUS_SecondValue;
 		auto service = ImplFixture->GetGameInstance()->GetSubsystem<UTbNamesNamEs>();
 		service->Execute_SetEnumProperty(service, TestValue);
 	});

--- a/goldenmaster/Plugins/TbNames/Source/TbNames/Private/Tests/TbNamesNamEsOLinkFixture.cpp
+++ b/goldenmaster/Plugins/TbNames/Source/TbNames/Private/Tests/TbNamesNamEsOLinkFixture.cpp
@@ -234,9 +234,9 @@ void UTbNamesNamEsOLinkHelper::SomePoperty2PropertyChangeLocalChangeRemoteCb(int
 
 void UTbNamesNamEsOLinkHelper::EnumPropertyPropertyCb(ETbNamesEnum_With_Under_scores InEnumProperty)
 {
-	ETbNamesEnum_With_Under_scores TestValue = ETbNamesEnum_With_Under_scores::TNEWUS_FIRSTVALUE;
+	ETbNamesEnum_With_Under_scores TestValue = ETbNamesEnum_With_Under_scores::TNEWUS_FirstValue;
 	// use different test value
-	TestValue = ETbNamesEnum_With_Under_scores::TNEWUS_SECONDVALUE;
+	TestValue = ETbNamesEnum_With_Under_scores::TNEWUS_SecondValue;
 	Spec->TestEqual(TEXT("Delegate parameter should be the same value as set by the setter"), InEnumProperty, TestValue);
 	if (TSharedPtr<FTbNamesNamEsOLinkFixture> PinnedImplFixture = ImplFixture.Pin())
 	{
@@ -247,9 +247,9 @@ void UTbNamesNamEsOLinkHelper::EnumPropertyPropertyCb(ETbNamesEnum_With_Under_sc
 
 void UTbNamesNamEsOLinkHelper::EnumPropertyPropertyChangeLocalCheckRemoteCb(ETbNamesEnum_With_Under_scores InEnumProperty)
 {
-	ETbNamesEnum_With_Under_scores TestValue = ETbNamesEnum_With_Under_scores::TNEWUS_FIRSTVALUE;
+	ETbNamesEnum_With_Under_scores TestValue = ETbNamesEnum_With_Under_scores::TNEWUS_FirstValue;
 	// use different test value
-	TestValue = ETbNamesEnum_With_Under_scores::TNEWUS_SECONDVALUE;
+	TestValue = ETbNamesEnum_With_Under_scores::TNEWUS_SecondValue;
 	Spec->TestEqual(TEXT("Delegate parameter should be the same value as set by the setter"), InEnumProperty, TestValue);
 	if (TSharedPtr<FTbNamesNamEsOLinkFixture> PinnedImplFixture = ImplFixture.Pin())
 	{
@@ -268,9 +268,9 @@ void UTbNamesNamEsOLinkHelper::EnumPropertyPropertyChangeLocalChangeRemoteCb(ETb
 
 	if (count % 2 != 0)
 	{
-		ETbNamesEnum_With_Under_scores TestValue = ETbNamesEnum_With_Under_scores::TNEWUS_FIRSTVALUE;
+		ETbNamesEnum_With_Under_scores TestValue = ETbNamesEnum_With_Under_scores::TNEWUS_FirstValue;
 		// use different test value
-		TestValue = ETbNamesEnum_With_Under_scores::TNEWUS_SECONDVALUE;
+		TestValue = ETbNamesEnum_With_Under_scores::TNEWUS_SecondValue;
 		Spec->TestEqual(TEXT("Delegate parameter should be the same value as set by the setter"), InEnumProperty, TestValue);
 		if (TSharedPtr<FTbNamesNamEsOLinkFixture> PinnedImplFixture = ImplFixture.Pin())
 		{
@@ -278,7 +278,7 @@ void UTbNamesNamEsOLinkHelper::EnumPropertyPropertyChangeLocalChangeRemoteCb(ETb
 		}
 
 		// now set it to the default value
-		TestValue = ETbNamesEnum_With_Under_scores::TNEWUS_FIRSTVALUE; // default value
+		TestValue = ETbNamesEnum_With_Under_scores::TNEWUS_FirstValue; // default value
 		if (TSharedPtr<FTbNamesNamEsOLinkFixture> PinnedImplFixture = ImplFixture.Pin())
 		{
 			PinnedImplFixture->GetImplementation()->Execute_SetEnumProperty(PinnedImplFixture->GetImplementation().GetObject(), TestValue);
@@ -286,7 +286,7 @@ void UTbNamesNamEsOLinkHelper::EnumPropertyPropertyChangeLocalChangeRemoteCb(ETb
 	}
 	else
 	{
-		ETbNamesEnum_With_Under_scores TestValue = ETbNamesEnum_With_Under_scores::TNEWUS_FIRSTVALUE; // default value
+		ETbNamesEnum_With_Under_scores TestValue = ETbNamesEnum_With_Under_scores::TNEWUS_FirstValue; // default value
 		Spec->TestEqual(TEXT("Delegate parameter should be the same value as set by the setter"), InEnumProperty, TestValue);
 		if (TSharedPtr<FTbNamesNamEsOLinkFixture> PinnedImplFixture = ImplFixture.Pin())
 		{

--- a/goldenmaster/Plugins/TbNames/Source/TbNames/Public/Generated/MsgBus/TbNamesNamEsMsgBusMessages.h
+++ b/goldenmaster/Plugins/TbNames/Source/TbNames/Public/Generated/MsgBus/TbNamesNamEsMsgBusMessages.h
@@ -61,7 +61,7 @@ struct FTbNamesNamEsInitMessage
 	int32 SomePoperty2 = 0;
 
 	UPROPERTY()
-	ETbNamesEnum_With_Under_scores EnumProperty = ETbNamesEnum_With_Under_scores::TNEWUS_FIRSTVALUE;
+	ETbNamesEnum_With_Under_scores EnumProperty = ETbNamesEnum_With_Under_scores::TNEWUS_FirstValue;
 };
 
 USTRUCT()
@@ -172,7 +172,7 @@ struct FTbNamesNamEsSetEnumPropertyRequestMessage
 	GENERATED_BODY()
 
 	UPROPERTY()
-	ETbNamesEnum_With_Under_scores EnumProperty = ETbNamesEnum_With_Under_scores::TNEWUS_FIRSTVALUE;
+	ETbNamesEnum_With_Under_scores EnumProperty = ETbNamesEnum_With_Under_scores::TNEWUS_FirstValue;
 };
 
 USTRUCT()
@@ -181,7 +181,7 @@ struct FTbNamesNamEsEnumPropertyChangedMessage
 	GENERATED_BODY()
 
 	UPROPERTY()
-	ETbNamesEnum_With_Under_scores EnumProperty = ETbNamesEnum_With_Under_scores::TNEWUS_FIRSTVALUE;
+	ETbNamesEnum_With_Under_scores EnumProperty = ETbNamesEnum_With_Under_scores::TNEWUS_FirstValue;
 };
 
 USTRUCT()

--- a/goldenmaster/Plugins/TbNames/Source/TbNames/Public/Generated/api/AbstractTbNamesNamEs.h
+++ b/goldenmaster/Plugins/TbNames/Source/TbNames/Public/Generated/api/AbstractTbNamesNamEs.h
@@ -55,7 +55,7 @@ public:
 	virtual int32 GetSomePoperty2_Implementation() const override PURE_VIRTUAL(UAbstractTbNamesNamEs::GetSomePoperty2_Implementation, return 0;);
 	virtual void SetSomePoperty2_Implementation(int32 InSomePoperty2) override PURE_VIRTUAL(UAbstractTbNamesNamEs::SetSomePoperty2_Implementation, return;);
 
-	virtual ETbNamesEnum_With_Under_scores GetEnumProperty_Implementation() const override PURE_VIRTUAL(UAbstractTbNamesNamEs::GetEnumProperty_Implementation, return ETbNamesEnum_With_Under_scores::TNEWUS_FIRSTVALUE;);
+	virtual ETbNamesEnum_With_Under_scores GetEnumProperty_Implementation() const override PURE_VIRTUAL(UAbstractTbNamesNamEs::GetEnumProperty_Implementation, return ETbNamesEnum_With_Under_scores::TNEWUS_FirstValue;);
 	virtual void SetEnumProperty_Implementation(ETbNamesEnum_With_Under_scores InEnumProperty) override PURE_VIRTUAL(UAbstractTbNamesNamEs::SetEnumProperty_Implementation, return;);
 
 	virtual bool IsInitialized() const;
@@ -92,7 +92,7 @@ protected:
 	void SetSomePoperty2_Private(int32 InSomePoperty2);
 
 	UPROPERTY(EditAnywhere, BlueprintGetter = GetEnumProperty_Private, BlueprintSetter = SetEnumProperty_Private, Category = "ApiGear|TbNames|NamEs")
-	ETbNamesEnum_With_Under_scores EnumProperty{ETbNamesEnum_With_Under_scores::TNEWUS_FIRSTVALUE};
+	ETbNamesEnum_With_Under_scores EnumProperty{ETbNamesEnum_With_Under_scores::TNEWUS_FirstValue};
 
 	UFUNCTION(BlueprintGetter, Category = "ApiGear|TbNames|NamEs|Properties", BlueprintInternalUseOnly)
 	ETbNamesEnum_With_Under_scores GetEnumProperty_Private() const;

--- a/goldenmaster/Plugins/TbNames/Source/TbNames/Public/Generated/api/TbNames_data.h
+++ b/goldenmaster/Plugins/TbNames/Source/TbNames/Public/Generated/api/TbNames_data.h
@@ -28,9 +28,9 @@ limitations under the License.
 UENUM(BlueprintType)
 enum class ETbNamesEnum_With_Under_scores : uint8
 {
-	TNEWUS_FIRSTVALUE = 0 UMETA(Displayname = "First_Value"),
-	TNEWUS_SECONDVALUE = 1 UMETA(Displayname = "second_value"),
-	TNEWUS_THIRDVALUE = 2 UMETA(Displayname = "third_Value")
+	TNEWUS_FirstValue = 0 UMETA(Displayname = "First_Value"),
+	TNEWUS_SecondValue = 1 UMETA(Displayname = "second_value"),
+	TNEWUS_ThirdValue = 2 UMETA(Displayname = "third_Value")
 };
 
 /**

--- a/goldenmaster/Plugins/TbSame1/Source/TbSame1/Private/Generated/MsgBus/TbSame1SameEnum1InterfaceMsgBusClient.cpp
+++ b/goldenmaster/Plugins/TbSame1/Source/TbSame1/Private/Generated/MsgBus/TbSame1SameEnum1InterfaceMsgBusClient.cpp
@@ -37,7 +37,7 @@ limitations under the License.
 */
 struct TbSame1SameEnum1InterfacePropertiesMsgBusData
 {
-	std::atomic<ETbSame1Enum1> Prop1{ETbSame1Enum1::TS1E1_VALUE1};
+	std::atomic<ETbSame1Enum1> Prop1{ETbSame1Enum1::TS1E1_Value1};
 };
 DEFINE_LOG_CATEGORY(LogTbSame1SameEnum1InterfaceMsgBusClient);
 
@@ -335,7 +335,7 @@ ETbSame1Enum1 UTbSame1SameEnum1InterfaceMsgBusClient::Func1_Implementation(ETbSa
 	{
 		UE_LOG(LogTbSame1SameEnum1InterfaceMsgBusClient, Error, TEXT("Client has no connection to service."));
 
-		return ETbSame1Enum1::TS1E1_VALUE1;
+		return ETbSame1Enum1::TS1E1_Value1;
 	}
 
 	auto msg = new FTbSame1SameEnum1InterfaceFunc1RequestMessage();

--- a/goldenmaster/Plugins/TbSame1/Source/TbSame1/Private/Generated/MsgBus/TbSame1SameEnum2InterfaceMsgBusClient.cpp
+++ b/goldenmaster/Plugins/TbSame1/Source/TbSame1/Private/Generated/MsgBus/TbSame1SameEnum2InterfaceMsgBusClient.cpp
@@ -37,8 +37,8 @@ limitations under the License.
 */
 struct TbSame1SameEnum2InterfacePropertiesMsgBusData
 {
-	std::atomic<ETbSame1Enum1> Prop1{ETbSame1Enum1::TS1E1_VALUE1};
-	std::atomic<ETbSame1Enum2> Prop2{ETbSame1Enum2::TS1E2_VALUE1};
+	std::atomic<ETbSame1Enum1> Prop1{ETbSame1Enum1::TS1E1_Value1};
+	std::atomic<ETbSame1Enum2> Prop2{ETbSame1Enum2::TS1E2_Value1};
 };
 DEFINE_LOG_CATEGORY(LogTbSame1SameEnum2InterfaceMsgBusClient);
 
@@ -384,7 +384,7 @@ ETbSame1Enum1 UTbSame1SameEnum2InterfaceMsgBusClient::Func1_Implementation(ETbSa
 	{
 		UE_LOG(LogTbSame1SameEnum2InterfaceMsgBusClient, Error, TEXT("Client has no connection to service."));
 
-		return ETbSame1Enum1::TS1E1_VALUE1;
+		return ETbSame1Enum1::TS1E1_Value1;
 	}
 
 	auto msg = new FTbSame1SameEnum2InterfaceFunc1RequestMessage();
@@ -413,7 +413,7 @@ ETbSame1Enum1 UTbSame1SameEnum2InterfaceMsgBusClient::Func2_Implementation(ETbSa
 	{
 		UE_LOG(LogTbSame1SameEnum2InterfaceMsgBusClient, Error, TEXT("Client has no connection to service."));
 
-		return ETbSame1Enum1::TS1E1_VALUE1;
+		return ETbSame1Enum1::TS1E1_Value1;
 	}
 
 	auto msg = new FTbSame1SameEnum2InterfaceFunc2RequestMessage();

--- a/goldenmaster/Plugins/TbSame1/Source/TbSame1/Private/Generated/OLink/TbSame1SameEnum1InterfaceOLinkClient.cpp
+++ b/goldenmaster/Plugins/TbSame1/Source/TbSame1/Private/Generated/OLink/TbSame1SameEnum1InterfaceOLinkClient.cpp
@@ -42,7 +42,7 @@ THIRD_PARTY_INCLUDES_END
 */
 struct TbSame1SameEnum1InterfacePropertiesData
 {
-	std::atomic<ETbSame1Enum1> Prop1{ETbSame1Enum1::TS1E1_VALUE1};
+	std::atomic<ETbSame1Enum1> Prop1{ETbSame1Enum1::TS1E1_Value1};
 };
 DEFINE_LOG_CATEGORY(LogTbSame1SameEnum1InterfaceOLinkClient);
 
@@ -185,7 +185,7 @@ ETbSame1Enum1 UTbSame1SameEnum1InterfaceOLinkClient::Func1_Implementation(ETbSam
 	{
 		UE_LOG(LogTbSame1SameEnum1InterfaceOLinkClient, Error, TEXT("%s has no node. Probably no valid connection or service. Are the ApiGear TbSame1 plugin settings correct? Service set up correctly?"), UTF8_TO_TCHAR(m_sink->olinkObjectName().c_str()));
 
-		return ETbSame1Enum1::TS1E1_VALUE1;
+		return ETbSame1Enum1::TS1E1_Value1;
 	}
 	TPromise<ETbSame1Enum1> Promise;
 	Async(EAsyncExecution::ThreadPool,

--- a/goldenmaster/Plugins/TbSame1/Source/TbSame1/Private/Generated/OLink/TbSame1SameEnum2InterfaceOLinkClient.cpp
+++ b/goldenmaster/Plugins/TbSame1/Source/TbSame1/Private/Generated/OLink/TbSame1SameEnum2InterfaceOLinkClient.cpp
@@ -42,8 +42,8 @@ THIRD_PARTY_INCLUDES_END
 */
 struct TbSame1SameEnum2InterfacePropertiesData
 {
-	std::atomic<ETbSame1Enum1> Prop1{ETbSame1Enum1::TS1E1_VALUE1};
-	std::atomic<ETbSame1Enum2> Prop2{ETbSame1Enum2::TS1E2_VALUE1};
+	std::atomic<ETbSame1Enum1> Prop1{ETbSame1Enum1::TS1E1_Value1};
+	std::atomic<ETbSame1Enum2> Prop2{ETbSame1Enum2::TS1E2_Value1};
 };
 DEFINE_LOG_CATEGORY(LogTbSame1SameEnum2InterfaceOLinkClient);
 
@@ -215,7 +215,7 @@ ETbSame1Enum1 UTbSame1SameEnum2InterfaceOLinkClient::Func1_Implementation(ETbSam
 	{
 		UE_LOG(LogTbSame1SameEnum2InterfaceOLinkClient, Error, TEXT("%s has no node. Probably no valid connection or service. Are the ApiGear TbSame1 plugin settings correct? Service set up correctly?"), UTF8_TO_TCHAR(m_sink->olinkObjectName().c_str()));
 
-		return ETbSame1Enum1::TS1E1_VALUE1;
+		return ETbSame1Enum1::TS1E1_Value1;
 	}
 	TPromise<ETbSame1Enum1> Promise;
 	Async(EAsyncExecution::ThreadPool,
@@ -246,7 +246,7 @@ ETbSame1Enum1 UTbSame1SameEnum2InterfaceOLinkClient::Func2_Implementation(ETbSam
 	{
 		UE_LOG(LogTbSame1SameEnum2InterfaceOLinkClient, Error, TEXT("%s has no node. Probably no valid connection or service. Are the ApiGear TbSame1 plugin settings correct? Service set up correctly?"), UTF8_TO_TCHAR(m_sink->olinkObjectName().c_str()));
 
-		return ETbSame1Enum1::TS1E1_VALUE1;
+		return ETbSame1Enum1::TS1E1_Value1;
 	}
 	TPromise<ETbSame1Enum1> Promise;
 	Async(EAsyncExecution::ThreadPool,

--- a/goldenmaster/Plugins/TbSame1/Source/TbSame1/Private/Generated/api/TbSame1_data.cpp
+++ b/goldenmaster/Plugins/TbSame1/Source/TbSame1/Private/Generated/api/TbSame1_data.cpp
@@ -27,15 +27,15 @@ bool UTbSame1Library::toTbSame1Enum1(ETbSame1Enum1& ConvertedEnum, uint8 InValue
 	switch (InValue)
 	{
 	case 1:
-		ConvertedEnum = ETbSame1Enum1::TS1E1_VALUE1;
+		ConvertedEnum = ETbSame1Enum1::TS1E1_Value1;
 		bSuccessful = true;
 		break;
 	case 2:
-		ConvertedEnum = ETbSame1Enum1::TS1E1_VALUE2;
+		ConvertedEnum = ETbSame1Enum1::TS1E1_Value2;
 		bSuccessful = true;
 		break;
 	default:
-		ConvertedEnum = ETbSame1Enum1::TS1E1_VALUE1;
+		ConvertedEnum = ETbSame1Enum1::TS1E1_Value1;
 	}
 	return bSuccessful;
 }
@@ -48,15 +48,15 @@ bool UTbSame1Library::toTbSame1Enum2(ETbSame1Enum2& ConvertedEnum, uint8 InValue
 	switch (InValue)
 	{
 	case 1:
-		ConvertedEnum = ETbSame1Enum2::TS1E2_VALUE1;
+		ConvertedEnum = ETbSame1Enum2::TS1E2_Value1;
 		bSuccessful = true;
 		break;
 	case 2:
-		ConvertedEnum = ETbSame1Enum2::TS1E2_VALUE2;
+		ConvertedEnum = ETbSame1Enum2::TS1E2_Value2;
 		bSuccessful = true;
 		break;
 	default:
-		ConvertedEnum = ETbSame1Enum2::TS1E2_VALUE1;
+		ConvertedEnum = ETbSame1Enum2::TS1E2_Value1;
 	}
 	return bSuccessful;
 }

--- a/goldenmaster/Plugins/TbSame1/Source/TbSame1/Private/Implementation/TbSame1SameEnum1Interface.cpp
+++ b/goldenmaster/Plugins/TbSame1/Source/TbSame1/Private/Implementation/TbSame1SameEnum1Interface.cpp
@@ -36,14 +36,14 @@ ETbSame1Enum1 UTbSame1SameEnum1Interface::Func1_Implementation(ETbSame1Enum1 Par
 {
 	(void)Param1;
 	// do business logic here
-	return ETbSame1Enum1::TS1E1_VALUE1;
+	return ETbSame1Enum1::TS1E1_Value1;
 }
 
 void UTbSame1SameEnum1Interface::_ResetProperties()
 {
-	if (Prop1 != ETbSame1Enum1::TS1E1_VALUE1)
+	if (Prop1 != ETbSame1Enum1::TS1E1_Value1)
 	{
-		Prop1 = ETbSame1Enum1::TS1E1_VALUE1;
+		Prop1 = ETbSame1Enum1::TS1E1_Value1;
 		Execute__GetSignals(this)->OnProp1Changed.Broadcast(Prop1);
 	}
 }

--- a/goldenmaster/Plugins/TbSame1/Source/TbSame1/Private/Implementation/TbSame1SameEnum2Interface.cpp
+++ b/goldenmaster/Plugins/TbSame1/Source/TbSame1/Private/Implementation/TbSame1SameEnum2Interface.cpp
@@ -49,7 +49,7 @@ ETbSame1Enum1 UTbSame1SameEnum2Interface::Func1_Implementation(ETbSame1Enum1 Par
 {
 	(void)Param1;
 	// do business logic here
-	return ETbSame1Enum1::TS1E1_VALUE1;
+	return ETbSame1Enum1::TS1E1_Value1;
 }
 
 ETbSame1Enum1 UTbSame1SameEnum2Interface::Func2_Implementation(ETbSame1Enum1 Param1, ETbSame1Enum2 Param2)
@@ -57,19 +57,19 @@ ETbSame1Enum1 UTbSame1SameEnum2Interface::Func2_Implementation(ETbSame1Enum1 Par
 	(void)Param1;
 	(void)Param2;
 	// do business logic here
-	return ETbSame1Enum1::TS1E1_VALUE1;
+	return ETbSame1Enum1::TS1E1_Value1;
 }
 
 void UTbSame1SameEnum2Interface::_ResetProperties()
 {
-	if (Prop1 != ETbSame1Enum1::TS1E1_VALUE1)
+	if (Prop1 != ETbSame1Enum1::TS1E1_Value1)
 	{
-		Prop1 = ETbSame1Enum1::TS1E1_VALUE1;
+		Prop1 = ETbSame1Enum1::TS1E1_Value1;
 		Execute__GetSignals(this)->OnProp1Changed.Broadcast(Prop1);
 	}
-	if (Prop2 != ETbSame1Enum2::TS1E2_VALUE1)
+	if (Prop2 != ETbSame1Enum2::TS1E2_Value1)
 	{
-		Prop2 = ETbSame1Enum2::TS1E2_VALUE1;
+		Prop2 = ETbSame1Enum2::TS1E2_Value1;
 		Execute__GetSignals(this)->OnProp2Changed.Broadcast(Prop2);
 	}
 }

--- a/goldenmaster/Plugins/TbSame1/Source/TbSame1/Private/Tests/TbSame1SameEnum1InterfaceImpl.spec.cpp
+++ b/goldenmaster/Plugins/TbSame1/Source/TbSame1/Private/Tests/TbSame1SameEnum1InterfaceImpl.spec.cpp
@@ -50,28 +50,28 @@ void UTbSame1SameEnum1InterfaceImplSpec::Define()
 	It("Property.Prop1.Default", [this]()
 		{
 		// Do implement test here
-		ETbSame1Enum1 TestValue = ETbSame1Enum1::TS1E1_VALUE1; // default value
+		ETbSame1Enum1 TestValue = ETbSame1Enum1::TS1E1_Value1; // default value
 		TestEqual(TEXT("Getter should return the default value"), ImplFixture->GetImplementation()->Execute_GetProp1(ImplFixture->GetImplementation().GetObject()), TestValue);
 	});
 
 	LatentIt("Property.Prop1.Change", EAsyncExecution::ThreadPool, [this](const FDoneDelegate TestDone)
 		{
 		// Do implement test here
-		ETbSame1Enum1 TestValue = ETbSame1Enum1::TS1E1_VALUE1; // default value
+		ETbSame1Enum1 TestValue = ETbSame1Enum1::TS1E1_Value1; // default value
 		TestEqual(TEXT("Getter should return the default value"), ImplFixture->GetImplementation()->Execute_GetProp1(ImplFixture->GetImplementation().GetObject()), TestValue);
 
 		ImplFixture->GetHelper()->SetTestDone(TestDone);
 		UTbSame1SameEnum1InterfaceSignals* TbSame1SameEnum1InterfaceSignals = ImplFixture->GetImplementation()->Execute__GetSignals(ImplFixture->GetImplementation().GetObject());
 		TbSame1SameEnum1InterfaceSignals->OnProp1Changed.AddDynamic(ImplFixture->GetHelper().Get(), &UTbSame1SameEnum1InterfaceImplHelper::Prop1PropertyCb);
 		// use different test value
-		TestValue = ETbSame1Enum1::TS1E1_VALUE2;
+		TestValue = ETbSame1Enum1::TS1E1_Value2;
 		ImplFixture->GetImplementation()->Execute_SetProp1(ImplFixture->GetImplementation().GetObject(), TestValue);
 	});
 
 	It("Operation.Func1", [this]()
 		{
 		// Do implement test here
-		ImplFixture->GetImplementation()->Execute_Func1(ImplFixture->GetImplementation().GetObject(), ETbSame1Enum1::TS1E1_VALUE1);
+		ImplFixture->GetImplementation()->Execute_Func1(ImplFixture->GetImplementation().GetObject(), ETbSame1Enum1::TS1E1_Value1);
 	});
 
 	LatentIt("Signal.Sig1", EAsyncExecution::ThreadPool, [this](const FDoneDelegate TestDone)
@@ -81,7 +81,7 @@ void UTbSame1SameEnum1InterfaceImplSpec::Define()
 		TbSame1SameEnum1InterfaceSignals->OnSig1Signal.AddDynamic(ImplFixture->GetHelper().Get(), &UTbSame1SameEnum1InterfaceImplHelper::Sig1SignalCb);
 
 		// use different test value
-		ETbSame1Enum1 Param1TestValue = ETbSame1Enum1::TS1E1_VALUE2;
+		ETbSame1Enum1 Param1TestValue = ETbSame1Enum1::TS1E1_Value2;
 		TbSame1SameEnum1InterfaceSignals->BroadcastSig1Signal(Param1TestValue);
 	});
 }

--- a/goldenmaster/Plugins/TbSame1/Source/TbSame1/Private/Tests/TbSame1SameEnum1InterfaceImplFixture.cpp
+++ b/goldenmaster/Plugins/TbSame1/Source/TbSame1/Private/Tests/TbSame1SameEnum1InterfaceImplFixture.cpp
@@ -39,9 +39,9 @@ void UTbSame1SameEnum1InterfaceImplHelper::SetTestDone(const FDoneDelegate& InDo
 
 void UTbSame1SameEnum1InterfaceImplHelper::Prop1PropertyCb(ETbSame1Enum1 InProp1)
 {
-	ETbSame1Enum1 TestValue = ETbSame1Enum1::TS1E1_VALUE1;
+	ETbSame1Enum1 TestValue = ETbSame1Enum1::TS1E1_Value1;
 	// use different test value
-	TestValue = ETbSame1Enum1::TS1E1_VALUE2;
+	TestValue = ETbSame1Enum1::TS1E1_Value2;
 	Spec->TestEqual(TEXT("Delegate parameter should be the same value as set by the setter"), InProp1, TestValue);
 	if (TSharedPtr<FTbSame1SameEnum1InterfaceImplFixture> PinnedImplFixture = ImplFixture.Pin())
 	{
@@ -53,7 +53,7 @@ void UTbSame1SameEnum1InterfaceImplHelper::Prop1PropertyCb(ETbSame1Enum1 InProp1
 void UTbSame1SameEnum1InterfaceImplHelper::Sig1SignalCb(ETbSame1Enum1 InParam1)
 {
 	// known test value
-	ETbSame1Enum1 Param1TestValue = ETbSame1Enum1::TS1E1_VALUE2;
+	ETbSame1Enum1 Param1TestValue = ETbSame1Enum1::TS1E1_Value2;
 	Spec->TestEqual(TEXT("Parameter should be the same value as sent by the signal"), InParam1, Param1TestValue);
 	testDoneDelegate.Execute();
 }

--- a/goldenmaster/Plugins/TbSame1/Source/TbSame1/Private/Tests/TbSame1SameEnum1InterfaceMsgBus.spec.cpp
+++ b/goldenmaster/Plugins/TbSame1/Source/TbSame1/Private/Tests/TbSame1SameEnum1InterfaceMsgBus.spec.cpp
@@ -67,35 +67,35 @@ void UTbSame1SameEnum1InterfaceMsgBusSpec::Define()
 	It("Property.Prop1.Default", [this]()
 		{
 		// Do implement test here
-		ETbSame1Enum1 TestValue = ETbSame1Enum1::TS1E1_VALUE1; // default value
+		ETbSame1Enum1 TestValue = ETbSame1Enum1::TS1E1_Value1; // default value
 		TestEqual(TEXT("Getter should return the default value"), ImplFixture->GetImplementation()->Execute_GetProp1(ImplFixture->GetImplementation().GetObject()), TestValue);
 	});
 
 	LatentIt("Property.Prop1.Change", EAsyncExecution::ThreadPool, [this](const FDoneDelegate TestDone)
 		{
 		// Do implement test here
-		ETbSame1Enum1 TestValue = ETbSame1Enum1::TS1E1_VALUE1; // default value
+		ETbSame1Enum1 TestValue = ETbSame1Enum1::TS1E1_Value1; // default value
 		TestEqual(TEXT("Getter should return the default value"), ImplFixture->GetImplementation()->Execute_GetProp1(ImplFixture->GetImplementation().GetObject()), TestValue);
 
 		ImplFixture->GetHelper()->SetTestDone(TestDone);
 		UTbSame1SameEnum1InterfaceSignals* TbSame1SameEnum1InterfaceSignals = ImplFixture->GetImplementation()->Execute__GetSignals(ImplFixture->GetImplementation().GetObject());
 		TbSame1SameEnum1InterfaceSignals->OnProp1Changed.AddDynamic(ImplFixture->GetHelper().Get(), &UTbSame1SameEnum1InterfaceMsgBusHelper::Prop1PropertyCb);
 		// use different test value
-		TestValue = ETbSame1Enum1::TS1E1_VALUE2;
+		TestValue = ETbSame1Enum1::TS1E1_Value2;
 		ImplFixture->GetImplementation()->Execute_SetProp1(ImplFixture->GetImplementation().GetObject(), TestValue);
 	});
 
 	LatentIt("Property.Prop1.ChangeLocalCheckRemote", EAsyncExecution::ThreadPool, [this](const FDoneDelegate TestDone)
 		{
 		// Do implement test here
-		ETbSame1Enum1 TestValue = ETbSame1Enum1::TS1E1_VALUE1; // default value
+		ETbSame1Enum1 TestValue = ETbSame1Enum1::TS1E1_Value1; // default value
 		TestEqual(TEXT("Getter should return the default value"), ImplFixture->GetImplementation()->Execute_GetProp1(ImplFixture->GetImplementation().GetObject()), TestValue);
 
 		ImplFixture->GetHelper()->SetTestDone(TestDone);
 		UTbSame1SameEnum1InterfaceSignals* TbSame1SameEnum1InterfaceSignals = ImplFixture->GetImplementation()->Execute__GetSignals(ImplFixture->GetImplementation().GetObject());
 		TbSame1SameEnum1InterfaceSignals->OnProp1Changed.AddDynamic(ImplFixture->GetHelper().Get(), &UTbSame1SameEnum1InterfaceMsgBusHelper::Prop1PropertyChangeLocalCheckRemoteCb);
 		// use different test value
-		TestValue = ETbSame1Enum1::TS1E1_VALUE2;
+		TestValue = ETbSame1Enum1::TS1E1_Value2;
 		auto service = ImplFixture->GetGameInstance()->GetSubsystem<UTbSame1SameEnum1Interface>();
 		service->Execute_SetProp1(service, TestValue);
 	});
@@ -103,14 +103,14 @@ void UTbSame1SameEnum1InterfaceMsgBusSpec::Define()
 	LatentIt("Property.Prop1.ChangeLocalChangeBackRemote", EAsyncExecution::ThreadPool, [this](const FDoneDelegate TestDone)
 		{
 		// Do implement test here
-		ETbSame1Enum1 TestValue = ETbSame1Enum1::TS1E1_VALUE1; // default value
+		ETbSame1Enum1 TestValue = ETbSame1Enum1::TS1E1_Value1; // default value
 		TestEqual(TEXT("Getter should return the default value"), ImplFixture->GetImplementation()->Execute_GetProp1(ImplFixture->GetImplementation().GetObject()), TestValue);
 
 		ImplFixture->GetHelper()->SetTestDone(TestDone);
 		UTbSame1SameEnum1InterfaceSignals* TbSame1SameEnum1InterfaceSignals = ImplFixture->GetImplementation()->Execute__GetSignals(ImplFixture->GetImplementation().GetObject());
 		TbSame1SameEnum1InterfaceSignals->OnProp1Changed.AddDynamic(ImplFixture->GetHelper().Get(), &UTbSame1SameEnum1InterfaceMsgBusHelper::Prop1PropertyChangeLocalChangeRemoteCb);
 		// use different test value
-		TestValue = ETbSame1Enum1::TS1E1_VALUE2;
+		TestValue = ETbSame1Enum1::TS1E1_Value2;
 		auto service = ImplFixture->GetGameInstance()->GetSubsystem<UTbSame1SameEnum1Interface>();
 		service->Execute_SetProp1(service, TestValue);
 	});
@@ -120,7 +120,7 @@ void UTbSame1SameEnum1InterfaceMsgBusSpec::Define()
 		// Do implement test here
 		AsyncTask(ENamedThreads::AnyThread, [this, TestDone]()
 			{
-			ImplFixture->GetImplementation()->Execute_Func1(ImplFixture->GetImplementation().GetObject(), ETbSame1Enum1::TS1E1_VALUE1);
+			ImplFixture->GetImplementation()->Execute_Func1(ImplFixture->GetImplementation().GetObject(), ETbSame1Enum1::TS1E1_Value1);
 			TestDone.Execute();
 		});
 	});
@@ -132,7 +132,7 @@ void UTbSame1SameEnum1InterfaceMsgBusSpec::Define()
 		TbSame1SameEnum1InterfaceSignals->OnSig1Signal.AddDynamic(ImplFixture->GetHelper().Get(), &UTbSame1SameEnum1InterfaceMsgBusHelper::Sig1SignalCb);
 
 		// use different test value
-		ETbSame1Enum1 Param1TestValue = ETbSame1Enum1::TS1E1_VALUE2;
+		ETbSame1Enum1 Param1TestValue = ETbSame1Enum1::TS1E1_Value2;
 		TbSame1SameEnum1InterfaceSignals->BroadcastSig1Signal(Param1TestValue);
 	});
 }

--- a/goldenmaster/Plugins/TbSame1/Source/TbSame1/Private/Tests/TbSame1SameEnum1InterfaceMsgBusFixture.cpp
+++ b/goldenmaster/Plugins/TbSame1/Source/TbSame1/Private/Tests/TbSame1SameEnum1InterfaceMsgBusFixture.cpp
@@ -45,9 +45,9 @@ void UTbSame1SameEnum1InterfaceMsgBusHelper::SetTestDone(const FDoneDelegate& In
 
 void UTbSame1SameEnum1InterfaceMsgBusHelper::Prop1PropertyCb(ETbSame1Enum1 InProp1)
 {
-	ETbSame1Enum1 TestValue = ETbSame1Enum1::TS1E1_VALUE1;
+	ETbSame1Enum1 TestValue = ETbSame1Enum1::TS1E1_Value1;
 	// use different test value
-	TestValue = ETbSame1Enum1::TS1E1_VALUE2;
+	TestValue = ETbSame1Enum1::TS1E1_Value2;
 	Spec->TestEqual(TEXT("Delegate parameter should be the same value as set by the setter"), InProp1, TestValue);
 	if (TSharedPtr<FTbSame1SameEnum1InterfaceMsgBusFixture> PinnedImplFixture = ImplFixture.Pin())
 	{
@@ -58,9 +58,9 @@ void UTbSame1SameEnum1InterfaceMsgBusHelper::Prop1PropertyCb(ETbSame1Enum1 InPro
 
 void UTbSame1SameEnum1InterfaceMsgBusHelper::Prop1PropertyChangeLocalCheckRemoteCb(ETbSame1Enum1 InProp1)
 {
-	ETbSame1Enum1 TestValue = ETbSame1Enum1::TS1E1_VALUE1;
+	ETbSame1Enum1 TestValue = ETbSame1Enum1::TS1E1_Value1;
 	// use different test value
-	TestValue = ETbSame1Enum1::TS1E1_VALUE2;
+	TestValue = ETbSame1Enum1::TS1E1_Value2;
 	Spec->TestEqual(TEXT("Delegate parameter should be the same value as set by the setter"), InProp1, TestValue);
 	if (TSharedPtr<FTbSame1SameEnum1InterfaceMsgBusFixture> PinnedImplFixture = ImplFixture.Pin())
 	{
@@ -79,9 +79,9 @@ void UTbSame1SameEnum1InterfaceMsgBusHelper::Prop1PropertyChangeLocalChangeRemot
 
 	if (count % 2 != 0)
 	{
-		ETbSame1Enum1 TestValue = ETbSame1Enum1::TS1E1_VALUE1;
+		ETbSame1Enum1 TestValue = ETbSame1Enum1::TS1E1_Value1;
 		// use different test value
-		TestValue = ETbSame1Enum1::TS1E1_VALUE2;
+		TestValue = ETbSame1Enum1::TS1E1_Value2;
 		Spec->TestEqual(TEXT("Delegate parameter should be the same value as set by the setter"), InProp1, TestValue);
 		if (TSharedPtr<FTbSame1SameEnum1InterfaceMsgBusFixture> PinnedImplFixture = ImplFixture.Pin())
 		{
@@ -89,7 +89,7 @@ void UTbSame1SameEnum1InterfaceMsgBusHelper::Prop1PropertyChangeLocalChangeRemot
 		}
 
 		// now set it to the default value
-		TestValue = ETbSame1Enum1::TS1E1_VALUE1; // default value
+		TestValue = ETbSame1Enum1::TS1E1_Value1; // default value
 		if (TSharedPtr<FTbSame1SameEnum1InterfaceMsgBusFixture> PinnedImplFixture = ImplFixture.Pin())
 		{
 			PinnedImplFixture->GetImplementation()->Execute_SetProp1(PinnedImplFixture->GetImplementation().GetObject(), TestValue);
@@ -97,7 +97,7 @@ void UTbSame1SameEnum1InterfaceMsgBusHelper::Prop1PropertyChangeLocalChangeRemot
 	}
 	else
 	{
-		ETbSame1Enum1 TestValue = ETbSame1Enum1::TS1E1_VALUE1; // default value
+		ETbSame1Enum1 TestValue = ETbSame1Enum1::TS1E1_Value1; // default value
 		Spec->TestEqual(TEXT("Delegate parameter should be the same value as set by the setter"), InProp1, TestValue);
 		if (TSharedPtr<FTbSame1SameEnum1InterfaceMsgBusFixture> PinnedImplFixture = ImplFixture.Pin())
 		{
@@ -110,7 +110,7 @@ void UTbSame1SameEnum1InterfaceMsgBusHelper::Prop1PropertyChangeLocalChangeRemot
 void UTbSame1SameEnum1InterfaceMsgBusHelper::Sig1SignalCb(ETbSame1Enum1 InParam1)
 {
 	// known test value
-	ETbSame1Enum1 Param1TestValue = ETbSame1Enum1::TS1E1_VALUE2;
+	ETbSame1Enum1 Param1TestValue = ETbSame1Enum1::TS1E1_Value2;
 	Spec->TestEqual(TEXT("Parameter should be the same value as sent by the signal"), InParam1, Param1TestValue);
 	testDoneDelegate.Execute();
 }

--- a/goldenmaster/Plugins/TbSame1/Source/TbSame1/Private/Tests/TbSame1SameEnum1InterfaceOLink.spec.cpp
+++ b/goldenmaster/Plugins/TbSame1/Source/TbSame1/Private/Tests/TbSame1SameEnum1InterfaceOLink.spec.cpp
@@ -85,35 +85,35 @@ void UTbSame1SameEnum1InterfaceOLinkSpec::Define()
 	It("Property.Prop1.Default", [this]()
 		{
 		// Do implement test here
-		ETbSame1Enum1 TestValue = ETbSame1Enum1::TS1E1_VALUE1; // default value
+		ETbSame1Enum1 TestValue = ETbSame1Enum1::TS1E1_Value1; // default value
 		TestEqual(TEXT("Getter should return the default value"), ImplFixture->GetImplementation()->Execute_GetProp1(ImplFixture->GetImplementation().GetObject()), TestValue);
 	});
 
 	LatentIt("Property.Prop1.Change", EAsyncExecution::ThreadPool, [this](const FDoneDelegate TestDone)
 		{
 		// Do implement test here
-		ETbSame1Enum1 TestValue = ETbSame1Enum1::TS1E1_VALUE1; // default value
+		ETbSame1Enum1 TestValue = ETbSame1Enum1::TS1E1_Value1; // default value
 		TestEqual(TEXT("Getter should return the default value"), ImplFixture->GetImplementation()->Execute_GetProp1(ImplFixture->GetImplementation().GetObject()), TestValue);
 
 		ImplFixture->GetHelper()->SetTestDone(TestDone);
 		UTbSame1SameEnum1InterfaceSignals* TbSame1SameEnum1InterfaceSignals = ImplFixture->GetImplementation()->Execute__GetSignals(ImplFixture->GetImplementation().GetObject());
 		TbSame1SameEnum1InterfaceSignals->OnProp1Changed.AddDynamic(ImplFixture->GetHelper().Get(), &UTbSame1SameEnum1InterfaceOLinkHelper::Prop1PropertyCb);
 		// use different test value
-		TestValue = ETbSame1Enum1::TS1E1_VALUE2;
+		TestValue = ETbSame1Enum1::TS1E1_Value2;
 		ImplFixture->GetImplementation()->Execute_SetProp1(ImplFixture->GetImplementation().GetObject(), TestValue);
 	});
 
 	LatentIt("Property.Prop1.ChangeLocalCheckRemote", EAsyncExecution::ThreadPool, [this](const FDoneDelegate TestDone)
 		{
 		// Do implement test here
-		ETbSame1Enum1 TestValue = ETbSame1Enum1::TS1E1_VALUE1; // default value
+		ETbSame1Enum1 TestValue = ETbSame1Enum1::TS1E1_Value1; // default value
 		TestEqual(TEXT("Getter should return the default value"), ImplFixture->GetImplementation()->Execute_GetProp1(ImplFixture->GetImplementation().GetObject()), TestValue);
 
 		ImplFixture->GetHelper()->SetTestDone(TestDone);
 		UTbSame1SameEnum1InterfaceSignals* TbSame1SameEnum1InterfaceSignals = ImplFixture->GetImplementation()->Execute__GetSignals(ImplFixture->GetImplementation().GetObject());
 		TbSame1SameEnum1InterfaceSignals->OnProp1Changed.AddDynamic(ImplFixture->GetHelper().Get(), &UTbSame1SameEnum1InterfaceOLinkHelper::Prop1PropertyChangeLocalCheckRemoteCb);
 		// use different test value
-		TestValue = ETbSame1Enum1::TS1E1_VALUE2;
+		TestValue = ETbSame1Enum1::TS1E1_Value2;
 		auto service = ImplFixture->GetGameInstance()->GetSubsystem<UTbSame1SameEnum1Interface>();
 		service->Execute_SetProp1(service, TestValue);
 	});
@@ -121,14 +121,14 @@ void UTbSame1SameEnum1InterfaceOLinkSpec::Define()
 	LatentIt("Property.Prop1.ChangeLocalChangeBackRemote", EAsyncExecution::ThreadPool, [this](const FDoneDelegate TestDone)
 		{
 		// Do implement test here
-		ETbSame1Enum1 TestValue = ETbSame1Enum1::TS1E1_VALUE1; // default value
+		ETbSame1Enum1 TestValue = ETbSame1Enum1::TS1E1_Value1; // default value
 		TestEqual(TEXT("Getter should return the default value"), ImplFixture->GetImplementation()->Execute_GetProp1(ImplFixture->GetImplementation().GetObject()), TestValue);
 
 		ImplFixture->GetHelper()->SetTestDone(TestDone);
 		UTbSame1SameEnum1InterfaceSignals* TbSame1SameEnum1InterfaceSignals = ImplFixture->GetImplementation()->Execute__GetSignals(ImplFixture->GetImplementation().GetObject());
 		TbSame1SameEnum1InterfaceSignals->OnProp1Changed.AddDynamic(ImplFixture->GetHelper().Get(), &UTbSame1SameEnum1InterfaceOLinkHelper::Prop1PropertyChangeLocalChangeRemoteCb);
 		// use different test value
-		TestValue = ETbSame1Enum1::TS1E1_VALUE2;
+		TestValue = ETbSame1Enum1::TS1E1_Value2;
 		auto service = ImplFixture->GetGameInstance()->GetSubsystem<UTbSame1SameEnum1Interface>();
 		service->Execute_SetProp1(service, TestValue);
 	});
@@ -138,7 +138,7 @@ void UTbSame1SameEnum1InterfaceOLinkSpec::Define()
 		// Do implement test here
 		AsyncTask(ENamedThreads::AnyThread, [this, TestDone]()
 			{
-			ImplFixture->GetImplementation()->Execute_Func1(ImplFixture->GetImplementation().GetObject(), ETbSame1Enum1::TS1E1_VALUE1);
+			ImplFixture->GetImplementation()->Execute_Func1(ImplFixture->GetImplementation().GetObject(), ETbSame1Enum1::TS1E1_Value1);
 			TestDone.Execute();
 		});
 	});
@@ -150,7 +150,7 @@ void UTbSame1SameEnum1InterfaceOLinkSpec::Define()
 		TbSame1SameEnum1InterfaceSignals->OnSig1Signal.AddDynamic(ImplFixture->GetHelper().Get(), &UTbSame1SameEnum1InterfaceOLinkHelper::Sig1SignalCb);
 
 		// use different test value
-		ETbSame1Enum1 Param1TestValue = ETbSame1Enum1::TS1E1_VALUE2;
+		ETbSame1Enum1 Param1TestValue = ETbSame1Enum1::TS1E1_Value2;
 		TbSame1SameEnum1InterfaceSignals->BroadcastSig1Signal(Param1TestValue);
 	});
 }

--- a/goldenmaster/Plugins/TbSame1/Source/TbSame1/Private/Tests/TbSame1SameEnum1InterfaceOLinkFixture.cpp
+++ b/goldenmaster/Plugins/TbSame1/Source/TbSame1/Private/Tests/TbSame1SameEnum1InterfaceOLinkFixture.cpp
@@ -42,9 +42,9 @@ void UTbSame1SameEnum1InterfaceOLinkHelper::SetTestDone(const FDoneDelegate& InD
 
 void UTbSame1SameEnum1InterfaceOLinkHelper::Prop1PropertyCb(ETbSame1Enum1 InProp1)
 {
-	ETbSame1Enum1 TestValue = ETbSame1Enum1::TS1E1_VALUE1;
+	ETbSame1Enum1 TestValue = ETbSame1Enum1::TS1E1_Value1;
 	// use different test value
-	TestValue = ETbSame1Enum1::TS1E1_VALUE2;
+	TestValue = ETbSame1Enum1::TS1E1_Value2;
 	Spec->TestEqual(TEXT("Delegate parameter should be the same value as set by the setter"), InProp1, TestValue);
 	if (TSharedPtr<FTbSame1SameEnum1InterfaceOLinkFixture> PinnedImplFixture = ImplFixture.Pin())
 	{
@@ -55,9 +55,9 @@ void UTbSame1SameEnum1InterfaceOLinkHelper::Prop1PropertyCb(ETbSame1Enum1 InProp
 
 void UTbSame1SameEnum1InterfaceOLinkHelper::Prop1PropertyChangeLocalCheckRemoteCb(ETbSame1Enum1 InProp1)
 {
-	ETbSame1Enum1 TestValue = ETbSame1Enum1::TS1E1_VALUE1;
+	ETbSame1Enum1 TestValue = ETbSame1Enum1::TS1E1_Value1;
 	// use different test value
-	TestValue = ETbSame1Enum1::TS1E1_VALUE2;
+	TestValue = ETbSame1Enum1::TS1E1_Value2;
 	Spec->TestEqual(TEXT("Delegate parameter should be the same value as set by the setter"), InProp1, TestValue);
 	if (TSharedPtr<FTbSame1SameEnum1InterfaceOLinkFixture> PinnedImplFixture = ImplFixture.Pin())
 	{
@@ -76,9 +76,9 @@ void UTbSame1SameEnum1InterfaceOLinkHelper::Prop1PropertyChangeLocalChangeRemote
 
 	if (count % 2 != 0)
 	{
-		ETbSame1Enum1 TestValue = ETbSame1Enum1::TS1E1_VALUE1;
+		ETbSame1Enum1 TestValue = ETbSame1Enum1::TS1E1_Value1;
 		// use different test value
-		TestValue = ETbSame1Enum1::TS1E1_VALUE2;
+		TestValue = ETbSame1Enum1::TS1E1_Value2;
 		Spec->TestEqual(TEXT("Delegate parameter should be the same value as set by the setter"), InProp1, TestValue);
 		if (TSharedPtr<FTbSame1SameEnum1InterfaceOLinkFixture> PinnedImplFixture = ImplFixture.Pin())
 		{
@@ -86,7 +86,7 @@ void UTbSame1SameEnum1InterfaceOLinkHelper::Prop1PropertyChangeLocalChangeRemote
 		}
 
 		// now set it to the default value
-		TestValue = ETbSame1Enum1::TS1E1_VALUE1; // default value
+		TestValue = ETbSame1Enum1::TS1E1_Value1; // default value
 		if (TSharedPtr<FTbSame1SameEnum1InterfaceOLinkFixture> PinnedImplFixture = ImplFixture.Pin())
 		{
 			PinnedImplFixture->GetImplementation()->Execute_SetProp1(PinnedImplFixture->GetImplementation().GetObject(), TestValue);
@@ -94,7 +94,7 @@ void UTbSame1SameEnum1InterfaceOLinkHelper::Prop1PropertyChangeLocalChangeRemote
 	}
 	else
 	{
-		ETbSame1Enum1 TestValue = ETbSame1Enum1::TS1E1_VALUE1; // default value
+		ETbSame1Enum1 TestValue = ETbSame1Enum1::TS1E1_Value1; // default value
 		Spec->TestEqual(TEXT("Delegate parameter should be the same value as set by the setter"), InProp1, TestValue);
 		if (TSharedPtr<FTbSame1SameEnum1InterfaceOLinkFixture> PinnedImplFixture = ImplFixture.Pin())
 		{
@@ -107,7 +107,7 @@ void UTbSame1SameEnum1InterfaceOLinkHelper::Prop1PropertyChangeLocalChangeRemote
 void UTbSame1SameEnum1InterfaceOLinkHelper::Sig1SignalCb(ETbSame1Enum1 InParam1)
 {
 	// known test value
-	ETbSame1Enum1 Param1TestValue = ETbSame1Enum1::TS1E1_VALUE2;
+	ETbSame1Enum1 Param1TestValue = ETbSame1Enum1::TS1E1_Value2;
 	Spec->TestEqual(TEXT("Parameter should be the same value as sent by the signal"), InParam1, Param1TestValue);
 	testDoneDelegate.Execute();
 }

--- a/goldenmaster/Plugins/TbSame1/Source/TbSame1/Private/Tests/TbSame1SameEnum2InterfaceImpl.spec.cpp
+++ b/goldenmaster/Plugins/TbSame1/Source/TbSame1/Private/Tests/TbSame1SameEnum2InterfaceImpl.spec.cpp
@@ -50,55 +50,55 @@ void UTbSame1SameEnum2InterfaceImplSpec::Define()
 	It("Property.Prop1.Default", [this]()
 		{
 		// Do implement test here
-		ETbSame1Enum1 TestValue = ETbSame1Enum1::TS1E1_VALUE1; // default value
+		ETbSame1Enum1 TestValue = ETbSame1Enum1::TS1E1_Value1; // default value
 		TestEqual(TEXT("Getter should return the default value"), ImplFixture->GetImplementation()->Execute_GetProp1(ImplFixture->GetImplementation().GetObject()), TestValue);
 	});
 
 	LatentIt("Property.Prop1.Change", EAsyncExecution::ThreadPool, [this](const FDoneDelegate TestDone)
 		{
 		// Do implement test here
-		ETbSame1Enum1 TestValue = ETbSame1Enum1::TS1E1_VALUE1; // default value
+		ETbSame1Enum1 TestValue = ETbSame1Enum1::TS1E1_Value1; // default value
 		TestEqual(TEXT("Getter should return the default value"), ImplFixture->GetImplementation()->Execute_GetProp1(ImplFixture->GetImplementation().GetObject()), TestValue);
 
 		ImplFixture->GetHelper()->SetTestDone(TestDone);
 		UTbSame1SameEnum2InterfaceSignals* TbSame1SameEnum2InterfaceSignals = ImplFixture->GetImplementation()->Execute__GetSignals(ImplFixture->GetImplementation().GetObject());
 		TbSame1SameEnum2InterfaceSignals->OnProp1Changed.AddDynamic(ImplFixture->GetHelper().Get(), &UTbSame1SameEnum2InterfaceImplHelper::Prop1PropertyCb);
 		// use different test value
-		TestValue = ETbSame1Enum1::TS1E1_VALUE2;
+		TestValue = ETbSame1Enum1::TS1E1_Value2;
 		ImplFixture->GetImplementation()->Execute_SetProp1(ImplFixture->GetImplementation().GetObject(), TestValue);
 	});
 
 	It("Property.Prop2.Default", [this]()
 		{
 		// Do implement test here
-		ETbSame1Enum2 TestValue = ETbSame1Enum2::TS1E2_VALUE1; // default value
+		ETbSame1Enum2 TestValue = ETbSame1Enum2::TS1E2_Value1; // default value
 		TestEqual(TEXT("Getter should return the default value"), ImplFixture->GetImplementation()->Execute_GetProp2(ImplFixture->GetImplementation().GetObject()), TestValue);
 	});
 
 	LatentIt("Property.Prop2.Change", EAsyncExecution::ThreadPool, [this](const FDoneDelegate TestDone)
 		{
 		// Do implement test here
-		ETbSame1Enum2 TestValue = ETbSame1Enum2::TS1E2_VALUE1; // default value
+		ETbSame1Enum2 TestValue = ETbSame1Enum2::TS1E2_Value1; // default value
 		TestEqual(TEXT("Getter should return the default value"), ImplFixture->GetImplementation()->Execute_GetProp2(ImplFixture->GetImplementation().GetObject()), TestValue);
 
 		ImplFixture->GetHelper()->SetTestDone(TestDone);
 		UTbSame1SameEnum2InterfaceSignals* TbSame1SameEnum2InterfaceSignals = ImplFixture->GetImplementation()->Execute__GetSignals(ImplFixture->GetImplementation().GetObject());
 		TbSame1SameEnum2InterfaceSignals->OnProp2Changed.AddDynamic(ImplFixture->GetHelper().Get(), &UTbSame1SameEnum2InterfaceImplHelper::Prop2PropertyCb);
 		// use different test value
-		TestValue = ETbSame1Enum2::TS1E2_VALUE2;
+		TestValue = ETbSame1Enum2::TS1E2_Value2;
 		ImplFixture->GetImplementation()->Execute_SetProp2(ImplFixture->GetImplementation().GetObject(), TestValue);
 	});
 
 	It("Operation.Func1", [this]()
 		{
 		// Do implement test here
-		ImplFixture->GetImplementation()->Execute_Func1(ImplFixture->GetImplementation().GetObject(), ETbSame1Enum1::TS1E1_VALUE1);
+		ImplFixture->GetImplementation()->Execute_Func1(ImplFixture->GetImplementation().GetObject(), ETbSame1Enum1::TS1E1_Value1);
 	});
 
 	It("Operation.Func2", [this]()
 		{
 		// Do implement test here
-		ImplFixture->GetImplementation()->Execute_Func2(ImplFixture->GetImplementation().GetObject(), ETbSame1Enum1::TS1E1_VALUE1, ETbSame1Enum2::TS1E2_VALUE1);
+		ImplFixture->GetImplementation()->Execute_Func2(ImplFixture->GetImplementation().GetObject(), ETbSame1Enum1::TS1E1_Value1, ETbSame1Enum2::TS1E2_Value1);
 	});
 
 	LatentIt("Signal.Sig1", EAsyncExecution::ThreadPool, [this](const FDoneDelegate TestDone)
@@ -108,7 +108,7 @@ void UTbSame1SameEnum2InterfaceImplSpec::Define()
 		TbSame1SameEnum2InterfaceSignals->OnSig1Signal.AddDynamic(ImplFixture->GetHelper().Get(), &UTbSame1SameEnum2InterfaceImplHelper::Sig1SignalCb);
 
 		// use different test value
-		ETbSame1Enum1 Param1TestValue = ETbSame1Enum1::TS1E1_VALUE2;
+		ETbSame1Enum1 Param1TestValue = ETbSame1Enum1::TS1E1_Value2;
 		TbSame1SameEnum2InterfaceSignals->BroadcastSig1Signal(Param1TestValue);
 	});
 
@@ -119,8 +119,8 @@ void UTbSame1SameEnum2InterfaceImplSpec::Define()
 		TbSame1SameEnum2InterfaceSignals->OnSig2Signal.AddDynamic(ImplFixture->GetHelper().Get(), &UTbSame1SameEnum2InterfaceImplHelper::Sig2SignalCb);
 
 		// use different test value
-		ETbSame1Enum1 Param1TestValue = ETbSame1Enum1::TS1E1_VALUE2;
-		ETbSame1Enum2 Param2TestValue = ETbSame1Enum2::TS1E2_VALUE2;
+		ETbSame1Enum1 Param1TestValue = ETbSame1Enum1::TS1E1_Value2;
+		ETbSame1Enum2 Param2TestValue = ETbSame1Enum2::TS1E2_Value2;
 		TbSame1SameEnum2InterfaceSignals->BroadcastSig2Signal(Param1TestValue, Param2TestValue);
 	});
 }

--- a/goldenmaster/Plugins/TbSame1/Source/TbSame1/Private/Tests/TbSame1SameEnum2InterfaceImplFixture.cpp
+++ b/goldenmaster/Plugins/TbSame1/Source/TbSame1/Private/Tests/TbSame1SameEnum2InterfaceImplFixture.cpp
@@ -39,9 +39,9 @@ void UTbSame1SameEnum2InterfaceImplHelper::SetTestDone(const FDoneDelegate& InDo
 
 void UTbSame1SameEnum2InterfaceImplHelper::Prop1PropertyCb(ETbSame1Enum1 InProp1)
 {
-	ETbSame1Enum1 TestValue = ETbSame1Enum1::TS1E1_VALUE1;
+	ETbSame1Enum1 TestValue = ETbSame1Enum1::TS1E1_Value1;
 	// use different test value
-	TestValue = ETbSame1Enum1::TS1E1_VALUE2;
+	TestValue = ETbSame1Enum1::TS1E1_Value2;
 	Spec->TestEqual(TEXT("Delegate parameter should be the same value as set by the setter"), InProp1, TestValue);
 	if (TSharedPtr<FTbSame1SameEnum2InterfaceImplFixture> PinnedImplFixture = ImplFixture.Pin())
 	{
@@ -52,9 +52,9 @@ void UTbSame1SameEnum2InterfaceImplHelper::Prop1PropertyCb(ETbSame1Enum1 InProp1
 
 void UTbSame1SameEnum2InterfaceImplHelper::Prop2PropertyCb(ETbSame1Enum2 InProp2)
 {
-	ETbSame1Enum2 TestValue = ETbSame1Enum2::TS1E2_VALUE1;
+	ETbSame1Enum2 TestValue = ETbSame1Enum2::TS1E2_Value1;
 	// use different test value
-	TestValue = ETbSame1Enum2::TS1E2_VALUE2;
+	TestValue = ETbSame1Enum2::TS1E2_Value2;
 	Spec->TestEqual(TEXT("Delegate parameter should be the same value as set by the setter"), InProp2, TestValue);
 	if (TSharedPtr<FTbSame1SameEnum2InterfaceImplFixture> PinnedImplFixture = ImplFixture.Pin())
 	{
@@ -66,7 +66,7 @@ void UTbSame1SameEnum2InterfaceImplHelper::Prop2PropertyCb(ETbSame1Enum2 InProp2
 void UTbSame1SameEnum2InterfaceImplHelper::Sig1SignalCb(ETbSame1Enum1 InParam1)
 {
 	// known test value
-	ETbSame1Enum1 Param1TestValue = ETbSame1Enum1::TS1E1_VALUE2;
+	ETbSame1Enum1 Param1TestValue = ETbSame1Enum1::TS1E1_Value2;
 	Spec->TestEqual(TEXT("Parameter should be the same value as sent by the signal"), InParam1, Param1TestValue);
 	testDoneDelegate.Execute();
 }
@@ -74,9 +74,9 @@ void UTbSame1SameEnum2InterfaceImplHelper::Sig1SignalCb(ETbSame1Enum1 InParam1)
 void UTbSame1SameEnum2InterfaceImplHelper::Sig2SignalCb(ETbSame1Enum1 InParam1, ETbSame1Enum2 InParam2)
 {
 	// known test value
-	ETbSame1Enum1 Param1TestValue = ETbSame1Enum1::TS1E1_VALUE2;
+	ETbSame1Enum1 Param1TestValue = ETbSame1Enum1::TS1E1_Value2;
 	Spec->TestEqual(TEXT("Parameter should be the same value as sent by the signal"), InParam1, Param1TestValue);
-	ETbSame1Enum2 Param2TestValue = ETbSame1Enum2::TS1E2_VALUE2;
+	ETbSame1Enum2 Param2TestValue = ETbSame1Enum2::TS1E2_Value2;
 	Spec->TestEqual(TEXT("Parameter should be the same value as sent by the signal"), InParam2, Param2TestValue);
 	testDoneDelegate.Execute();
 }

--- a/goldenmaster/Plugins/TbSame1/Source/TbSame1/Private/Tests/TbSame1SameEnum2InterfaceMsgBus.spec.cpp
+++ b/goldenmaster/Plugins/TbSame1/Source/TbSame1/Private/Tests/TbSame1SameEnum2InterfaceMsgBus.spec.cpp
@@ -67,35 +67,35 @@ void UTbSame1SameEnum2InterfaceMsgBusSpec::Define()
 	It("Property.Prop1.Default", [this]()
 		{
 		// Do implement test here
-		ETbSame1Enum1 TestValue = ETbSame1Enum1::TS1E1_VALUE1; // default value
+		ETbSame1Enum1 TestValue = ETbSame1Enum1::TS1E1_Value1; // default value
 		TestEqual(TEXT("Getter should return the default value"), ImplFixture->GetImplementation()->Execute_GetProp1(ImplFixture->GetImplementation().GetObject()), TestValue);
 	});
 
 	LatentIt("Property.Prop1.Change", EAsyncExecution::ThreadPool, [this](const FDoneDelegate TestDone)
 		{
 		// Do implement test here
-		ETbSame1Enum1 TestValue = ETbSame1Enum1::TS1E1_VALUE1; // default value
+		ETbSame1Enum1 TestValue = ETbSame1Enum1::TS1E1_Value1; // default value
 		TestEqual(TEXT("Getter should return the default value"), ImplFixture->GetImplementation()->Execute_GetProp1(ImplFixture->GetImplementation().GetObject()), TestValue);
 
 		ImplFixture->GetHelper()->SetTestDone(TestDone);
 		UTbSame1SameEnum2InterfaceSignals* TbSame1SameEnum2InterfaceSignals = ImplFixture->GetImplementation()->Execute__GetSignals(ImplFixture->GetImplementation().GetObject());
 		TbSame1SameEnum2InterfaceSignals->OnProp1Changed.AddDynamic(ImplFixture->GetHelper().Get(), &UTbSame1SameEnum2InterfaceMsgBusHelper::Prop1PropertyCb);
 		// use different test value
-		TestValue = ETbSame1Enum1::TS1E1_VALUE2;
+		TestValue = ETbSame1Enum1::TS1E1_Value2;
 		ImplFixture->GetImplementation()->Execute_SetProp1(ImplFixture->GetImplementation().GetObject(), TestValue);
 	});
 
 	LatentIt("Property.Prop1.ChangeLocalCheckRemote", EAsyncExecution::ThreadPool, [this](const FDoneDelegate TestDone)
 		{
 		// Do implement test here
-		ETbSame1Enum1 TestValue = ETbSame1Enum1::TS1E1_VALUE1; // default value
+		ETbSame1Enum1 TestValue = ETbSame1Enum1::TS1E1_Value1; // default value
 		TestEqual(TEXT("Getter should return the default value"), ImplFixture->GetImplementation()->Execute_GetProp1(ImplFixture->GetImplementation().GetObject()), TestValue);
 
 		ImplFixture->GetHelper()->SetTestDone(TestDone);
 		UTbSame1SameEnum2InterfaceSignals* TbSame1SameEnum2InterfaceSignals = ImplFixture->GetImplementation()->Execute__GetSignals(ImplFixture->GetImplementation().GetObject());
 		TbSame1SameEnum2InterfaceSignals->OnProp1Changed.AddDynamic(ImplFixture->GetHelper().Get(), &UTbSame1SameEnum2InterfaceMsgBusHelper::Prop1PropertyChangeLocalCheckRemoteCb);
 		// use different test value
-		TestValue = ETbSame1Enum1::TS1E1_VALUE2;
+		TestValue = ETbSame1Enum1::TS1E1_Value2;
 		auto service = ImplFixture->GetGameInstance()->GetSubsystem<UTbSame1SameEnum2Interface>();
 		service->Execute_SetProp1(service, TestValue);
 	});
@@ -103,14 +103,14 @@ void UTbSame1SameEnum2InterfaceMsgBusSpec::Define()
 	LatentIt("Property.Prop1.ChangeLocalChangeBackRemote", EAsyncExecution::ThreadPool, [this](const FDoneDelegate TestDone)
 		{
 		// Do implement test here
-		ETbSame1Enum1 TestValue = ETbSame1Enum1::TS1E1_VALUE1; // default value
+		ETbSame1Enum1 TestValue = ETbSame1Enum1::TS1E1_Value1; // default value
 		TestEqual(TEXT("Getter should return the default value"), ImplFixture->GetImplementation()->Execute_GetProp1(ImplFixture->GetImplementation().GetObject()), TestValue);
 
 		ImplFixture->GetHelper()->SetTestDone(TestDone);
 		UTbSame1SameEnum2InterfaceSignals* TbSame1SameEnum2InterfaceSignals = ImplFixture->GetImplementation()->Execute__GetSignals(ImplFixture->GetImplementation().GetObject());
 		TbSame1SameEnum2InterfaceSignals->OnProp1Changed.AddDynamic(ImplFixture->GetHelper().Get(), &UTbSame1SameEnum2InterfaceMsgBusHelper::Prop1PropertyChangeLocalChangeRemoteCb);
 		// use different test value
-		TestValue = ETbSame1Enum1::TS1E1_VALUE2;
+		TestValue = ETbSame1Enum1::TS1E1_Value2;
 		auto service = ImplFixture->GetGameInstance()->GetSubsystem<UTbSame1SameEnum2Interface>();
 		service->Execute_SetProp1(service, TestValue);
 	});
@@ -118,35 +118,35 @@ void UTbSame1SameEnum2InterfaceMsgBusSpec::Define()
 	It("Property.Prop2.Default", [this]()
 		{
 		// Do implement test here
-		ETbSame1Enum2 TestValue = ETbSame1Enum2::TS1E2_VALUE1; // default value
+		ETbSame1Enum2 TestValue = ETbSame1Enum2::TS1E2_Value1; // default value
 		TestEqual(TEXT("Getter should return the default value"), ImplFixture->GetImplementation()->Execute_GetProp2(ImplFixture->GetImplementation().GetObject()), TestValue);
 	});
 
 	LatentIt("Property.Prop2.Change", EAsyncExecution::ThreadPool, [this](const FDoneDelegate TestDone)
 		{
 		// Do implement test here
-		ETbSame1Enum2 TestValue = ETbSame1Enum2::TS1E2_VALUE1; // default value
+		ETbSame1Enum2 TestValue = ETbSame1Enum2::TS1E2_Value1; // default value
 		TestEqual(TEXT("Getter should return the default value"), ImplFixture->GetImplementation()->Execute_GetProp2(ImplFixture->GetImplementation().GetObject()), TestValue);
 
 		ImplFixture->GetHelper()->SetTestDone(TestDone);
 		UTbSame1SameEnum2InterfaceSignals* TbSame1SameEnum2InterfaceSignals = ImplFixture->GetImplementation()->Execute__GetSignals(ImplFixture->GetImplementation().GetObject());
 		TbSame1SameEnum2InterfaceSignals->OnProp2Changed.AddDynamic(ImplFixture->GetHelper().Get(), &UTbSame1SameEnum2InterfaceMsgBusHelper::Prop2PropertyCb);
 		// use different test value
-		TestValue = ETbSame1Enum2::TS1E2_VALUE2;
+		TestValue = ETbSame1Enum2::TS1E2_Value2;
 		ImplFixture->GetImplementation()->Execute_SetProp2(ImplFixture->GetImplementation().GetObject(), TestValue);
 	});
 
 	LatentIt("Property.Prop2.ChangeLocalCheckRemote", EAsyncExecution::ThreadPool, [this](const FDoneDelegate TestDone)
 		{
 		// Do implement test here
-		ETbSame1Enum2 TestValue = ETbSame1Enum2::TS1E2_VALUE1; // default value
+		ETbSame1Enum2 TestValue = ETbSame1Enum2::TS1E2_Value1; // default value
 		TestEqual(TEXT("Getter should return the default value"), ImplFixture->GetImplementation()->Execute_GetProp2(ImplFixture->GetImplementation().GetObject()), TestValue);
 
 		ImplFixture->GetHelper()->SetTestDone(TestDone);
 		UTbSame1SameEnum2InterfaceSignals* TbSame1SameEnum2InterfaceSignals = ImplFixture->GetImplementation()->Execute__GetSignals(ImplFixture->GetImplementation().GetObject());
 		TbSame1SameEnum2InterfaceSignals->OnProp2Changed.AddDynamic(ImplFixture->GetHelper().Get(), &UTbSame1SameEnum2InterfaceMsgBusHelper::Prop2PropertyChangeLocalCheckRemoteCb);
 		// use different test value
-		TestValue = ETbSame1Enum2::TS1E2_VALUE2;
+		TestValue = ETbSame1Enum2::TS1E2_Value2;
 		auto service = ImplFixture->GetGameInstance()->GetSubsystem<UTbSame1SameEnum2Interface>();
 		service->Execute_SetProp2(service, TestValue);
 	});
@@ -154,14 +154,14 @@ void UTbSame1SameEnum2InterfaceMsgBusSpec::Define()
 	LatentIt("Property.Prop2.ChangeLocalChangeBackRemote", EAsyncExecution::ThreadPool, [this](const FDoneDelegate TestDone)
 		{
 		// Do implement test here
-		ETbSame1Enum2 TestValue = ETbSame1Enum2::TS1E2_VALUE1; // default value
+		ETbSame1Enum2 TestValue = ETbSame1Enum2::TS1E2_Value1; // default value
 		TestEqual(TEXT("Getter should return the default value"), ImplFixture->GetImplementation()->Execute_GetProp2(ImplFixture->GetImplementation().GetObject()), TestValue);
 
 		ImplFixture->GetHelper()->SetTestDone(TestDone);
 		UTbSame1SameEnum2InterfaceSignals* TbSame1SameEnum2InterfaceSignals = ImplFixture->GetImplementation()->Execute__GetSignals(ImplFixture->GetImplementation().GetObject());
 		TbSame1SameEnum2InterfaceSignals->OnProp2Changed.AddDynamic(ImplFixture->GetHelper().Get(), &UTbSame1SameEnum2InterfaceMsgBusHelper::Prop2PropertyChangeLocalChangeRemoteCb);
 		// use different test value
-		TestValue = ETbSame1Enum2::TS1E2_VALUE2;
+		TestValue = ETbSame1Enum2::TS1E2_Value2;
 		auto service = ImplFixture->GetGameInstance()->GetSubsystem<UTbSame1SameEnum2Interface>();
 		service->Execute_SetProp2(service, TestValue);
 	});
@@ -171,7 +171,7 @@ void UTbSame1SameEnum2InterfaceMsgBusSpec::Define()
 		// Do implement test here
 		AsyncTask(ENamedThreads::AnyThread, [this, TestDone]()
 			{
-			ImplFixture->GetImplementation()->Execute_Func1(ImplFixture->GetImplementation().GetObject(), ETbSame1Enum1::TS1E1_VALUE1);
+			ImplFixture->GetImplementation()->Execute_Func1(ImplFixture->GetImplementation().GetObject(), ETbSame1Enum1::TS1E1_Value1);
 			TestDone.Execute();
 		});
 	});
@@ -181,7 +181,7 @@ void UTbSame1SameEnum2InterfaceMsgBusSpec::Define()
 		// Do implement test here
 		AsyncTask(ENamedThreads::AnyThread, [this, TestDone]()
 			{
-			ImplFixture->GetImplementation()->Execute_Func2(ImplFixture->GetImplementation().GetObject(), ETbSame1Enum1::TS1E1_VALUE1, ETbSame1Enum2::TS1E2_VALUE1);
+			ImplFixture->GetImplementation()->Execute_Func2(ImplFixture->GetImplementation().GetObject(), ETbSame1Enum1::TS1E1_Value1, ETbSame1Enum2::TS1E2_Value1);
 			TestDone.Execute();
 		});
 	});
@@ -193,7 +193,7 @@ void UTbSame1SameEnum2InterfaceMsgBusSpec::Define()
 		TbSame1SameEnum2InterfaceSignals->OnSig1Signal.AddDynamic(ImplFixture->GetHelper().Get(), &UTbSame1SameEnum2InterfaceMsgBusHelper::Sig1SignalCb);
 
 		// use different test value
-		ETbSame1Enum1 Param1TestValue = ETbSame1Enum1::TS1E1_VALUE2;
+		ETbSame1Enum1 Param1TestValue = ETbSame1Enum1::TS1E1_Value2;
 		TbSame1SameEnum2InterfaceSignals->BroadcastSig1Signal(Param1TestValue);
 	});
 
@@ -204,8 +204,8 @@ void UTbSame1SameEnum2InterfaceMsgBusSpec::Define()
 		TbSame1SameEnum2InterfaceSignals->OnSig2Signal.AddDynamic(ImplFixture->GetHelper().Get(), &UTbSame1SameEnum2InterfaceMsgBusHelper::Sig2SignalCb);
 
 		// use different test value
-		ETbSame1Enum1 Param1TestValue = ETbSame1Enum1::TS1E1_VALUE2;
-		ETbSame1Enum2 Param2TestValue = ETbSame1Enum2::TS1E2_VALUE2;
+		ETbSame1Enum1 Param1TestValue = ETbSame1Enum1::TS1E1_Value2;
+		ETbSame1Enum2 Param2TestValue = ETbSame1Enum2::TS1E2_Value2;
 		TbSame1SameEnum2InterfaceSignals->BroadcastSig2Signal(Param1TestValue, Param2TestValue);
 	});
 }

--- a/goldenmaster/Plugins/TbSame1/Source/TbSame1/Private/Tests/TbSame1SameEnum2InterfaceMsgBusFixture.cpp
+++ b/goldenmaster/Plugins/TbSame1/Source/TbSame1/Private/Tests/TbSame1SameEnum2InterfaceMsgBusFixture.cpp
@@ -45,9 +45,9 @@ void UTbSame1SameEnum2InterfaceMsgBusHelper::SetTestDone(const FDoneDelegate& In
 
 void UTbSame1SameEnum2InterfaceMsgBusHelper::Prop1PropertyCb(ETbSame1Enum1 InProp1)
 {
-	ETbSame1Enum1 TestValue = ETbSame1Enum1::TS1E1_VALUE1;
+	ETbSame1Enum1 TestValue = ETbSame1Enum1::TS1E1_Value1;
 	// use different test value
-	TestValue = ETbSame1Enum1::TS1E1_VALUE2;
+	TestValue = ETbSame1Enum1::TS1E1_Value2;
 	Spec->TestEqual(TEXT("Delegate parameter should be the same value as set by the setter"), InProp1, TestValue);
 	if (TSharedPtr<FTbSame1SameEnum2InterfaceMsgBusFixture> PinnedImplFixture = ImplFixture.Pin())
 	{
@@ -58,9 +58,9 @@ void UTbSame1SameEnum2InterfaceMsgBusHelper::Prop1PropertyCb(ETbSame1Enum1 InPro
 
 void UTbSame1SameEnum2InterfaceMsgBusHelper::Prop1PropertyChangeLocalCheckRemoteCb(ETbSame1Enum1 InProp1)
 {
-	ETbSame1Enum1 TestValue = ETbSame1Enum1::TS1E1_VALUE1;
+	ETbSame1Enum1 TestValue = ETbSame1Enum1::TS1E1_Value1;
 	// use different test value
-	TestValue = ETbSame1Enum1::TS1E1_VALUE2;
+	TestValue = ETbSame1Enum1::TS1E1_Value2;
 	Spec->TestEqual(TEXT("Delegate parameter should be the same value as set by the setter"), InProp1, TestValue);
 	if (TSharedPtr<FTbSame1SameEnum2InterfaceMsgBusFixture> PinnedImplFixture = ImplFixture.Pin())
 	{
@@ -79,9 +79,9 @@ void UTbSame1SameEnum2InterfaceMsgBusHelper::Prop1PropertyChangeLocalChangeRemot
 
 	if (count % 2 != 0)
 	{
-		ETbSame1Enum1 TestValue = ETbSame1Enum1::TS1E1_VALUE1;
+		ETbSame1Enum1 TestValue = ETbSame1Enum1::TS1E1_Value1;
 		// use different test value
-		TestValue = ETbSame1Enum1::TS1E1_VALUE2;
+		TestValue = ETbSame1Enum1::TS1E1_Value2;
 		Spec->TestEqual(TEXT("Delegate parameter should be the same value as set by the setter"), InProp1, TestValue);
 		if (TSharedPtr<FTbSame1SameEnum2InterfaceMsgBusFixture> PinnedImplFixture = ImplFixture.Pin())
 		{
@@ -89,7 +89,7 @@ void UTbSame1SameEnum2InterfaceMsgBusHelper::Prop1PropertyChangeLocalChangeRemot
 		}
 
 		// now set it to the default value
-		TestValue = ETbSame1Enum1::TS1E1_VALUE1; // default value
+		TestValue = ETbSame1Enum1::TS1E1_Value1; // default value
 		if (TSharedPtr<FTbSame1SameEnum2InterfaceMsgBusFixture> PinnedImplFixture = ImplFixture.Pin())
 		{
 			PinnedImplFixture->GetImplementation()->Execute_SetProp1(PinnedImplFixture->GetImplementation().GetObject(), TestValue);
@@ -97,7 +97,7 @@ void UTbSame1SameEnum2InterfaceMsgBusHelper::Prop1PropertyChangeLocalChangeRemot
 	}
 	else
 	{
-		ETbSame1Enum1 TestValue = ETbSame1Enum1::TS1E1_VALUE1; // default value
+		ETbSame1Enum1 TestValue = ETbSame1Enum1::TS1E1_Value1; // default value
 		Spec->TestEqual(TEXT("Delegate parameter should be the same value as set by the setter"), InProp1, TestValue);
 		if (TSharedPtr<FTbSame1SameEnum2InterfaceMsgBusFixture> PinnedImplFixture = ImplFixture.Pin())
 		{
@@ -109,9 +109,9 @@ void UTbSame1SameEnum2InterfaceMsgBusHelper::Prop1PropertyChangeLocalChangeRemot
 
 void UTbSame1SameEnum2InterfaceMsgBusHelper::Prop2PropertyCb(ETbSame1Enum2 InProp2)
 {
-	ETbSame1Enum2 TestValue = ETbSame1Enum2::TS1E2_VALUE1;
+	ETbSame1Enum2 TestValue = ETbSame1Enum2::TS1E2_Value1;
 	// use different test value
-	TestValue = ETbSame1Enum2::TS1E2_VALUE2;
+	TestValue = ETbSame1Enum2::TS1E2_Value2;
 	Spec->TestEqual(TEXT("Delegate parameter should be the same value as set by the setter"), InProp2, TestValue);
 	if (TSharedPtr<FTbSame1SameEnum2InterfaceMsgBusFixture> PinnedImplFixture = ImplFixture.Pin())
 	{
@@ -122,9 +122,9 @@ void UTbSame1SameEnum2InterfaceMsgBusHelper::Prop2PropertyCb(ETbSame1Enum2 InPro
 
 void UTbSame1SameEnum2InterfaceMsgBusHelper::Prop2PropertyChangeLocalCheckRemoteCb(ETbSame1Enum2 InProp2)
 {
-	ETbSame1Enum2 TestValue = ETbSame1Enum2::TS1E2_VALUE1;
+	ETbSame1Enum2 TestValue = ETbSame1Enum2::TS1E2_Value1;
 	// use different test value
-	TestValue = ETbSame1Enum2::TS1E2_VALUE2;
+	TestValue = ETbSame1Enum2::TS1E2_Value2;
 	Spec->TestEqual(TEXT("Delegate parameter should be the same value as set by the setter"), InProp2, TestValue);
 	if (TSharedPtr<FTbSame1SameEnum2InterfaceMsgBusFixture> PinnedImplFixture = ImplFixture.Pin())
 	{
@@ -143,9 +143,9 @@ void UTbSame1SameEnum2InterfaceMsgBusHelper::Prop2PropertyChangeLocalChangeRemot
 
 	if (count % 2 != 0)
 	{
-		ETbSame1Enum2 TestValue = ETbSame1Enum2::TS1E2_VALUE1;
+		ETbSame1Enum2 TestValue = ETbSame1Enum2::TS1E2_Value1;
 		// use different test value
-		TestValue = ETbSame1Enum2::TS1E2_VALUE2;
+		TestValue = ETbSame1Enum2::TS1E2_Value2;
 		Spec->TestEqual(TEXT("Delegate parameter should be the same value as set by the setter"), InProp2, TestValue);
 		if (TSharedPtr<FTbSame1SameEnum2InterfaceMsgBusFixture> PinnedImplFixture = ImplFixture.Pin())
 		{
@@ -153,7 +153,7 @@ void UTbSame1SameEnum2InterfaceMsgBusHelper::Prop2PropertyChangeLocalChangeRemot
 		}
 
 		// now set it to the default value
-		TestValue = ETbSame1Enum2::TS1E2_VALUE1; // default value
+		TestValue = ETbSame1Enum2::TS1E2_Value1; // default value
 		if (TSharedPtr<FTbSame1SameEnum2InterfaceMsgBusFixture> PinnedImplFixture = ImplFixture.Pin())
 		{
 			PinnedImplFixture->GetImplementation()->Execute_SetProp2(PinnedImplFixture->GetImplementation().GetObject(), TestValue);
@@ -161,7 +161,7 @@ void UTbSame1SameEnum2InterfaceMsgBusHelper::Prop2PropertyChangeLocalChangeRemot
 	}
 	else
 	{
-		ETbSame1Enum2 TestValue = ETbSame1Enum2::TS1E2_VALUE1; // default value
+		ETbSame1Enum2 TestValue = ETbSame1Enum2::TS1E2_Value1; // default value
 		Spec->TestEqual(TEXT("Delegate parameter should be the same value as set by the setter"), InProp2, TestValue);
 		if (TSharedPtr<FTbSame1SameEnum2InterfaceMsgBusFixture> PinnedImplFixture = ImplFixture.Pin())
 		{
@@ -174,7 +174,7 @@ void UTbSame1SameEnum2InterfaceMsgBusHelper::Prop2PropertyChangeLocalChangeRemot
 void UTbSame1SameEnum2InterfaceMsgBusHelper::Sig1SignalCb(ETbSame1Enum1 InParam1)
 {
 	// known test value
-	ETbSame1Enum1 Param1TestValue = ETbSame1Enum1::TS1E1_VALUE2;
+	ETbSame1Enum1 Param1TestValue = ETbSame1Enum1::TS1E1_Value2;
 	Spec->TestEqual(TEXT("Parameter should be the same value as sent by the signal"), InParam1, Param1TestValue);
 	testDoneDelegate.Execute();
 }
@@ -182,9 +182,9 @@ void UTbSame1SameEnum2InterfaceMsgBusHelper::Sig1SignalCb(ETbSame1Enum1 InParam1
 void UTbSame1SameEnum2InterfaceMsgBusHelper::Sig2SignalCb(ETbSame1Enum1 InParam1, ETbSame1Enum2 InParam2)
 {
 	// known test value
-	ETbSame1Enum1 Param1TestValue = ETbSame1Enum1::TS1E1_VALUE2;
+	ETbSame1Enum1 Param1TestValue = ETbSame1Enum1::TS1E1_Value2;
 	Spec->TestEqual(TEXT("Parameter should be the same value as sent by the signal"), InParam1, Param1TestValue);
-	ETbSame1Enum2 Param2TestValue = ETbSame1Enum2::TS1E2_VALUE2;
+	ETbSame1Enum2 Param2TestValue = ETbSame1Enum2::TS1E2_Value2;
 	Spec->TestEqual(TEXT("Parameter should be the same value as sent by the signal"), InParam2, Param2TestValue);
 	testDoneDelegate.Execute();
 }

--- a/goldenmaster/Plugins/TbSame1/Source/TbSame1/Private/Tests/TbSame1SameEnum2InterfaceOLink.spec.cpp
+++ b/goldenmaster/Plugins/TbSame1/Source/TbSame1/Private/Tests/TbSame1SameEnum2InterfaceOLink.spec.cpp
@@ -85,35 +85,35 @@ void UTbSame1SameEnum2InterfaceOLinkSpec::Define()
 	It("Property.Prop1.Default", [this]()
 		{
 		// Do implement test here
-		ETbSame1Enum1 TestValue = ETbSame1Enum1::TS1E1_VALUE1; // default value
+		ETbSame1Enum1 TestValue = ETbSame1Enum1::TS1E1_Value1; // default value
 		TestEqual(TEXT("Getter should return the default value"), ImplFixture->GetImplementation()->Execute_GetProp1(ImplFixture->GetImplementation().GetObject()), TestValue);
 	});
 
 	LatentIt("Property.Prop1.Change", EAsyncExecution::ThreadPool, [this](const FDoneDelegate TestDone)
 		{
 		// Do implement test here
-		ETbSame1Enum1 TestValue = ETbSame1Enum1::TS1E1_VALUE1; // default value
+		ETbSame1Enum1 TestValue = ETbSame1Enum1::TS1E1_Value1; // default value
 		TestEqual(TEXT("Getter should return the default value"), ImplFixture->GetImplementation()->Execute_GetProp1(ImplFixture->GetImplementation().GetObject()), TestValue);
 
 		ImplFixture->GetHelper()->SetTestDone(TestDone);
 		UTbSame1SameEnum2InterfaceSignals* TbSame1SameEnum2InterfaceSignals = ImplFixture->GetImplementation()->Execute__GetSignals(ImplFixture->GetImplementation().GetObject());
 		TbSame1SameEnum2InterfaceSignals->OnProp1Changed.AddDynamic(ImplFixture->GetHelper().Get(), &UTbSame1SameEnum2InterfaceOLinkHelper::Prop1PropertyCb);
 		// use different test value
-		TestValue = ETbSame1Enum1::TS1E1_VALUE2;
+		TestValue = ETbSame1Enum1::TS1E1_Value2;
 		ImplFixture->GetImplementation()->Execute_SetProp1(ImplFixture->GetImplementation().GetObject(), TestValue);
 	});
 
 	LatentIt("Property.Prop1.ChangeLocalCheckRemote", EAsyncExecution::ThreadPool, [this](const FDoneDelegate TestDone)
 		{
 		// Do implement test here
-		ETbSame1Enum1 TestValue = ETbSame1Enum1::TS1E1_VALUE1; // default value
+		ETbSame1Enum1 TestValue = ETbSame1Enum1::TS1E1_Value1; // default value
 		TestEqual(TEXT("Getter should return the default value"), ImplFixture->GetImplementation()->Execute_GetProp1(ImplFixture->GetImplementation().GetObject()), TestValue);
 
 		ImplFixture->GetHelper()->SetTestDone(TestDone);
 		UTbSame1SameEnum2InterfaceSignals* TbSame1SameEnum2InterfaceSignals = ImplFixture->GetImplementation()->Execute__GetSignals(ImplFixture->GetImplementation().GetObject());
 		TbSame1SameEnum2InterfaceSignals->OnProp1Changed.AddDynamic(ImplFixture->GetHelper().Get(), &UTbSame1SameEnum2InterfaceOLinkHelper::Prop1PropertyChangeLocalCheckRemoteCb);
 		// use different test value
-		TestValue = ETbSame1Enum1::TS1E1_VALUE2;
+		TestValue = ETbSame1Enum1::TS1E1_Value2;
 		auto service = ImplFixture->GetGameInstance()->GetSubsystem<UTbSame1SameEnum2Interface>();
 		service->Execute_SetProp1(service, TestValue);
 	});
@@ -121,14 +121,14 @@ void UTbSame1SameEnum2InterfaceOLinkSpec::Define()
 	LatentIt("Property.Prop1.ChangeLocalChangeBackRemote", EAsyncExecution::ThreadPool, [this](const FDoneDelegate TestDone)
 		{
 		// Do implement test here
-		ETbSame1Enum1 TestValue = ETbSame1Enum1::TS1E1_VALUE1; // default value
+		ETbSame1Enum1 TestValue = ETbSame1Enum1::TS1E1_Value1; // default value
 		TestEqual(TEXT("Getter should return the default value"), ImplFixture->GetImplementation()->Execute_GetProp1(ImplFixture->GetImplementation().GetObject()), TestValue);
 
 		ImplFixture->GetHelper()->SetTestDone(TestDone);
 		UTbSame1SameEnum2InterfaceSignals* TbSame1SameEnum2InterfaceSignals = ImplFixture->GetImplementation()->Execute__GetSignals(ImplFixture->GetImplementation().GetObject());
 		TbSame1SameEnum2InterfaceSignals->OnProp1Changed.AddDynamic(ImplFixture->GetHelper().Get(), &UTbSame1SameEnum2InterfaceOLinkHelper::Prop1PropertyChangeLocalChangeRemoteCb);
 		// use different test value
-		TestValue = ETbSame1Enum1::TS1E1_VALUE2;
+		TestValue = ETbSame1Enum1::TS1E1_Value2;
 		auto service = ImplFixture->GetGameInstance()->GetSubsystem<UTbSame1SameEnum2Interface>();
 		service->Execute_SetProp1(service, TestValue);
 	});
@@ -136,35 +136,35 @@ void UTbSame1SameEnum2InterfaceOLinkSpec::Define()
 	It("Property.Prop2.Default", [this]()
 		{
 		// Do implement test here
-		ETbSame1Enum2 TestValue = ETbSame1Enum2::TS1E2_VALUE1; // default value
+		ETbSame1Enum2 TestValue = ETbSame1Enum2::TS1E2_Value1; // default value
 		TestEqual(TEXT("Getter should return the default value"), ImplFixture->GetImplementation()->Execute_GetProp2(ImplFixture->GetImplementation().GetObject()), TestValue);
 	});
 
 	LatentIt("Property.Prop2.Change", EAsyncExecution::ThreadPool, [this](const FDoneDelegate TestDone)
 		{
 		// Do implement test here
-		ETbSame1Enum2 TestValue = ETbSame1Enum2::TS1E2_VALUE1; // default value
+		ETbSame1Enum2 TestValue = ETbSame1Enum2::TS1E2_Value1; // default value
 		TestEqual(TEXT("Getter should return the default value"), ImplFixture->GetImplementation()->Execute_GetProp2(ImplFixture->GetImplementation().GetObject()), TestValue);
 
 		ImplFixture->GetHelper()->SetTestDone(TestDone);
 		UTbSame1SameEnum2InterfaceSignals* TbSame1SameEnum2InterfaceSignals = ImplFixture->GetImplementation()->Execute__GetSignals(ImplFixture->GetImplementation().GetObject());
 		TbSame1SameEnum2InterfaceSignals->OnProp2Changed.AddDynamic(ImplFixture->GetHelper().Get(), &UTbSame1SameEnum2InterfaceOLinkHelper::Prop2PropertyCb);
 		// use different test value
-		TestValue = ETbSame1Enum2::TS1E2_VALUE2;
+		TestValue = ETbSame1Enum2::TS1E2_Value2;
 		ImplFixture->GetImplementation()->Execute_SetProp2(ImplFixture->GetImplementation().GetObject(), TestValue);
 	});
 
 	LatentIt("Property.Prop2.ChangeLocalCheckRemote", EAsyncExecution::ThreadPool, [this](const FDoneDelegate TestDone)
 		{
 		// Do implement test here
-		ETbSame1Enum2 TestValue = ETbSame1Enum2::TS1E2_VALUE1; // default value
+		ETbSame1Enum2 TestValue = ETbSame1Enum2::TS1E2_Value1; // default value
 		TestEqual(TEXT("Getter should return the default value"), ImplFixture->GetImplementation()->Execute_GetProp2(ImplFixture->GetImplementation().GetObject()), TestValue);
 
 		ImplFixture->GetHelper()->SetTestDone(TestDone);
 		UTbSame1SameEnum2InterfaceSignals* TbSame1SameEnum2InterfaceSignals = ImplFixture->GetImplementation()->Execute__GetSignals(ImplFixture->GetImplementation().GetObject());
 		TbSame1SameEnum2InterfaceSignals->OnProp2Changed.AddDynamic(ImplFixture->GetHelper().Get(), &UTbSame1SameEnum2InterfaceOLinkHelper::Prop2PropertyChangeLocalCheckRemoteCb);
 		// use different test value
-		TestValue = ETbSame1Enum2::TS1E2_VALUE2;
+		TestValue = ETbSame1Enum2::TS1E2_Value2;
 		auto service = ImplFixture->GetGameInstance()->GetSubsystem<UTbSame1SameEnum2Interface>();
 		service->Execute_SetProp2(service, TestValue);
 	});
@@ -172,14 +172,14 @@ void UTbSame1SameEnum2InterfaceOLinkSpec::Define()
 	LatentIt("Property.Prop2.ChangeLocalChangeBackRemote", EAsyncExecution::ThreadPool, [this](const FDoneDelegate TestDone)
 		{
 		// Do implement test here
-		ETbSame1Enum2 TestValue = ETbSame1Enum2::TS1E2_VALUE1; // default value
+		ETbSame1Enum2 TestValue = ETbSame1Enum2::TS1E2_Value1; // default value
 		TestEqual(TEXT("Getter should return the default value"), ImplFixture->GetImplementation()->Execute_GetProp2(ImplFixture->GetImplementation().GetObject()), TestValue);
 
 		ImplFixture->GetHelper()->SetTestDone(TestDone);
 		UTbSame1SameEnum2InterfaceSignals* TbSame1SameEnum2InterfaceSignals = ImplFixture->GetImplementation()->Execute__GetSignals(ImplFixture->GetImplementation().GetObject());
 		TbSame1SameEnum2InterfaceSignals->OnProp2Changed.AddDynamic(ImplFixture->GetHelper().Get(), &UTbSame1SameEnum2InterfaceOLinkHelper::Prop2PropertyChangeLocalChangeRemoteCb);
 		// use different test value
-		TestValue = ETbSame1Enum2::TS1E2_VALUE2;
+		TestValue = ETbSame1Enum2::TS1E2_Value2;
 		auto service = ImplFixture->GetGameInstance()->GetSubsystem<UTbSame1SameEnum2Interface>();
 		service->Execute_SetProp2(service, TestValue);
 	});
@@ -189,7 +189,7 @@ void UTbSame1SameEnum2InterfaceOLinkSpec::Define()
 		// Do implement test here
 		AsyncTask(ENamedThreads::AnyThread, [this, TestDone]()
 			{
-			ImplFixture->GetImplementation()->Execute_Func1(ImplFixture->GetImplementation().GetObject(), ETbSame1Enum1::TS1E1_VALUE1);
+			ImplFixture->GetImplementation()->Execute_Func1(ImplFixture->GetImplementation().GetObject(), ETbSame1Enum1::TS1E1_Value1);
 			TestDone.Execute();
 		});
 	});
@@ -199,7 +199,7 @@ void UTbSame1SameEnum2InterfaceOLinkSpec::Define()
 		// Do implement test here
 		AsyncTask(ENamedThreads::AnyThread, [this, TestDone]()
 			{
-			ImplFixture->GetImplementation()->Execute_Func2(ImplFixture->GetImplementation().GetObject(), ETbSame1Enum1::TS1E1_VALUE1, ETbSame1Enum2::TS1E2_VALUE1);
+			ImplFixture->GetImplementation()->Execute_Func2(ImplFixture->GetImplementation().GetObject(), ETbSame1Enum1::TS1E1_Value1, ETbSame1Enum2::TS1E2_Value1);
 			TestDone.Execute();
 		});
 	});
@@ -211,7 +211,7 @@ void UTbSame1SameEnum2InterfaceOLinkSpec::Define()
 		TbSame1SameEnum2InterfaceSignals->OnSig1Signal.AddDynamic(ImplFixture->GetHelper().Get(), &UTbSame1SameEnum2InterfaceOLinkHelper::Sig1SignalCb);
 
 		// use different test value
-		ETbSame1Enum1 Param1TestValue = ETbSame1Enum1::TS1E1_VALUE2;
+		ETbSame1Enum1 Param1TestValue = ETbSame1Enum1::TS1E1_Value2;
 		TbSame1SameEnum2InterfaceSignals->BroadcastSig1Signal(Param1TestValue);
 	});
 
@@ -222,8 +222,8 @@ void UTbSame1SameEnum2InterfaceOLinkSpec::Define()
 		TbSame1SameEnum2InterfaceSignals->OnSig2Signal.AddDynamic(ImplFixture->GetHelper().Get(), &UTbSame1SameEnum2InterfaceOLinkHelper::Sig2SignalCb);
 
 		// use different test value
-		ETbSame1Enum1 Param1TestValue = ETbSame1Enum1::TS1E1_VALUE2;
-		ETbSame1Enum2 Param2TestValue = ETbSame1Enum2::TS1E2_VALUE2;
+		ETbSame1Enum1 Param1TestValue = ETbSame1Enum1::TS1E1_Value2;
+		ETbSame1Enum2 Param2TestValue = ETbSame1Enum2::TS1E2_Value2;
 		TbSame1SameEnum2InterfaceSignals->BroadcastSig2Signal(Param1TestValue, Param2TestValue);
 	});
 }

--- a/goldenmaster/Plugins/TbSame1/Source/TbSame1/Private/Tests/TbSame1SameEnum2InterfaceOLinkFixture.cpp
+++ b/goldenmaster/Plugins/TbSame1/Source/TbSame1/Private/Tests/TbSame1SameEnum2InterfaceOLinkFixture.cpp
@@ -42,9 +42,9 @@ void UTbSame1SameEnum2InterfaceOLinkHelper::SetTestDone(const FDoneDelegate& InD
 
 void UTbSame1SameEnum2InterfaceOLinkHelper::Prop1PropertyCb(ETbSame1Enum1 InProp1)
 {
-	ETbSame1Enum1 TestValue = ETbSame1Enum1::TS1E1_VALUE1;
+	ETbSame1Enum1 TestValue = ETbSame1Enum1::TS1E1_Value1;
 	// use different test value
-	TestValue = ETbSame1Enum1::TS1E1_VALUE2;
+	TestValue = ETbSame1Enum1::TS1E1_Value2;
 	Spec->TestEqual(TEXT("Delegate parameter should be the same value as set by the setter"), InProp1, TestValue);
 	if (TSharedPtr<FTbSame1SameEnum2InterfaceOLinkFixture> PinnedImplFixture = ImplFixture.Pin())
 	{
@@ -55,9 +55,9 @@ void UTbSame1SameEnum2InterfaceOLinkHelper::Prop1PropertyCb(ETbSame1Enum1 InProp
 
 void UTbSame1SameEnum2InterfaceOLinkHelper::Prop1PropertyChangeLocalCheckRemoteCb(ETbSame1Enum1 InProp1)
 {
-	ETbSame1Enum1 TestValue = ETbSame1Enum1::TS1E1_VALUE1;
+	ETbSame1Enum1 TestValue = ETbSame1Enum1::TS1E1_Value1;
 	// use different test value
-	TestValue = ETbSame1Enum1::TS1E1_VALUE2;
+	TestValue = ETbSame1Enum1::TS1E1_Value2;
 	Spec->TestEqual(TEXT("Delegate parameter should be the same value as set by the setter"), InProp1, TestValue);
 	if (TSharedPtr<FTbSame1SameEnum2InterfaceOLinkFixture> PinnedImplFixture = ImplFixture.Pin())
 	{
@@ -76,9 +76,9 @@ void UTbSame1SameEnum2InterfaceOLinkHelper::Prop1PropertyChangeLocalChangeRemote
 
 	if (count % 2 != 0)
 	{
-		ETbSame1Enum1 TestValue = ETbSame1Enum1::TS1E1_VALUE1;
+		ETbSame1Enum1 TestValue = ETbSame1Enum1::TS1E1_Value1;
 		// use different test value
-		TestValue = ETbSame1Enum1::TS1E1_VALUE2;
+		TestValue = ETbSame1Enum1::TS1E1_Value2;
 		Spec->TestEqual(TEXT("Delegate parameter should be the same value as set by the setter"), InProp1, TestValue);
 		if (TSharedPtr<FTbSame1SameEnum2InterfaceOLinkFixture> PinnedImplFixture = ImplFixture.Pin())
 		{
@@ -86,7 +86,7 @@ void UTbSame1SameEnum2InterfaceOLinkHelper::Prop1PropertyChangeLocalChangeRemote
 		}
 
 		// now set it to the default value
-		TestValue = ETbSame1Enum1::TS1E1_VALUE1; // default value
+		TestValue = ETbSame1Enum1::TS1E1_Value1; // default value
 		if (TSharedPtr<FTbSame1SameEnum2InterfaceOLinkFixture> PinnedImplFixture = ImplFixture.Pin())
 		{
 			PinnedImplFixture->GetImplementation()->Execute_SetProp1(PinnedImplFixture->GetImplementation().GetObject(), TestValue);
@@ -94,7 +94,7 @@ void UTbSame1SameEnum2InterfaceOLinkHelper::Prop1PropertyChangeLocalChangeRemote
 	}
 	else
 	{
-		ETbSame1Enum1 TestValue = ETbSame1Enum1::TS1E1_VALUE1; // default value
+		ETbSame1Enum1 TestValue = ETbSame1Enum1::TS1E1_Value1; // default value
 		Spec->TestEqual(TEXT("Delegate parameter should be the same value as set by the setter"), InProp1, TestValue);
 		if (TSharedPtr<FTbSame1SameEnum2InterfaceOLinkFixture> PinnedImplFixture = ImplFixture.Pin())
 		{
@@ -106,9 +106,9 @@ void UTbSame1SameEnum2InterfaceOLinkHelper::Prop1PropertyChangeLocalChangeRemote
 
 void UTbSame1SameEnum2InterfaceOLinkHelper::Prop2PropertyCb(ETbSame1Enum2 InProp2)
 {
-	ETbSame1Enum2 TestValue = ETbSame1Enum2::TS1E2_VALUE1;
+	ETbSame1Enum2 TestValue = ETbSame1Enum2::TS1E2_Value1;
 	// use different test value
-	TestValue = ETbSame1Enum2::TS1E2_VALUE2;
+	TestValue = ETbSame1Enum2::TS1E2_Value2;
 	Spec->TestEqual(TEXT("Delegate parameter should be the same value as set by the setter"), InProp2, TestValue);
 	if (TSharedPtr<FTbSame1SameEnum2InterfaceOLinkFixture> PinnedImplFixture = ImplFixture.Pin())
 	{
@@ -119,9 +119,9 @@ void UTbSame1SameEnum2InterfaceOLinkHelper::Prop2PropertyCb(ETbSame1Enum2 InProp
 
 void UTbSame1SameEnum2InterfaceOLinkHelper::Prop2PropertyChangeLocalCheckRemoteCb(ETbSame1Enum2 InProp2)
 {
-	ETbSame1Enum2 TestValue = ETbSame1Enum2::TS1E2_VALUE1;
+	ETbSame1Enum2 TestValue = ETbSame1Enum2::TS1E2_Value1;
 	// use different test value
-	TestValue = ETbSame1Enum2::TS1E2_VALUE2;
+	TestValue = ETbSame1Enum2::TS1E2_Value2;
 	Spec->TestEqual(TEXT("Delegate parameter should be the same value as set by the setter"), InProp2, TestValue);
 	if (TSharedPtr<FTbSame1SameEnum2InterfaceOLinkFixture> PinnedImplFixture = ImplFixture.Pin())
 	{
@@ -140,9 +140,9 @@ void UTbSame1SameEnum2InterfaceOLinkHelper::Prop2PropertyChangeLocalChangeRemote
 
 	if (count % 2 != 0)
 	{
-		ETbSame1Enum2 TestValue = ETbSame1Enum2::TS1E2_VALUE1;
+		ETbSame1Enum2 TestValue = ETbSame1Enum2::TS1E2_Value1;
 		// use different test value
-		TestValue = ETbSame1Enum2::TS1E2_VALUE2;
+		TestValue = ETbSame1Enum2::TS1E2_Value2;
 		Spec->TestEqual(TEXT("Delegate parameter should be the same value as set by the setter"), InProp2, TestValue);
 		if (TSharedPtr<FTbSame1SameEnum2InterfaceOLinkFixture> PinnedImplFixture = ImplFixture.Pin())
 		{
@@ -150,7 +150,7 @@ void UTbSame1SameEnum2InterfaceOLinkHelper::Prop2PropertyChangeLocalChangeRemote
 		}
 
 		// now set it to the default value
-		TestValue = ETbSame1Enum2::TS1E2_VALUE1; // default value
+		TestValue = ETbSame1Enum2::TS1E2_Value1; // default value
 		if (TSharedPtr<FTbSame1SameEnum2InterfaceOLinkFixture> PinnedImplFixture = ImplFixture.Pin())
 		{
 			PinnedImplFixture->GetImplementation()->Execute_SetProp2(PinnedImplFixture->GetImplementation().GetObject(), TestValue);
@@ -158,7 +158,7 @@ void UTbSame1SameEnum2InterfaceOLinkHelper::Prop2PropertyChangeLocalChangeRemote
 	}
 	else
 	{
-		ETbSame1Enum2 TestValue = ETbSame1Enum2::TS1E2_VALUE1; // default value
+		ETbSame1Enum2 TestValue = ETbSame1Enum2::TS1E2_Value1; // default value
 		Spec->TestEqual(TEXT("Delegate parameter should be the same value as set by the setter"), InProp2, TestValue);
 		if (TSharedPtr<FTbSame1SameEnum2InterfaceOLinkFixture> PinnedImplFixture = ImplFixture.Pin())
 		{
@@ -171,7 +171,7 @@ void UTbSame1SameEnum2InterfaceOLinkHelper::Prop2PropertyChangeLocalChangeRemote
 void UTbSame1SameEnum2InterfaceOLinkHelper::Sig1SignalCb(ETbSame1Enum1 InParam1)
 {
 	// known test value
-	ETbSame1Enum1 Param1TestValue = ETbSame1Enum1::TS1E1_VALUE2;
+	ETbSame1Enum1 Param1TestValue = ETbSame1Enum1::TS1E1_Value2;
 	Spec->TestEqual(TEXT("Parameter should be the same value as sent by the signal"), InParam1, Param1TestValue);
 	testDoneDelegate.Execute();
 }
@@ -179,9 +179,9 @@ void UTbSame1SameEnum2InterfaceOLinkHelper::Sig1SignalCb(ETbSame1Enum1 InParam1)
 void UTbSame1SameEnum2InterfaceOLinkHelper::Sig2SignalCb(ETbSame1Enum1 InParam1, ETbSame1Enum2 InParam2)
 {
 	// known test value
-	ETbSame1Enum1 Param1TestValue = ETbSame1Enum1::TS1E1_VALUE2;
+	ETbSame1Enum1 Param1TestValue = ETbSame1Enum1::TS1E1_Value2;
 	Spec->TestEqual(TEXT("Parameter should be the same value as sent by the signal"), InParam1, Param1TestValue);
-	ETbSame1Enum2 Param2TestValue = ETbSame1Enum2::TS1E2_VALUE2;
+	ETbSame1Enum2 Param2TestValue = ETbSame1Enum2::TS1E2_Value2;
 	Spec->TestEqual(TEXT("Parameter should be the same value as sent by the signal"), InParam2, Param2TestValue);
 	testDoneDelegate.Execute();
 }

--- a/goldenmaster/Plugins/TbSame1/Source/TbSame1/Public/Generated/MsgBus/TbSame1SameEnum1InterfaceMsgBusMessages.h
+++ b/goldenmaster/Plugins/TbSame1/Source/TbSame1/Public/Generated/MsgBus/TbSame1SameEnum1InterfaceMsgBusMessages.h
@@ -52,7 +52,7 @@ struct FTbSame1SameEnum1InterfaceInitMessage
 	int32 _ClientPingIntervalMS = 100;
 
 	UPROPERTY()
-	ETbSame1Enum1 Prop1 = ETbSame1Enum1::TS1E1_VALUE1;
+	ETbSame1Enum1 Prop1 = ETbSame1Enum1::TS1E1_Value1;
 };
 
 USTRUCT()
@@ -91,7 +91,7 @@ struct FTbSame1SameEnum1InterfaceSig1SignalMessage
 	GENERATED_BODY()
 
 	UPROPERTY()
-	ETbSame1Enum1 Param1 = ETbSame1Enum1::TS1E1_VALUE1;
+	ETbSame1Enum1 Param1 = ETbSame1Enum1::TS1E1_Value1;
 };
 
 USTRUCT()
@@ -100,7 +100,7 @@ struct FTbSame1SameEnum1InterfaceSetProp1RequestMessage
 	GENERATED_BODY()
 
 	UPROPERTY()
-	ETbSame1Enum1 Prop1 = ETbSame1Enum1::TS1E1_VALUE1;
+	ETbSame1Enum1 Prop1 = ETbSame1Enum1::TS1E1_Value1;
 };
 
 USTRUCT()
@@ -109,7 +109,7 @@ struct FTbSame1SameEnum1InterfaceProp1ChangedMessage
 	GENERATED_BODY()
 
 	UPROPERTY()
-	ETbSame1Enum1 Prop1 = ETbSame1Enum1::TS1E1_VALUE1;
+	ETbSame1Enum1 Prop1 = ETbSame1Enum1::TS1E1_Value1;
 };
 
 USTRUCT()
@@ -121,7 +121,7 @@ struct FTbSame1SameEnum1InterfaceFunc1RequestMessage
 	FGuid ResponseId;
 
 	UPROPERTY()
-	ETbSame1Enum1 Param1 = ETbSame1Enum1::TS1E1_VALUE1;
+	ETbSame1Enum1 Param1 = ETbSame1Enum1::TS1E1_Value1;
 };
 
 USTRUCT()
@@ -133,5 +133,5 @@ struct FTbSame1SameEnum1InterfaceFunc1ReplyMessage
 	FGuid ResponseId;
 
 	UPROPERTY()
-	ETbSame1Enum1 Result = ETbSame1Enum1::TS1E1_VALUE1;
+	ETbSame1Enum1 Result = ETbSame1Enum1::TS1E1_Value1;
 };

--- a/goldenmaster/Plugins/TbSame1/Source/TbSame1/Public/Generated/MsgBus/TbSame1SameEnum2InterfaceMsgBusMessages.h
+++ b/goldenmaster/Plugins/TbSame1/Source/TbSame1/Public/Generated/MsgBus/TbSame1SameEnum2InterfaceMsgBusMessages.h
@@ -52,10 +52,10 @@ struct FTbSame1SameEnum2InterfaceInitMessage
 	int32 _ClientPingIntervalMS = 100;
 
 	UPROPERTY()
-	ETbSame1Enum1 Prop1 = ETbSame1Enum1::TS1E1_VALUE1;
+	ETbSame1Enum1 Prop1 = ETbSame1Enum1::TS1E1_Value1;
 
 	UPROPERTY()
-	ETbSame1Enum2 Prop2 = ETbSame1Enum2::TS1E2_VALUE1;
+	ETbSame1Enum2 Prop2 = ETbSame1Enum2::TS1E2_Value1;
 };
 
 USTRUCT()
@@ -94,7 +94,7 @@ struct FTbSame1SameEnum2InterfaceSig1SignalMessage
 	GENERATED_BODY()
 
 	UPROPERTY()
-	ETbSame1Enum1 Param1 = ETbSame1Enum1::TS1E1_VALUE1;
+	ETbSame1Enum1 Param1 = ETbSame1Enum1::TS1E1_Value1;
 };
 
 USTRUCT()
@@ -103,10 +103,10 @@ struct FTbSame1SameEnum2InterfaceSig2SignalMessage
 	GENERATED_BODY()
 
 	UPROPERTY()
-	ETbSame1Enum1 Param1 = ETbSame1Enum1::TS1E1_VALUE1;
+	ETbSame1Enum1 Param1 = ETbSame1Enum1::TS1E1_Value1;
 
 	UPROPERTY()
-	ETbSame1Enum2 Param2 = ETbSame1Enum2::TS1E2_VALUE1;
+	ETbSame1Enum2 Param2 = ETbSame1Enum2::TS1E2_Value1;
 };
 
 USTRUCT()
@@ -115,7 +115,7 @@ struct FTbSame1SameEnum2InterfaceSetProp1RequestMessage
 	GENERATED_BODY()
 
 	UPROPERTY()
-	ETbSame1Enum1 Prop1 = ETbSame1Enum1::TS1E1_VALUE1;
+	ETbSame1Enum1 Prop1 = ETbSame1Enum1::TS1E1_Value1;
 };
 
 USTRUCT()
@@ -124,7 +124,7 @@ struct FTbSame1SameEnum2InterfaceProp1ChangedMessage
 	GENERATED_BODY()
 
 	UPROPERTY()
-	ETbSame1Enum1 Prop1 = ETbSame1Enum1::TS1E1_VALUE1;
+	ETbSame1Enum1 Prop1 = ETbSame1Enum1::TS1E1_Value1;
 };
 
 USTRUCT()
@@ -133,7 +133,7 @@ struct FTbSame1SameEnum2InterfaceSetProp2RequestMessage
 	GENERATED_BODY()
 
 	UPROPERTY()
-	ETbSame1Enum2 Prop2 = ETbSame1Enum2::TS1E2_VALUE1;
+	ETbSame1Enum2 Prop2 = ETbSame1Enum2::TS1E2_Value1;
 };
 
 USTRUCT()
@@ -142,7 +142,7 @@ struct FTbSame1SameEnum2InterfaceProp2ChangedMessage
 	GENERATED_BODY()
 
 	UPROPERTY()
-	ETbSame1Enum2 Prop2 = ETbSame1Enum2::TS1E2_VALUE1;
+	ETbSame1Enum2 Prop2 = ETbSame1Enum2::TS1E2_Value1;
 };
 
 USTRUCT()
@@ -154,7 +154,7 @@ struct FTbSame1SameEnum2InterfaceFunc1RequestMessage
 	FGuid ResponseId;
 
 	UPROPERTY()
-	ETbSame1Enum1 Param1 = ETbSame1Enum1::TS1E1_VALUE1;
+	ETbSame1Enum1 Param1 = ETbSame1Enum1::TS1E1_Value1;
 };
 
 USTRUCT()
@@ -166,7 +166,7 @@ struct FTbSame1SameEnum2InterfaceFunc1ReplyMessage
 	FGuid ResponseId;
 
 	UPROPERTY()
-	ETbSame1Enum1 Result = ETbSame1Enum1::TS1E1_VALUE1;
+	ETbSame1Enum1 Result = ETbSame1Enum1::TS1E1_Value1;
 };
 
 USTRUCT()
@@ -178,10 +178,10 @@ struct FTbSame1SameEnum2InterfaceFunc2RequestMessage
 	FGuid ResponseId;
 
 	UPROPERTY()
-	ETbSame1Enum1 Param1 = ETbSame1Enum1::TS1E1_VALUE1;
+	ETbSame1Enum1 Param1 = ETbSame1Enum1::TS1E1_Value1;
 
 	UPROPERTY()
-	ETbSame1Enum2 Param2 = ETbSame1Enum2::TS1E2_VALUE1;
+	ETbSame1Enum2 Param2 = ETbSame1Enum2::TS1E2_Value1;
 };
 
 USTRUCT()
@@ -193,5 +193,5 @@ struct FTbSame1SameEnum2InterfaceFunc2ReplyMessage
 	FGuid ResponseId;
 
 	UPROPERTY()
-	ETbSame1Enum1 Result = ETbSame1Enum1::TS1E1_VALUE1;
+	ETbSame1Enum1 Result = ETbSame1Enum1::TS1E1_Value1;
 };

--- a/goldenmaster/Plugins/TbSame1/Source/TbSame1/Public/Generated/api/AbstractTbSame1SameEnum1Interface.h
+++ b/goldenmaster/Plugins/TbSame1/Source/TbSame1/Public/Generated/api/AbstractTbSame1SameEnum1Interface.h
@@ -42,10 +42,10 @@ public:
 
 	// methods
 	virtual void Func1Async_Implementation(UObject* WorldContextObject, FLatentActionInfo LatentInfo, ETbSame1Enum1& Result, ETbSame1Enum1 Param1) override;
-	virtual ETbSame1Enum1 Func1_Implementation(ETbSame1Enum1 Param1) override PURE_VIRTUAL(UAbstractTbSame1SameEnum1Interface::Func1_Implementation, return ETbSame1Enum1::TS1E1_VALUE1;);
+	virtual ETbSame1Enum1 Func1_Implementation(ETbSame1Enum1 Param1) override PURE_VIRTUAL(UAbstractTbSame1SameEnum1Interface::Func1_Implementation, return ETbSame1Enum1::TS1E1_Value1;);
 
 	// properties
-	virtual ETbSame1Enum1 GetProp1_Implementation() const override PURE_VIRTUAL(UAbstractTbSame1SameEnum1Interface::GetProp1_Implementation, return ETbSame1Enum1::TS1E1_VALUE1;);
+	virtual ETbSame1Enum1 GetProp1_Implementation() const override PURE_VIRTUAL(UAbstractTbSame1SameEnum1Interface::GetProp1_Implementation, return ETbSame1Enum1::TS1E1_Value1;);
 	virtual void SetProp1_Implementation(ETbSame1Enum1 InProp1) override PURE_VIRTUAL(UAbstractTbSame1SameEnum1Interface::SetProp1_Implementation, return;);
 
 	virtual bool IsInitialized() const;
@@ -55,7 +55,7 @@ protected:
 
 	// properties - local copy
 	UPROPERTY(EditAnywhere, BlueprintGetter = GetProp1_Private, BlueprintSetter = SetProp1_Private, Category = "ApiGear|TbSame1|SameEnum1Interface")
-	ETbSame1Enum1 Prop1{ETbSame1Enum1::TS1E1_VALUE1};
+	ETbSame1Enum1 Prop1{ETbSame1Enum1::TS1E1_Value1};
 
 	UFUNCTION(BlueprintGetter, Category = "ApiGear|TbSame1|SameEnum1Interface|Properties", BlueprintInternalUseOnly)
 	ETbSame1Enum1 GetProp1_Private() const;

--- a/goldenmaster/Plugins/TbSame1/Source/TbSame1/Public/Generated/api/AbstractTbSame1SameEnum2Interface.h
+++ b/goldenmaster/Plugins/TbSame1/Source/TbSame1/Public/Generated/api/AbstractTbSame1SameEnum2Interface.h
@@ -42,16 +42,16 @@ public:
 
 	// methods
 	virtual void Func1Async_Implementation(UObject* WorldContextObject, FLatentActionInfo LatentInfo, ETbSame1Enum1& Result, ETbSame1Enum1 Param1) override;
-	virtual ETbSame1Enum1 Func1_Implementation(ETbSame1Enum1 Param1) override PURE_VIRTUAL(UAbstractTbSame1SameEnum2Interface::Func1_Implementation, return ETbSame1Enum1::TS1E1_VALUE1;);
+	virtual ETbSame1Enum1 Func1_Implementation(ETbSame1Enum1 Param1) override PURE_VIRTUAL(UAbstractTbSame1SameEnum2Interface::Func1_Implementation, return ETbSame1Enum1::TS1E1_Value1;);
 
 	virtual void Func2Async_Implementation(UObject* WorldContextObject, FLatentActionInfo LatentInfo, ETbSame1Enum1& Result, ETbSame1Enum1 Param1, ETbSame1Enum2 Param2) override;
-	virtual ETbSame1Enum1 Func2_Implementation(ETbSame1Enum1 Param1, ETbSame1Enum2 Param2) override PURE_VIRTUAL(UAbstractTbSame1SameEnum2Interface::Func2_Implementation, return ETbSame1Enum1::TS1E1_VALUE1;);
+	virtual ETbSame1Enum1 Func2_Implementation(ETbSame1Enum1 Param1, ETbSame1Enum2 Param2) override PURE_VIRTUAL(UAbstractTbSame1SameEnum2Interface::Func2_Implementation, return ETbSame1Enum1::TS1E1_Value1;);
 
 	// properties
-	virtual ETbSame1Enum1 GetProp1_Implementation() const override PURE_VIRTUAL(UAbstractTbSame1SameEnum2Interface::GetProp1_Implementation, return ETbSame1Enum1::TS1E1_VALUE1;);
+	virtual ETbSame1Enum1 GetProp1_Implementation() const override PURE_VIRTUAL(UAbstractTbSame1SameEnum2Interface::GetProp1_Implementation, return ETbSame1Enum1::TS1E1_Value1;);
 	virtual void SetProp1_Implementation(ETbSame1Enum1 InProp1) override PURE_VIRTUAL(UAbstractTbSame1SameEnum2Interface::SetProp1_Implementation, return;);
 
-	virtual ETbSame1Enum2 GetProp2_Implementation() const override PURE_VIRTUAL(UAbstractTbSame1SameEnum2Interface::GetProp2_Implementation, return ETbSame1Enum2::TS1E2_VALUE1;);
+	virtual ETbSame1Enum2 GetProp2_Implementation() const override PURE_VIRTUAL(UAbstractTbSame1SameEnum2Interface::GetProp2_Implementation, return ETbSame1Enum2::TS1E2_Value1;);
 	virtual void SetProp2_Implementation(ETbSame1Enum2 InProp2) override PURE_VIRTUAL(UAbstractTbSame1SameEnum2Interface::SetProp2_Implementation, return;);
 
 	virtual bool IsInitialized() const;
@@ -61,7 +61,7 @@ protected:
 
 	// properties - local copy
 	UPROPERTY(EditAnywhere, BlueprintGetter = GetProp1_Private, BlueprintSetter = SetProp1_Private, Category = "ApiGear|TbSame1|SameEnum2Interface")
-	ETbSame1Enum1 Prop1{ETbSame1Enum1::TS1E1_VALUE1};
+	ETbSame1Enum1 Prop1{ETbSame1Enum1::TS1E1_Value1};
 
 	UFUNCTION(BlueprintGetter, Category = "ApiGear|TbSame1|SameEnum2Interface|Properties", BlueprintInternalUseOnly)
 	ETbSame1Enum1 GetProp1_Private() const;
@@ -70,7 +70,7 @@ protected:
 	void SetProp1_Private(ETbSame1Enum1 InProp1);
 
 	UPROPERTY(EditAnywhere, BlueprintGetter = GetProp2_Private, BlueprintSetter = SetProp2_Private, Category = "ApiGear|TbSame1|SameEnum2Interface")
-	ETbSame1Enum2 Prop2{ETbSame1Enum2::TS1E2_VALUE1};
+	ETbSame1Enum2 Prop2{ETbSame1Enum2::TS1E2_Value1};
 
 	UFUNCTION(BlueprintGetter, Category = "ApiGear|TbSame1|SameEnum2Interface|Properties", BlueprintInternalUseOnly)
 	ETbSame1Enum2 GetProp2_Private() const;

--- a/goldenmaster/Plugins/TbSame1/Source/TbSame1/Public/Generated/api/TbSame1_data.h
+++ b/goldenmaster/Plugins/TbSame1/Source/TbSame1/Public/Generated/api/TbSame1_data.h
@@ -28,9 +28,9 @@ limitations under the License.
 UENUM(BlueprintType)
 enum class ETbSame1Enum1 : uint8
 {
-	TS1E1_VALUE1 = 1 UMETA(Displayname = "value1"),
-	TS1E1_VALUE2 = 2 UMETA(Displayname = "value2"),
-	UNSPECIFIED = 0 UMETA(Hidden)
+	TS1E1_Value1 = 1 UMETA(Displayname = "value1"),
+	TS1E1_Value2 = 2 UMETA(Displayname = "value2"),
+	Unspecified = 0 UMETA(Hidden)
 };
 
 /**
@@ -39,9 +39,9 @@ enum class ETbSame1Enum1 : uint8
 UENUM(BlueprintType)
 enum class ETbSame1Enum2 : uint8
 {
-	TS1E2_VALUE1 = 1 UMETA(Displayname = "value1"),
-	TS1E2_VALUE2 = 2 UMETA(Displayname = "value2"),
-	UNSPECIFIED = 0 UMETA(Hidden)
+	TS1E2_Value1 = 1 UMETA(Displayname = "value1"),
+	TS1E2_Value2 = 2 UMETA(Displayname = "value2"),
+	Unspecified = 0 UMETA(Hidden)
 };
 
 /**

--- a/goldenmaster/Plugins/TbSame2/Source/TbSame2/Private/Generated/MsgBus/TbSame2SameEnum1InterfaceMsgBusClient.cpp
+++ b/goldenmaster/Plugins/TbSame2/Source/TbSame2/Private/Generated/MsgBus/TbSame2SameEnum1InterfaceMsgBusClient.cpp
@@ -37,7 +37,7 @@ limitations under the License.
 */
 struct TbSame2SameEnum1InterfacePropertiesMsgBusData
 {
-	std::atomic<ETbSame2Enum1> Prop1{ETbSame2Enum1::TS2E1_VALUE1};
+	std::atomic<ETbSame2Enum1> Prop1{ETbSame2Enum1::TS2E1_Value1};
 };
 DEFINE_LOG_CATEGORY(LogTbSame2SameEnum1InterfaceMsgBusClient);
 
@@ -335,7 +335,7 @@ ETbSame2Enum1 UTbSame2SameEnum1InterfaceMsgBusClient::Func1_Implementation(ETbSa
 	{
 		UE_LOG(LogTbSame2SameEnum1InterfaceMsgBusClient, Error, TEXT("Client has no connection to service."));
 
-		return ETbSame2Enum1::TS2E1_VALUE1;
+		return ETbSame2Enum1::TS2E1_Value1;
 	}
 
 	auto msg = new FTbSame2SameEnum1InterfaceFunc1RequestMessage();

--- a/goldenmaster/Plugins/TbSame2/Source/TbSame2/Private/Generated/MsgBus/TbSame2SameEnum2InterfaceMsgBusClient.cpp
+++ b/goldenmaster/Plugins/TbSame2/Source/TbSame2/Private/Generated/MsgBus/TbSame2SameEnum2InterfaceMsgBusClient.cpp
@@ -37,8 +37,8 @@ limitations under the License.
 */
 struct TbSame2SameEnum2InterfacePropertiesMsgBusData
 {
-	std::atomic<ETbSame2Enum1> Prop1{ETbSame2Enum1::TS2E1_VALUE1};
-	std::atomic<ETbSame2Enum2> Prop2{ETbSame2Enum2::TS2E2_VALUE1};
+	std::atomic<ETbSame2Enum1> Prop1{ETbSame2Enum1::TS2E1_Value1};
+	std::atomic<ETbSame2Enum2> Prop2{ETbSame2Enum2::TS2E2_Value1};
 };
 DEFINE_LOG_CATEGORY(LogTbSame2SameEnum2InterfaceMsgBusClient);
 
@@ -384,7 +384,7 @@ ETbSame2Enum1 UTbSame2SameEnum2InterfaceMsgBusClient::Func1_Implementation(ETbSa
 	{
 		UE_LOG(LogTbSame2SameEnum2InterfaceMsgBusClient, Error, TEXT("Client has no connection to service."));
 
-		return ETbSame2Enum1::TS2E1_VALUE1;
+		return ETbSame2Enum1::TS2E1_Value1;
 	}
 
 	auto msg = new FTbSame2SameEnum2InterfaceFunc1RequestMessage();
@@ -413,7 +413,7 @@ ETbSame2Enum1 UTbSame2SameEnum2InterfaceMsgBusClient::Func2_Implementation(ETbSa
 	{
 		UE_LOG(LogTbSame2SameEnum2InterfaceMsgBusClient, Error, TEXT("Client has no connection to service."));
 
-		return ETbSame2Enum1::TS2E1_VALUE1;
+		return ETbSame2Enum1::TS2E1_Value1;
 	}
 
 	auto msg = new FTbSame2SameEnum2InterfaceFunc2RequestMessage();

--- a/goldenmaster/Plugins/TbSame2/Source/TbSame2/Private/Generated/OLink/TbSame2SameEnum1InterfaceOLinkClient.cpp
+++ b/goldenmaster/Plugins/TbSame2/Source/TbSame2/Private/Generated/OLink/TbSame2SameEnum1InterfaceOLinkClient.cpp
@@ -42,7 +42,7 @@ THIRD_PARTY_INCLUDES_END
 */
 struct TbSame2SameEnum1InterfacePropertiesData
 {
-	std::atomic<ETbSame2Enum1> Prop1{ETbSame2Enum1::TS2E1_VALUE1};
+	std::atomic<ETbSame2Enum1> Prop1{ETbSame2Enum1::TS2E1_Value1};
 };
 DEFINE_LOG_CATEGORY(LogTbSame2SameEnum1InterfaceOLinkClient);
 
@@ -185,7 +185,7 @@ ETbSame2Enum1 UTbSame2SameEnum1InterfaceOLinkClient::Func1_Implementation(ETbSam
 	{
 		UE_LOG(LogTbSame2SameEnum1InterfaceOLinkClient, Error, TEXT("%s has no node. Probably no valid connection or service. Are the ApiGear TbSame2 plugin settings correct? Service set up correctly?"), UTF8_TO_TCHAR(m_sink->olinkObjectName().c_str()));
 
-		return ETbSame2Enum1::TS2E1_VALUE1;
+		return ETbSame2Enum1::TS2E1_Value1;
 	}
 	TPromise<ETbSame2Enum1> Promise;
 	Async(EAsyncExecution::ThreadPool,

--- a/goldenmaster/Plugins/TbSame2/Source/TbSame2/Private/Generated/OLink/TbSame2SameEnum2InterfaceOLinkClient.cpp
+++ b/goldenmaster/Plugins/TbSame2/Source/TbSame2/Private/Generated/OLink/TbSame2SameEnum2InterfaceOLinkClient.cpp
@@ -42,8 +42,8 @@ THIRD_PARTY_INCLUDES_END
 */
 struct TbSame2SameEnum2InterfacePropertiesData
 {
-	std::atomic<ETbSame2Enum1> Prop1{ETbSame2Enum1::TS2E1_VALUE1};
-	std::atomic<ETbSame2Enum2> Prop2{ETbSame2Enum2::TS2E2_VALUE1};
+	std::atomic<ETbSame2Enum1> Prop1{ETbSame2Enum1::TS2E1_Value1};
+	std::atomic<ETbSame2Enum2> Prop2{ETbSame2Enum2::TS2E2_Value1};
 };
 DEFINE_LOG_CATEGORY(LogTbSame2SameEnum2InterfaceOLinkClient);
 
@@ -215,7 +215,7 @@ ETbSame2Enum1 UTbSame2SameEnum2InterfaceOLinkClient::Func1_Implementation(ETbSam
 	{
 		UE_LOG(LogTbSame2SameEnum2InterfaceOLinkClient, Error, TEXT("%s has no node. Probably no valid connection or service. Are the ApiGear TbSame2 plugin settings correct? Service set up correctly?"), UTF8_TO_TCHAR(m_sink->olinkObjectName().c_str()));
 
-		return ETbSame2Enum1::TS2E1_VALUE1;
+		return ETbSame2Enum1::TS2E1_Value1;
 	}
 	TPromise<ETbSame2Enum1> Promise;
 	Async(EAsyncExecution::ThreadPool,
@@ -246,7 +246,7 @@ ETbSame2Enum1 UTbSame2SameEnum2InterfaceOLinkClient::Func2_Implementation(ETbSam
 	{
 		UE_LOG(LogTbSame2SameEnum2InterfaceOLinkClient, Error, TEXT("%s has no node. Probably no valid connection or service. Are the ApiGear TbSame2 plugin settings correct? Service set up correctly?"), UTF8_TO_TCHAR(m_sink->olinkObjectName().c_str()));
 
-		return ETbSame2Enum1::TS2E1_VALUE1;
+		return ETbSame2Enum1::TS2E1_Value1;
 	}
 	TPromise<ETbSame2Enum1> Promise;
 	Async(EAsyncExecution::ThreadPool,

--- a/goldenmaster/Plugins/TbSame2/Source/TbSame2/Private/Generated/api/TbSame2_data.cpp
+++ b/goldenmaster/Plugins/TbSame2/Source/TbSame2/Private/Generated/api/TbSame2_data.cpp
@@ -27,15 +27,15 @@ bool UTbSame2Library::toTbSame2Enum1(ETbSame2Enum1& ConvertedEnum, uint8 InValue
 	switch (InValue)
 	{
 	case 1:
-		ConvertedEnum = ETbSame2Enum1::TS2E1_VALUE1;
+		ConvertedEnum = ETbSame2Enum1::TS2E1_Value1;
 		bSuccessful = true;
 		break;
 	case 2:
-		ConvertedEnum = ETbSame2Enum1::TS2E1_VALUE2;
+		ConvertedEnum = ETbSame2Enum1::TS2E1_Value2;
 		bSuccessful = true;
 		break;
 	default:
-		ConvertedEnum = ETbSame2Enum1::TS2E1_VALUE1;
+		ConvertedEnum = ETbSame2Enum1::TS2E1_Value1;
 	}
 	return bSuccessful;
 }
@@ -48,15 +48,15 @@ bool UTbSame2Library::toTbSame2Enum2(ETbSame2Enum2& ConvertedEnum, uint8 InValue
 	switch (InValue)
 	{
 	case 1:
-		ConvertedEnum = ETbSame2Enum2::TS2E2_VALUE1;
+		ConvertedEnum = ETbSame2Enum2::TS2E2_Value1;
 		bSuccessful = true;
 		break;
 	case 2:
-		ConvertedEnum = ETbSame2Enum2::TS2E2_VALUE2;
+		ConvertedEnum = ETbSame2Enum2::TS2E2_Value2;
 		bSuccessful = true;
 		break;
 	default:
-		ConvertedEnum = ETbSame2Enum2::TS2E2_VALUE1;
+		ConvertedEnum = ETbSame2Enum2::TS2E2_Value1;
 	}
 	return bSuccessful;
 }

--- a/goldenmaster/Plugins/TbSame2/Source/TbSame2/Private/Implementation/TbSame2SameEnum1Interface.cpp
+++ b/goldenmaster/Plugins/TbSame2/Source/TbSame2/Private/Implementation/TbSame2SameEnum1Interface.cpp
@@ -36,14 +36,14 @@ ETbSame2Enum1 UTbSame2SameEnum1Interface::Func1_Implementation(ETbSame2Enum1 Par
 {
 	(void)Param1;
 	// do business logic here
-	return ETbSame2Enum1::TS2E1_VALUE1;
+	return ETbSame2Enum1::TS2E1_Value1;
 }
 
 void UTbSame2SameEnum1Interface::_ResetProperties()
 {
-	if (Prop1 != ETbSame2Enum1::TS2E1_VALUE1)
+	if (Prop1 != ETbSame2Enum1::TS2E1_Value1)
 	{
-		Prop1 = ETbSame2Enum1::TS2E1_VALUE1;
+		Prop1 = ETbSame2Enum1::TS2E1_Value1;
 		Execute__GetSignals(this)->OnProp1Changed.Broadcast(Prop1);
 	}
 }

--- a/goldenmaster/Plugins/TbSame2/Source/TbSame2/Private/Implementation/TbSame2SameEnum2Interface.cpp
+++ b/goldenmaster/Plugins/TbSame2/Source/TbSame2/Private/Implementation/TbSame2SameEnum2Interface.cpp
@@ -49,7 +49,7 @@ ETbSame2Enum1 UTbSame2SameEnum2Interface::Func1_Implementation(ETbSame2Enum1 Par
 {
 	(void)Param1;
 	// do business logic here
-	return ETbSame2Enum1::TS2E1_VALUE1;
+	return ETbSame2Enum1::TS2E1_Value1;
 }
 
 ETbSame2Enum1 UTbSame2SameEnum2Interface::Func2_Implementation(ETbSame2Enum1 Param1, ETbSame2Enum2 Param2)
@@ -57,19 +57,19 @@ ETbSame2Enum1 UTbSame2SameEnum2Interface::Func2_Implementation(ETbSame2Enum1 Par
 	(void)Param1;
 	(void)Param2;
 	// do business logic here
-	return ETbSame2Enum1::TS2E1_VALUE1;
+	return ETbSame2Enum1::TS2E1_Value1;
 }
 
 void UTbSame2SameEnum2Interface::_ResetProperties()
 {
-	if (Prop1 != ETbSame2Enum1::TS2E1_VALUE1)
+	if (Prop1 != ETbSame2Enum1::TS2E1_Value1)
 	{
-		Prop1 = ETbSame2Enum1::TS2E1_VALUE1;
+		Prop1 = ETbSame2Enum1::TS2E1_Value1;
 		Execute__GetSignals(this)->OnProp1Changed.Broadcast(Prop1);
 	}
-	if (Prop2 != ETbSame2Enum2::TS2E2_VALUE1)
+	if (Prop2 != ETbSame2Enum2::TS2E2_Value1)
 	{
-		Prop2 = ETbSame2Enum2::TS2E2_VALUE1;
+		Prop2 = ETbSame2Enum2::TS2E2_Value1;
 		Execute__GetSignals(this)->OnProp2Changed.Broadcast(Prop2);
 	}
 }

--- a/goldenmaster/Plugins/TbSame2/Source/TbSame2/Private/Tests/TbSame2SameEnum1InterfaceImpl.spec.cpp
+++ b/goldenmaster/Plugins/TbSame2/Source/TbSame2/Private/Tests/TbSame2SameEnum1InterfaceImpl.spec.cpp
@@ -50,28 +50,28 @@ void UTbSame2SameEnum1InterfaceImplSpec::Define()
 	It("Property.Prop1.Default", [this]()
 		{
 		// Do implement test here
-		ETbSame2Enum1 TestValue = ETbSame2Enum1::TS2E1_VALUE1; // default value
+		ETbSame2Enum1 TestValue = ETbSame2Enum1::TS2E1_Value1; // default value
 		TestEqual(TEXT("Getter should return the default value"), ImplFixture->GetImplementation()->Execute_GetProp1(ImplFixture->GetImplementation().GetObject()), TestValue);
 	});
 
 	LatentIt("Property.Prop1.Change", EAsyncExecution::ThreadPool, [this](const FDoneDelegate TestDone)
 		{
 		// Do implement test here
-		ETbSame2Enum1 TestValue = ETbSame2Enum1::TS2E1_VALUE1; // default value
+		ETbSame2Enum1 TestValue = ETbSame2Enum1::TS2E1_Value1; // default value
 		TestEqual(TEXT("Getter should return the default value"), ImplFixture->GetImplementation()->Execute_GetProp1(ImplFixture->GetImplementation().GetObject()), TestValue);
 
 		ImplFixture->GetHelper()->SetTestDone(TestDone);
 		UTbSame2SameEnum1InterfaceSignals* TbSame2SameEnum1InterfaceSignals = ImplFixture->GetImplementation()->Execute__GetSignals(ImplFixture->GetImplementation().GetObject());
 		TbSame2SameEnum1InterfaceSignals->OnProp1Changed.AddDynamic(ImplFixture->GetHelper().Get(), &UTbSame2SameEnum1InterfaceImplHelper::Prop1PropertyCb);
 		// use different test value
-		TestValue = ETbSame2Enum1::TS2E1_VALUE2;
+		TestValue = ETbSame2Enum1::TS2E1_Value2;
 		ImplFixture->GetImplementation()->Execute_SetProp1(ImplFixture->GetImplementation().GetObject(), TestValue);
 	});
 
 	It("Operation.Func1", [this]()
 		{
 		// Do implement test here
-		ImplFixture->GetImplementation()->Execute_Func1(ImplFixture->GetImplementation().GetObject(), ETbSame2Enum1::TS2E1_VALUE1);
+		ImplFixture->GetImplementation()->Execute_Func1(ImplFixture->GetImplementation().GetObject(), ETbSame2Enum1::TS2E1_Value1);
 	});
 
 	LatentIt("Signal.Sig1", EAsyncExecution::ThreadPool, [this](const FDoneDelegate TestDone)
@@ -81,7 +81,7 @@ void UTbSame2SameEnum1InterfaceImplSpec::Define()
 		TbSame2SameEnum1InterfaceSignals->OnSig1Signal.AddDynamic(ImplFixture->GetHelper().Get(), &UTbSame2SameEnum1InterfaceImplHelper::Sig1SignalCb);
 
 		// use different test value
-		ETbSame2Enum1 Param1TestValue = ETbSame2Enum1::TS2E1_VALUE2;
+		ETbSame2Enum1 Param1TestValue = ETbSame2Enum1::TS2E1_Value2;
 		TbSame2SameEnum1InterfaceSignals->BroadcastSig1Signal(Param1TestValue);
 	});
 }

--- a/goldenmaster/Plugins/TbSame2/Source/TbSame2/Private/Tests/TbSame2SameEnum1InterfaceImplFixture.cpp
+++ b/goldenmaster/Plugins/TbSame2/Source/TbSame2/Private/Tests/TbSame2SameEnum1InterfaceImplFixture.cpp
@@ -39,9 +39,9 @@ void UTbSame2SameEnum1InterfaceImplHelper::SetTestDone(const FDoneDelegate& InDo
 
 void UTbSame2SameEnum1InterfaceImplHelper::Prop1PropertyCb(ETbSame2Enum1 InProp1)
 {
-	ETbSame2Enum1 TestValue = ETbSame2Enum1::TS2E1_VALUE1;
+	ETbSame2Enum1 TestValue = ETbSame2Enum1::TS2E1_Value1;
 	// use different test value
-	TestValue = ETbSame2Enum1::TS2E1_VALUE2;
+	TestValue = ETbSame2Enum1::TS2E1_Value2;
 	Spec->TestEqual(TEXT("Delegate parameter should be the same value as set by the setter"), InProp1, TestValue);
 	if (TSharedPtr<FTbSame2SameEnum1InterfaceImplFixture> PinnedImplFixture = ImplFixture.Pin())
 	{
@@ -53,7 +53,7 @@ void UTbSame2SameEnum1InterfaceImplHelper::Prop1PropertyCb(ETbSame2Enum1 InProp1
 void UTbSame2SameEnum1InterfaceImplHelper::Sig1SignalCb(ETbSame2Enum1 InParam1)
 {
 	// known test value
-	ETbSame2Enum1 Param1TestValue = ETbSame2Enum1::TS2E1_VALUE2;
+	ETbSame2Enum1 Param1TestValue = ETbSame2Enum1::TS2E1_Value2;
 	Spec->TestEqual(TEXT("Parameter should be the same value as sent by the signal"), InParam1, Param1TestValue);
 	testDoneDelegate.Execute();
 }

--- a/goldenmaster/Plugins/TbSame2/Source/TbSame2/Private/Tests/TbSame2SameEnum1InterfaceMsgBus.spec.cpp
+++ b/goldenmaster/Plugins/TbSame2/Source/TbSame2/Private/Tests/TbSame2SameEnum1InterfaceMsgBus.spec.cpp
@@ -67,35 +67,35 @@ void UTbSame2SameEnum1InterfaceMsgBusSpec::Define()
 	It("Property.Prop1.Default", [this]()
 		{
 		// Do implement test here
-		ETbSame2Enum1 TestValue = ETbSame2Enum1::TS2E1_VALUE1; // default value
+		ETbSame2Enum1 TestValue = ETbSame2Enum1::TS2E1_Value1; // default value
 		TestEqual(TEXT("Getter should return the default value"), ImplFixture->GetImplementation()->Execute_GetProp1(ImplFixture->GetImplementation().GetObject()), TestValue);
 	});
 
 	LatentIt("Property.Prop1.Change", EAsyncExecution::ThreadPool, [this](const FDoneDelegate TestDone)
 		{
 		// Do implement test here
-		ETbSame2Enum1 TestValue = ETbSame2Enum1::TS2E1_VALUE1; // default value
+		ETbSame2Enum1 TestValue = ETbSame2Enum1::TS2E1_Value1; // default value
 		TestEqual(TEXT("Getter should return the default value"), ImplFixture->GetImplementation()->Execute_GetProp1(ImplFixture->GetImplementation().GetObject()), TestValue);
 
 		ImplFixture->GetHelper()->SetTestDone(TestDone);
 		UTbSame2SameEnum1InterfaceSignals* TbSame2SameEnum1InterfaceSignals = ImplFixture->GetImplementation()->Execute__GetSignals(ImplFixture->GetImplementation().GetObject());
 		TbSame2SameEnum1InterfaceSignals->OnProp1Changed.AddDynamic(ImplFixture->GetHelper().Get(), &UTbSame2SameEnum1InterfaceMsgBusHelper::Prop1PropertyCb);
 		// use different test value
-		TestValue = ETbSame2Enum1::TS2E1_VALUE2;
+		TestValue = ETbSame2Enum1::TS2E1_Value2;
 		ImplFixture->GetImplementation()->Execute_SetProp1(ImplFixture->GetImplementation().GetObject(), TestValue);
 	});
 
 	LatentIt("Property.Prop1.ChangeLocalCheckRemote", EAsyncExecution::ThreadPool, [this](const FDoneDelegate TestDone)
 		{
 		// Do implement test here
-		ETbSame2Enum1 TestValue = ETbSame2Enum1::TS2E1_VALUE1; // default value
+		ETbSame2Enum1 TestValue = ETbSame2Enum1::TS2E1_Value1; // default value
 		TestEqual(TEXT("Getter should return the default value"), ImplFixture->GetImplementation()->Execute_GetProp1(ImplFixture->GetImplementation().GetObject()), TestValue);
 
 		ImplFixture->GetHelper()->SetTestDone(TestDone);
 		UTbSame2SameEnum1InterfaceSignals* TbSame2SameEnum1InterfaceSignals = ImplFixture->GetImplementation()->Execute__GetSignals(ImplFixture->GetImplementation().GetObject());
 		TbSame2SameEnum1InterfaceSignals->OnProp1Changed.AddDynamic(ImplFixture->GetHelper().Get(), &UTbSame2SameEnum1InterfaceMsgBusHelper::Prop1PropertyChangeLocalCheckRemoteCb);
 		// use different test value
-		TestValue = ETbSame2Enum1::TS2E1_VALUE2;
+		TestValue = ETbSame2Enum1::TS2E1_Value2;
 		auto service = ImplFixture->GetGameInstance()->GetSubsystem<UTbSame2SameEnum1Interface>();
 		service->Execute_SetProp1(service, TestValue);
 	});
@@ -103,14 +103,14 @@ void UTbSame2SameEnum1InterfaceMsgBusSpec::Define()
 	LatentIt("Property.Prop1.ChangeLocalChangeBackRemote", EAsyncExecution::ThreadPool, [this](const FDoneDelegate TestDone)
 		{
 		// Do implement test here
-		ETbSame2Enum1 TestValue = ETbSame2Enum1::TS2E1_VALUE1; // default value
+		ETbSame2Enum1 TestValue = ETbSame2Enum1::TS2E1_Value1; // default value
 		TestEqual(TEXT("Getter should return the default value"), ImplFixture->GetImplementation()->Execute_GetProp1(ImplFixture->GetImplementation().GetObject()), TestValue);
 
 		ImplFixture->GetHelper()->SetTestDone(TestDone);
 		UTbSame2SameEnum1InterfaceSignals* TbSame2SameEnum1InterfaceSignals = ImplFixture->GetImplementation()->Execute__GetSignals(ImplFixture->GetImplementation().GetObject());
 		TbSame2SameEnum1InterfaceSignals->OnProp1Changed.AddDynamic(ImplFixture->GetHelper().Get(), &UTbSame2SameEnum1InterfaceMsgBusHelper::Prop1PropertyChangeLocalChangeRemoteCb);
 		// use different test value
-		TestValue = ETbSame2Enum1::TS2E1_VALUE2;
+		TestValue = ETbSame2Enum1::TS2E1_Value2;
 		auto service = ImplFixture->GetGameInstance()->GetSubsystem<UTbSame2SameEnum1Interface>();
 		service->Execute_SetProp1(service, TestValue);
 	});
@@ -120,7 +120,7 @@ void UTbSame2SameEnum1InterfaceMsgBusSpec::Define()
 		// Do implement test here
 		AsyncTask(ENamedThreads::AnyThread, [this, TestDone]()
 			{
-			ImplFixture->GetImplementation()->Execute_Func1(ImplFixture->GetImplementation().GetObject(), ETbSame2Enum1::TS2E1_VALUE1);
+			ImplFixture->GetImplementation()->Execute_Func1(ImplFixture->GetImplementation().GetObject(), ETbSame2Enum1::TS2E1_Value1);
 			TestDone.Execute();
 		});
 	});
@@ -132,7 +132,7 @@ void UTbSame2SameEnum1InterfaceMsgBusSpec::Define()
 		TbSame2SameEnum1InterfaceSignals->OnSig1Signal.AddDynamic(ImplFixture->GetHelper().Get(), &UTbSame2SameEnum1InterfaceMsgBusHelper::Sig1SignalCb);
 
 		// use different test value
-		ETbSame2Enum1 Param1TestValue = ETbSame2Enum1::TS2E1_VALUE2;
+		ETbSame2Enum1 Param1TestValue = ETbSame2Enum1::TS2E1_Value2;
 		TbSame2SameEnum1InterfaceSignals->BroadcastSig1Signal(Param1TestValue);
 	});
 }

--- a/goldenmaster/Plugins/TbSame2/Source/TbSame2/Private/Tests/TbSame2SameEnum1InterfaceMsgBusFixture.cpp
+++ b/goldenmaster/Plugins/TbSame2/Source/TbSame2/Private/Tests/TbSame2SameEnum1InterfaceMsgBusFixture.cpp
@@ -45,9 +45,9 @@ void UTbSame2SameEnum1InterfaceMsgBusHelper::SetTestDone(const FDoneDelegate& In
 
 void UTbSame2SameEnum1InterfaceMsgBusHelper::Prop1PropertyCb(ETbSame2Enum1 InProp1)
 {
-	ETbSame2Enum1 TestValue = ETbSame2Enum1::TS2E1_VALUE1;
+	ETbSame2Enum1 TestValue = ETbSame2Enum1::TS2E1_Value1;
 	// use different test value
-	TestValue = ETbSame2Enum1::TS2E1_VALUE2;
+	TestValue = ETbSame2Enum1::TS2E1_Value2;
 	Spec->TestEqual(TEXT("Delegate parameter should be the same value as set by the setter"), InProp1, TestValue);
 	if (TSharedPtr<FTbSame2SameEnum1InterfaceMsgBusFixture> PinnedImplFixture = ImplFixture.Pin())
 	{
@@ -58,9 +58,9 @@ void UTbSame2SameEnum1InterfaceMsgBusHelper::Prop1PropertyCb(ETbSame2Enum1 InPro
 
 void UTbSame2SameEnum1InterfaceMsgBusHelper::Prop1PropertyChangeLocalCheckRemoteCb(ETbSame2Enum1 InProp1)
 {
-	ETbSame2Enum1 TestValue = ETbSame2Enum1::TS2E1_VALUE1;
+	ETbSame2Enum1 TestValue = ETbSame2Enum1::TS2E1_Value1;
 	// use different test value
-	TestValue = ETbSame2Enum1::TS2E1_VALUE2;
+	TestValue = ETbSame2Enum1::TS2E1_Value2;
 	Spec->TestEqual(TEXT("Delegate parameter should be the same value as set by the setter"), InProp1, TestValue);
 	if (TSharedPtr<FTbSame2SameEnum1InterfaceMsgBusFixture> PinnedImplFixture = ImplFixture.Pin())
 	{
@@ -79,9 +79,9 @@ void UTbSame2SameEnum1InterfaceMsgBusHelper::Prop1PropertyChangeLocalChangeRemot
 
 	if (count % 2 != 0)
 	{
-		ETbSame2Enum1 TestValue = ETbSame2Enum1::TS2E1_VALUE1;
+		ETbSame2Enum1 TestValue = ETbSame2Enum1::TS2E1_Value1;
 		// use different test value
-		TestValue = ETbSame2Enum1::TS2E1_VALUE2;
+		TestValue = ETbSame2Enum1::TS2E1_Value2;
 		Spec->TestEqual(TEXT("Delegate parameter should be the same value as set by the setter"), InProp1, TestValue);
 		if (TSharedPtr<FTbSame2SameEnum1InterfaceMsgBusFixture> PinnedImplFixture = ImplFixture.Pin())
 		{
@@ -89,7 +89,7 @@ void UTbSame2SameEnum1InterfaceMsgBusHelper::Prop1PropertyChangeLocalChangeRemot
 		}
 
 		// now set it to the default value
-		TestValue = ETbSame2Enum1::TS2E1_VALUE1; // default value
+		TestValue = ETbSame2Enum1::TS2E1_Value1; // default value
 		if (TSharedPtr<FTbSame2SameEnum1InterfaceMsgBusFixture> PinnedImplFixture = ImplFixture.Pin())
 		{
 			PinnedImplFixture->GetImplementation()->Execute_SetProp1(PinnedImplFixture->GetImplementation().GetObject(), TestValue);
@@ -97,7 +97,7 @@ void UTbSame2SameEnum1InterfaceMsgBusHelper::Prop1PropertyChangeLocalChangeRemot
 	}
 	else
 	{
-		ETbSame2Enum1 TestValue = ETbSame2Enum1::TS2E1_VALUE1; // default value
+		ETbSame2Enum1 TestValue = ETbSame2Enum1::TS2E1_Value1; // default value
 		Spec->TestEqual(TEXT("Delegate parameter should be the same value as set by the setter"), InProp1, TestValue);
 		if (TSharedPtr<FTbSame2SameEnum1InterfaceMsgBusFixture> PinnedImplFixture = ImplFixture.Pin())
 		{
@@ -110,7 +110,7 @@ void UTbSame2SameEnum1InterfaceMsgBusHelper::Prop1PropertyChangeLocalChangeRemot
 void UTbSame2SameEnum1InterfaceMsgBusHelper::Sig1SignalCb(ETbSame2Enum1 InParam1)
 {
 	// known test value
-	ETbSame2Enum1 Param1TestValue = ETbSame2Enum1::TS2E1_VALUE2;
+	ETbSame2Enum1 Param1TestValue = ETbSame2Enum1::TS2E1_Value2;
 	Spec->TestEqual(TEXT("Parameter should be the same value as sent by the signal"), InParam1, Param1TestValue);
 	testDoneDelegate.Execute();
 }

--- a/goldenmaster/Plugins/TbSame2/Source/TbSame2/Private/Tests/TbSame2SameEnum1InterfaceOLink.spec.cpp
+++ b/goldenmaster/Plugins/TbSame2/Source/TbSame2/Private/Tests/TbSame2SameEnum1InterfaceOLink.spec.cpp
@@ -85,35 +85,35 @@ void UTbSame2SameEnum1InterfaceOLinkSpec::Define()
 	It("Property.Prop1.Default", [this]()
 		{
 		// Do implement test here
-		ETbSame2Enum1 TestValue = ETbSame2Enum1::TS2E1_VALUE1; // default value
+		ETbSame2Enum1 TestValue = ETbSame2Enum1::TS2E1_Value1; // default value
 		TestEqual(TEXT("Getter should return the default value"), ImplFixture->GetImplementation()->Execute_GetProp1(ImplFixture->GetImplementation().GetObject()), TestValue);
 	});
 
 	LatentIt("Property.Prop1.Change", EAsyncExecution::ThreadPool, [this](const FDoneDelegate TestDone)
 		{
 		// Do implement test here
-		ETbSame2Enum1 TestValue = ETbSame2Enum1::TS2E1_VALUE1; // default value
+		ETbSame2Enum1 TestValue = ETbSame2Enum1::TS2E1_Value1; // default value
 		TestEqual(TEXT("Getter should return the default value"), ImplFixture->GetImplementation()->Execute_GetProp1(ImplFixture->GetImplementation().GetObject()), TestValue);
 
 		ImplFixture->GetHelper()->SetTestDone(TestDone);
 		UTbSame2SameEnum1InterfaceSignals* TbSame2SameEnum1InterfaceSignals = ImplFixture->GetImplementation()->Execute__GetSignals(ImplFixture->GetImplementation().GetObject());
 		TbSame2SameEnum1InterfaceSignals->OnProp1Changed.AddDynamic(ImplFixture->GetHelper().Get(), &UTbSame2SameEnum1InterfaceOLinkHelper::Prop1PropertyCb);
 		// use different test value
-		TestValue = ETbSame2Enum1::TS2E1_VALUE2;
+		TestValue = ETbSame2Enum1::TS2E1_Value2;
 		ImplFixture->GetImplementation()->Execute_SetProp1(ImplFixture->GetImplementation().GetObject(), TestValue);
 	});
 
 	LatentIt("Property.Prop1.ChangeLocalCheckRemote", EAsyncExecution::ThreadPool, [this](const FDoneDelegate TestDone)
 		{
 		// Do implement test here
-		ETbSame2Enum1 TestValue = ETbSame2Enum1::TS2E1_VALUE1; // default value
+		ETbSame2Enum1 TestValue = ETbSame2Enum1::TS2E1_Value1; // default value
 		TestEqual(TEXT("Getter should return the default value"), ImplFixture->GetImplementation()->Execute_GetProp1(ImplFixture->GetImplementation().GetObject()), TestValue);
 
 		ImplFixture->GetHelper()->SetTestDone(TestDone);
 		UTbSame2SameEnum1InterfaceSignals* TbSame2SameEnum1InterfaceSignals = ImplFixture->GetImplementation()->Execute__GetSignals(ImplFixture->GetImplementation().GetObject());
 		TbSame2SameEnum1InterfaceSignals->OnProp1Changed.AddDynamic(ImplFixture->GetHelper().Get(), &UTbSame2SameEnum1InterfaceOLinkHelper::Prop1PropertyChangeLocalCheckRemoteCb);
 		// use different test value
-		TestValue = ETbSame2Enum1::TS2E1_VALUE2;
+		TestValue = ETbSame2Enum1::TS2E1_Value2;
 		auto service = ImplFixture->GetGameInstance()->GetSubsystem<UTbSame2SameEnum1Interface>();
 		service->Execute_SetProp1(service, TestValue);
 	});
@@ -121,14 +121,14 @@ void UTbSame2SameEnum1InterfaceOLinkSpec::Define()
 	LatentIt("Property.Prop1.ChangeLocalChangeBackRemote", EAsyncExecution::ThreadPool, [this](const FDoneDelegate TestDone)
 		{
 		// Do implement test here
-		ETbSame2Enum1 TestValue = ETbSame2Enum1::TS2E1_VALUE1; // default value
+		ETbSame2Enum1 TestValue = ETbSame2Enum1::TS2E1_Value1; // default value
 		TestEqual(TEXT("Getter should return the default value"), ImplFixture->GetImplementation()->Execute_GetProp1(ImplFixture->GetImplementation().GetObject()), TestValue);
 
 		ImplFixture->GetHelper()->SetTestDone(TestDone);
 		UTbSame2SameEnum1InterfaceSignals* TbSame2SameEnum1InterfaceSignals = ImplFixture->GetImplementation()->Execute__GetSignals(ImplFixture->GetImplementation().GetObject());
 		TbSame2SameEnum1InterfaceSignals->OnProp1Changed.AddDynamic(ImplFixture->GetHelper().Get(), &UTbSame2SameEnum1InterfaceOLinkHelper::Prop1PropertyChangeLocalChangeRemoteCb);
 		// use different test value
-		TestValue = ETbSame2Enum1::TS2E1_VALUE2;
+		TestValue = ETbSame2Enum1::TS2E1_Value2;
 		auto service = ImplFixture->GetGameInstance()->GetSubsystem<UTbSame2SameEnum1Interface>();
 		service->Execute_SetProp1(service, TestValue);
 	});
@@ -138,7 +138,7 @@ void UTbSame2SameEnum1InterfaceOLinkSpec::Define()
 		// Do implement test here
 		AsyncTask(ENamedThreads::AnyThread, [this, TestDone]()
 			{
-			ImplFixture->GetImplementation()->Execute_Func1(ImplFixture->GetImplementation().GetObject(), ETbSame2Enum1::TS2E1_VALUE1);
+			ImplFixture->GetImplementation()->Execute_Func1(ImplFixture->GetImplementation().GetObject(), ETbSame2Enum1::TS2E1_Value1);
 			TestDone.Execute();
 		});
 	});
@@ -150,7 +150,7 @@ void UTbSame2SameEnum1InterfaceOLinkSpec::Define()
 		TbSame2SameEnum1InterfaceSignals->OnSig1Signal.AddDynamic(ImplFixture->GetHelper().Get(), &UTbSame2SameEnum1InterfaceOLinkHelper::Sig1SignalCb);
 
 		// use different test value
-		ETbSame2Enum1 Param1TestValue = ETbSame2Enum1::TS2E1_VALUE2;
+		ETbSame2Enum1 Param1TestValue = ETbSame2Enum1::TS2E1_Value2;
 		TbSame2SameEnum1InterfaceSignals->BroadcastSig1Signal(Param1TestValue);
 	});
 }

--- a/goldenmaster/Plugins/TbSame2/Source/TbSame2/Private/Tests/TbSame2SameEnum1InterfaceOLinkFixture.cpp
+++ b/goldenmaster/Plugins/TbSame2/Source/TbSame2/Private/Tests/TbSame2SameEnum1InterfaceOLinkFixture.cpp
@@ -42,9 +42,9 @@ void UTbSame2SameEnum1InterfaceOLinkHelper::SetTestDone(const FDoneDelegate& InD
 
 void UTbSame2SameEnum1InterfaceOLinkHelper::Prop1PropertyCb(ETbSame2Enum1 InProp1)
 {
-	ETbSame2Enum1 TestValue = ETbSame2Enum1::TS2E1_VALUE1;
+	ETbSame2Enum1 TestValue = ETbSame2Enum1::TS2E1_Value1;
 	// use different test value
-	TestValue = ETbSame2Enum1::TS2E1_VALUE2;
+	TestValue = ETbSame2Enum1::TS2E1_Value2;
 	Spec->TestEqual(TEXT("Delegate parameter should be the same value as set by the setter"), InProp1, TestValue);
 	if (TSharedPtr<FTbSame2SameEnum1InterfaceOLinkFixture> PinnedImplFixture = ImplFixture.Pin())
 	{
@@ -55,9 +55,9 @@ void UTbSame2SameEnum1InterfaceOLinkHelper::Prop1PropertyCb(ETbSame2Enum1 InProp
 
 void UTbSame2SameEnum1InterfaceOLinkHelper::Prop1PropertyChangeLocalCheckRemoteCb(ETbSame2Enum1 InProp1)
 {
-	ETbSame2Enum1 TestValue = ETbSame2Enum1::TS2E1_VALUE1;
+	ETbSame2Enum1 TestValue = ETbSame2Enum1::TS2E1_Value1;
 	// use different test value
-	TestValue = ETbSame2Enum1::TS2E1_VALUE2;
+	TestValue = ETbSame2Enum1::TS2E1_Value2;
 	Spec->TestEqual(TEXT("Delegate parameter should be the same value as set by the setter"), InProp1, TestValue);
 	if (TSharedPtr<FTbSame2SameEnum1InterfaceOLinkFixture> PinnedImplFixture = ImplFixture.Pin())
 	{
@@ -76,9 +76,9 @@ void UTbSame2SameEnum1InterfaceOLinkHelper::Prop1PropertyChangeLocalChangeRemote
 
 	if (count % 2 != 0)
 	{
-		ETbSame2Enum1 TestValue = ETbSame2Enum1::TS2E1_VALUE1;
+		ETbSame2Enum1 TestValue = ETbSame2Enum1::TS2E1_Value1;
 		// use different test value
-		TestValue = ETbSame2Enum1::TS2E1_VALUE2;
+		TestValue = ETbSame2Enum1::TS2E1_Value2;
 		Spec->TestEqual(TEXT("Delegate parameter should be the same value as set by the setter"), InProp1, TestValue);
 		if (TSharedPtr<FTbSame2SameEnum1InterfaceOLinkFixture> PinnedImplFixture = ImplFixture.Pin())
 		{
@@ -86,7 +86,7 @@ void UTbSame2SameEnum1InterfaceOLinkHelper::Prop1PropertyChangeLocalChangeRemote
 		}
 
 		// now set it to the default value
-		TestValue = ETbSame2Enum1::TS2E1_VALUE1; // default value
+		TestValue = ETbSame2Enum1::TS2E1_Value1; // default value
 		if (TSharedPtr<FTbSame2SameEnum1InterfaceOLinkFixture> PinnedImplFixture = ImplFixture.Pin())
 		{
 			PinnedImplFixture->GetImplementation()->Execute_SetProp1(PinnedImplFixture->GetImplementation().GetObject(), TestValue);
@@ -94,7 +94,7 @@ void UTbSame2SameEnum1InterfaceOLinkHelper::Prop1PropertyChangeLocalChangeRemote
 	}
 	else
 	{
-		ETbSame2Enum1 TestValue = ETbSame2Enum1::TS2E1_VALUE1; // default value
+		ETbSame2Enum1 TestValue = ETbSame2Enum1::TS2E1_Value1; // default value
 		Spec->TestEqual(TEXT("Delegate parameter should be the same value as set by the setter"), InProp1, TestValue);
 		if (TSharedPtr<FTbSame2SameEnum1InterfaceOLinkFixture> PinnedImplFixture = ImplFixture.Pin())
 		{
@@ -107,7 +107,7 @@ void UTbSame2SameEnum1InterfaceOLinkHelper::Prop1PropertyChangeLocalChangeRemote
 void UTbSame2SameEnum1InterfaceOLinkHelper::Sig1SignalCb(ETbSame2Enum1 InParam1)
 {
 	// known test value
-	ETbSame2Enum1 Param1TestValue = ETbSame2Enum1::TS2E1_VALUE2;
+	ETbSame2Enum1 Param1TestValue = ETbSame2Enum1::TS2E1_Value2;
 	Spec->TestEqual(TEXT("Parameter should be the same value as sent by the signal"), InParam1, Param1TestValue);
 	testDoneDelegate.Execute();
 }

--- a/goldenmaster/Plugins/TbSame2/Source/TbSame2/Private/Tests/TbSame2SameEnum2InterfaceImpl.spec.cpp
+++ b/goldenmaster/Plugins/TbSame2/Source/TbSame2/Private/Tests/TbSame2SameEnum2InterfaceImpl.spec.cpp
@@ -50,55 +50,55 @@ void UTbSame2SameEnum2InterfaceImplSpec::Define()
 	It("Property.Prop1.Default", [this]()
 		{
 		// Do implement test here
-		ETbSame2Enum1 TestValue = ETbSame2Enum1::TS2E1_VALUE1; // default value
+		ETbSame2Enum1 TestValue = ETbSame2Enum1::TS2E1_Value1; // default value
 		TestEqual(TEXT("Getter should return the default value"), ImplFixture->GetImplementation()->Execute_GetProp1(ImplFixture->GetImplementation().GetObject()), TestValue);
 	});
 
 	LatentIt("Property.Prop1.Change", EAsyncExecution::ThreadPool, [this](const FDoneDelegate TestDone)
 		{
 		// Do implement test here
-		ETbSame2Enum1 TestValue = ETbSame2Enum1::TS2E1_VALUE1; // default value
+		ETbSame2Enum1 TestValue = ETbSame2Enum1::TS2E1_Value1; // default value
 		TestEqual(TEXT("Getter should return the default value"), ImplFixture->GetImplementation()->Execute_GetProp1(ImplFixture->GetImplementation().GetObject()), TestValue);
 
 		ImplFixture->GetHelper()->SetTestDone(TestDone);
 		UTbSame2SameEnum2InterfaceSignals* TbSame2SameEnum2InterfaceSignals = ImplFixture->GetImplementation()->Execute__GetSignals(ImplFixture->GetImplementation().GetObject());
 		TbSame2SameEnum2InterfaceSignals->OnProp1Changed.AddDynamic(ImplFixture->GetHelper().Get(), &UTbSame2SameEnum2InterfaceImplHelper::Prop1PropertyCb);
 		// use different test value
-		TestValue = ETbSame2Enum1::TS2E1_VALUE2;
+		TestValue = ETbSame2Enum1::TS2E1_Value2;
 		ImplFixture->GetImplementation()->Execute_SetProp1(ImplFixture->GetImplementation().GetObject(), TestValue);
 	});
 
 	It("Property.Prop2.Default", [this]()
 		{
 		// Do implement test here
-		ETbSame2Enum2 TestValue = ETbSame2Enum2::TS2E2_VALUE1; // default value
+		ETbSame2Enum2 TestValue = ETbSame2Enum2::TS2E2_Value1; // default value
 		TestEqual(TEXT("Getter should return the default value"), ImplFixture->GetImplementation()->Execute_GetProp2(ImplFixture->GetImplementation().GetObject()), TestValue);
 	});
 
 	LatentIt("Property.Prop2.Change", EAsyncExecution::ThreadPool, [this](const FDoneDelegate TestDone)
 		{
 		// Do implement test here
-		ETbSame2Enum2 TestValue = ETbSame2Enum2::TS2E2_VALUE1; // default value
+		ETbSame2Enum2 TestValue = ETbSame2Enum2::TS2E2_Value1; // default value
 		TestEqual(TEXT("Getter should return the default value"), ImplFixture->GetImplementation()->Execute_GetProp2(ImplFixture->GetImplementation().GetObject()), TestValue);
 
 		ImplFixture->GetHelper()->SetTestDone(TestDone);
 		UTbSame2SameEnum2InterfaceSignals* TbSame2SameEnum2InterfaceSignals = ImplFixture->GetImplementation()->Execute__GetSignals(ImplFixture->GetImplementation().GetObject());
 		TbSame2SameEnum2InterfaceSignals->OnProp2Changed.AddDynamic(ImplFixture->GetHelper().Get(), &UTbSame2SameEnum2InterfaceImplHelper::Prop2PropertyCb);
 		// use different test value
-		TestValue = ETbSame2Enum2::TS2E2_VALUE2;
+		TestValue = ETbSame2Enum2::TS2E2_Value2;
 		ImplFixture->GetImplementation()->Execute_SetProp2(ImplFixture->GetImplementation().GetObject(), TestValue);
 	});
 
 	It("Operation.Func1", [this]()
 		{
 		// Do implement test here
-		ImplFixture->GetImplementation()->Execute_Func1(ImplFixture->GetImplementation().GetObject(), ETbSame2Enum1::TS2E1_VALUE1);
+		ImplFixture->GetImplementation()->Execute_Func1(ImplFixture->GetImplementation().GetObject(), ETbSame2Enum1::TS2E1_Value1);
 	});
 
 	It("Operation.Func2", [this]()
 		{
 		// Do implement test here
-		ImplFixture->GetImplementation()->Execute_Func2(ImplFixture->GetImplementation().GetObject(), ETbSame2Enum1::TS2E1_VALUE1, ETbSame2Enum2::TS2E2_VALUE1);
+		ImplFixture->GetImplementation()->Execute_Func2(ImplFixture->GetImplementation().GetObject(), ETbSame2Enum1::TS2E1_Value1, ETbSame2Enum2::TS2E2_Value1);
 	});
 
 	LatentIt("Signal.Sig1", EAsyncExecution::ThreadPool, [this](const FDoneDelegate TestDone)
@@ -108,7 +108,7 @@ void UTbSame2SameEnum2InterfaceImplSpec::Define()
 		TbSame2SameEnum2InterfaceSignals->OnSig1Signal.AddDynamic(ImplFixture->GetHelper().Get(), &UTbSame2SameEnum2InterfaceImplHelper::Sig1SignalCb);
 
 		// use different test value
-		ETbSame2Enum1 Param1TestValue = ETbSame2Enum1::TS2E1_VALUE2;
+		ETbSame2Enum1 Param1TestValue = ETbSame2Enum1::TS2E1_Value2;
 		TbSame2SameEnum2InterfaceSignals->BroadcastSig1Signal(Param1TestValue);
 	});
 
@@ -119,8 +119,8 @@ void UTbSame2SameEnum2InterfaceImplSpec::Define()
 		TbSame2SameEnum2InterfaceSignals->OnSig2Signal.AddDynamic(ImplFixture->GetHelper().Get(), &UTbSame2SameEnum2InterfaceImplHelper::Sig2SignalCb);
 
 		// use different test value
-		ETbSame2Enum1 Param1TestValue = ETbSame2Enum1::TS2E1_VALUE2;
-		ETbSame2Enum2 Param2TestValue = ETbSame2Enum2::TS2E2_VALUE2;
+		ETbSame2Enum1 Param1TestValue = ETbSame2Enum1::TS2E1_Value2;
+		ETbSame2Enum2 Param2TestValue = ETbSame2Enum2::TS2E2_Value2;
 		TbSame2SameEnum2InterfaceSignals->BroadcastSig2Signal(Param1TestValue, Param2TestValue);
 	});
 }

--- a/goldenmaster/Plugins/TbSame2/Source/TbSame2/Private/Tests/TbSame2SameEnum2InterfaceImplFixture.cpp
+++ b/goldenmaster/Plugins/TbSame2/Source/TbSame2/Private/Tests/TbSame2SameEnum2InterfaceImplFixture.cpp
@@ -39,9 +39,9 @@ void UTbSame2SameEnum2InterfaceImplHelper::SetTestDone(const FDoneDelegate& InDo
 
 void UTbSame2SameEnum2InterfaceImplHelper::Prop1PropertyCb(ETbSame2Enum1 InProp1)
 {
-	ETbSame2Enum1 TestValue = ETbSame2Enum1::TS2E1_VALUE1;
+	ETbSame2Enum1 TestValue = ETbSame2Enum1::TS2E1_Value1;
 	// use different test value
-	TestValue = ETbSame2Enum1::TS2E1_VALUE2;
+	TestValue = ETbSame2Enum1::TS2E1_Value2;
 	Spec->TestEqual(TEXT("Delegate parameter should be the same value as set by the setter"), InProp1, TestValue);
 	if (TSharedPtr<FTbSame2SameEnum2InterfaceImplFixture> PinnedImplFixture = ImplFixture.Pin())
 	{
@@ -52,9 +52,9 @@ void UTbSame2SameEnum2InterfaceImplHelper::Prop1PropertyCb(ETbSame2Enum1 InProp1
 
 void UTbSame2SameEnum2InterfaceImplHelper::Prop2PropertyCb(ETbSame2Enum2 InProp2)
 {
-	ETbSame2Enum2 TestValue = ETbSame2Enum2::TS2E2_VALUE1;
+	ETbSame2Enum2 TestValue = ETbSame2Enum2::TS2E2_Value1;
 	// use different test value
-	TestValue = ETbSame2Enum2::TS2E2_VALUE2;
+	TestValue = ETbSame2Enum2::TS2E2_Value2;
 	Spec->TestEqual(TEXT("Delegate parameter should be the same value as set by the setter"), InProp2, TestValue);
 	if (TSharedPtr<FTbSame2SameEnum2InterfaceImplFixture> PinnedImplFixture = ImplFixture.Pin())
 	{
@@ -66,7 +66,7 @@ void UTbSame2SameEnum2InterfaceImplHelper::Prop2PropertyCb(ETbSame2Enum2 InProp2
 void UTbSame2SameEnum2InterfaceImplHelper::Sig1SignalCb(ETbSame2Enum1 InParam1)
 {
 	// known test value
-	ETbSame2Enum1 Param1TestValue = ETbSame2Enum1::TS2E1_VALUE2;
+	ETbSame2Enum1 Param1TestValue = ETbSame2Enum1::TS2E1_Value2;
 	Spec->TestEqual(TEXT("Parameter should be the same value as sent by the signal"), InParam1, Param1TestValue);
 	testDoneDelegate.Execute();
 }
@@ -74,9 +74,9 @@ void UTbSame2SameEnum2InterfaceImplHelper::Sig1SignalCb(ETbSame2Enum1 InParam1)
 void UTbSame2SameEnum2InterfaceImplHelper::Sig2SignalCb(ETbSame2Enum1 InParam1, ETbSame2Enum2 InParam2)
 {
 	// known test value
-	ETbSame2Enum1 Param1TestValue = ETbSame2Enum1::TS2E1_VALUE2;
+	ETbSame2Enum1 Param1TestValue = ETbSame2Enum1::TS2E1_Value2;
 	Spec->TestEqual(TEXT("Parameter should be the same value as sent by the signal"), InParam1, Param1TestValue);
-	ETbSame2Enum2 Param2TestValue = ETbSame2Enum2::TS2E2_VALUE2;
+	ETbSame2Enum2 Param2TestValue = ETbSame2Enum2::TS2E2_Value2;
 	Spec->TestEqual(TEXT("Parameter should be the same value as sent by the signal"), InParam2, Param2TestValue);
 	testDoneDelegate.Execute();
 }

--- a/goldenmaster/Plugins/TbSame2/Source/TbSame2/Private/Tests/TbSame2SameEnum2InterfaceMsgBus.spec.cpp
+++ b/goldenmaster/Plugins/TbSame2/Source/TbSame2/Private/Tests/TbSame2SameEnum2InterfaceMsgBus.spec.cpp
@@ -67,35 +67,35 @@ void UTbSame2SameEnum2InterfaceMsgBusSpec::Define()
 	It("Property.Prop1.Default", [this]()
 		{
 		// Do implement test here
-		ETbSame2Enum1 TestValue = ETbSame2Enum1::TS2E1_VALUE1; // default value
+		ETbSame2Enum1 TestValue = ETbSame2Enum1::TS2E1_Value1; // default value
 		TestEqual(TEXT("Getter should return the default value"), ImplFixture->GetImplementation()->Execute_GetProp1(ImplFixture->GetImplementation().GetObject()), TestValue);
 	});
 
 	LatentIt("Property.Prop1.Change", EAsyncExecution::ThreadPool, [this](const FDoneDelegate TestDone)
 		{
 		// Do implement test here
-		ETbSame2Enum1 TestValue = ETbSame2Enum1::TS2E1_VALUE1; // default value
+		ETbSame2Enum1 TestValue = ETbSame2Enum1::TS2E1_Value1; // default value
 		TestEqual(TEXT("Getter should return the default value"), ImplFixture->GetImplementation()->Execute_GetProp1(ImplFixture->GetImplementation().GetObject()), TestValue);
 
 		ImplFixture->GetHelper()->SetTestDone(TestDone);
 		UTbSame2SameEnum2InterfaceSignals* TbSame2SameEnum2InterfaceSignals = ImplFixture->GetImplementation()->Execute__GetSignals(ImplFixture->GetImplementation().GetObject());
 		TbSame2SameEnum2InterfaceSignals->OnProp1Changed.AddDynamic(ImplFixture->GetHelper().Get(), &UTbSame2SameEnum2InterfaceMsgBusHelper::Prop1PropertyCb);
 		// use different test value
-		TestValue = ETbSame2Enum1::TS2E1_VALUE2;
+		TestValue = ETbSame2Enum1::TS2E1_Value2;
 		ImplFixture->GetImplementation()->Execute_SetProp1(ImplFixture->GetImplementation().GetObject(), TestValue);
 	});
 
 	LatentIt("Property.Prop1.ChangeLocalCheckRemote", EAsyncExecution::ThreadPool, [this](const FDoneDelegate TestDone)
 		{
 		// Do implement test here
-		ETbSame2Enum1 TestValue = ETbSame2Enum1::TS2E1_VALUE1; // default value
+		ETbSame2Enum1 TestValue = ETbSame2Enum1::TS2E1_Value1; // default value
 		TestEqual(TEXT("Getter should return the default value"), ImplFixture->GetImplementation()->Execute_GetProp1(ImplFixture->GetImplementation().GetObject()), TestValue);
 
 		ImplFixture->GetHelper()->SetTestDone(TestDone);
 		UTbSame2SameEnum2InterfaceSignals* TbSame2SameEnum2InterfaceSignals = ImplFixture->GetImplementation()->Execute__GetSignals(ImplFixture->GetImplementation().GetObject());
 		TbSame2SameEnum2InterfaceSignals->OnProp1Changed.AddDynamic(ImplFixture->GetHelper().Get(), &UTbSame2SameEnum2InterfaceMsgBusHelper::Prop1PropertyChangeLocalCheckRemoteCb);
 		// use different test value
-		TestValue = ETbSame2Enum1::TS2E1_VALUE2;
+		TestValue = ETbSame2Enum1::TS2E1_Value2;
 		auto service = ImplFixture->GetGameInstance()->GetSubsystem<UTbSame2SameEnum2Interface>();
 		service->Execute_SetProp1(service, TestValue);
 	});
@@ -103,14 +103,14 @@ void UTbSame2SameEnum2InterfaceMsgBusSpec::Define()
 	LatentIt("Property.Prop1.ChangeLocalChangeBackRemote", EAsyncExecution::ThreadPool, [this](const FDoneDelegate TestDone)
 		{
 		// Do implement test here
-		ETbSame2Enum1 TestValue = ETbSame2Enum1::TS2E1_VALUE1; // default value
+		ETbSame2Enum1 TestValue = ETbSame2Enum1::TS2E1_Value1; // default value
 		TestEqual(TEXT("Getter should return the default value"), ImplFixture->GetImplementation()->Execute_GetProp1(ImplFixture->GetImplementation().GetObject()), TestValue);
 
 		ImplFixture->GetHelper()->SetTestDone(TestDone);
 		UTbSame2SameEnum2InterfaceSignals* TbSame2SameEnum2InterfaceSignals = ImplFixture->GetImplementation()->Execute__GetSignals(ImplFixture->GetImplementation().GetObject());
 		TbSame2SameEnum2InterfaceSignals->OnProp1Changed.AddDynamic(ImplFixture->GetHelper().Get(), &UTbSame2SameEnum2InterfaceMsgBusHelper::Prop1PropertyChangeLocalChangeRemoteCb);
 		// use different test value
-		TestValue = ETbSame2Enum1::TS2E1_VALUE2;
+		TestValue = ETbSame2Enum1::TS2E1_Value2;
 		auto service = ImplFixture->GetGameInstance()->GetSubsystem<UTbSame2SameEnum2Interface>();
 		service->Execute_SetProp1(service, TestValue);
 	});
@@ -118,35 +118,35 @@ void UTbSame2SameEnum2InterfaceMsgBusSpec::Define()
 	It("Property.Prop2.Default", [this]()
 		{
 		// Do implement test here
-		ETbSame2Enum2 TestValue = ETbSame2Enum2::TS2E2_VALUE1; // default value
+		ETbSame2Enum2 TestValue = ETbSame2Enum2::TS2E2_Value1; // default value
 		TestEqual(TEXT("Getter should return the default value"), ImplFixture->GetImplementation()->Execute_GetProp2(ImplFixture->GetImplementation().GetObject()), TestValue);
 	});
 
 	LatentIt("Property.Prop2.Change", EAsyncExecution::ThreadPool, [this](const FDoneDelegate TestDone)
 		{
 		// Do implement test here
-		ETbSame2Enum2 TestValue = ETbSame2Enum2::TS2E2_VALUE1; // default value
+		ETbSame2Enum2 TestValue = ETbSame2Enum2::TS2E2_Value1; // default value
 		TestEqual(TEXT("Getter should return the default value"), ImplFixture->GetImplementation()->Execute_GetProp2(ImplFixture->GetImplementation().GetObject()), TestValue);
 
 		ImplFixture->GetHelper()->SetTestDone(TestDone);
 		UTbSame2SameEnum2InterfaceSignals* TbSame2SameEnum2InterfaceSignals = ImplFixture->GetImplementation()->Execute__GetSignals(ImplFixture->GetImplementation().GetObject());
 		TbSame2SameEnum2InterfaceSignals->OnProp2Changed.AddDynamic(ImplFixture->GetHelper().Get(), &UTbSame2SameEnum2InterfaceMsgBusHelper::Prop2PropertyCb);
 		// use different test value
-		TestValue = ETbSame2Enum2::TS2E2_VALUE2;
+		TestValue = ETbSame2Enum2::TS2E2_Value2;
 		ImplFixture->GetImplementation()->Execute_SetProp2(ImplFixture->GetImplementation().GetObject(), TestValue);
 	});
 
 	LatentIt("Property.Prop2.ChangeLocalCheckRemote", EAsyncExecution::ThreadPool, [this](const FDoneDelegate TestDone)
 		{
 		// Do implement test here
-		ETbSame2Enum2 TestValue = ETbSame2Enum2::TS2E2_VALUE1; // default value
+		ETbSame2Enum2 TestValue = ETbSame2Enum2::TS2E2_Value1; // default value
 		TestEqual(TEXT("Getter should return the default value"), ImplFixture->GetImplementation()->Execute_GetProp2(ImplFixture->GetImplementation().GetObject()), TestValue);
 
 		ImplFixture->GetHelper()->SetTestDone(TestDone);
 		UTbSame2SameEnum2InterfaceSignals* TbSame2SameEnum2InterfaceSignals = ImplFixture->GetImplementation()->Execute__GetSignals(ImplFixture->GetImplementation().GetObject());
 		TbSame2SameEnum2InterfaceSignals->OnProp2Changed.AddDynamic(ImplFixture->GetHelper().Get(), &UTbSame2SameEnum2InterfaceMsgBusHelper::Prop2PropertyChangeLocalCheckRemoteCb);
 		// use different test value
-		TestValue = ETbSame2Enum2::TS2E2_VALUE2;
+		TestValue = ETbSame2Enum2::TS2E2_Value2;
 		auto service = ImplFixture->GetGameInstance()->GetSubsystem<UTbSame2SameEnum2Interface>();
 		service->Execute_SetProp2(service, TestValue);
 	});
@@ -154,14 +154,14 @@ void UTbSame2SameEnum2InterfaceMsgBusSpec::Define()
 	LatentIt("Property.Prop2.ChangeLocalChangeBackRemote", EAsyncExecution::ThreadPool, [this](const FDoneDelegate TestDone)
 		{
 		// Do implement test here
-		ETbSame2Enum2 TestValue = ETbSame2Enum2::TS2E2_VALUE1; // default value
+		ETbSame2Enum2 TestValue = ETbSame2Enum2::TS2E2_Value1; // default value
 		TestEqual(TEXT("Getter should return the default value"), ImplFixture->GetImplementation()->Execute_GetProp2(ImplFixture->GetImplementation().GetObject()), TestValue);
 
 		ImplFixture->GetHelper()->SetTestDone(TestDone);
 		UTbSame2SameEnum2InterfaceSignals* TbSame2SameEnum2InterfaceSignals = ImplFixture->GetImplementation()->Execute__GetSignals(ImplFixture->GetImplementation().GetObject());
 		TbSame2SameEnum2InterfaceSignals->OnProp2Changed.AddDynamic(ImplFixture->GetHelper().Get(), &UTbSame2SameEnum2InterfaceMsgBusHelper::Prop2PropertyChangeLocalChangeRemoteCb);
 		// use different test value
-		TestValue = ETbSame2Enum2::TS2E2_VALUE2;
+		TestValue = ETbSame2Enum2::TS2E2_Value2;
 		auto service = ImplFixture->GetGameInstance()->GetSubsystem<UTbSame2SameEnum2Interface>();
 		service->Execute_SetProp2(service, TestValue);
 	});
@@ -171,7 +171,7 @@ void UTbSame2SameEnum2InterfaceMsgBusSpec::Define()
 		// Do implement test here
 		AsyncTask(ENamedThreads::AnyThread, [this, TestDone]()
 			{
-			ImplFixture->GetImplementation()->Execute_Func1(ImplFixture->GetImplementation().GetObject(), ETbSame2Enum1::TS2E1_VALUE1);
+			ImplFixture->GetImplementation()->Execute_Func1(ImplFixture->GetImplementation().GetObject(), ETbSame2Enum1::TS2E1_Value1);
 			TestDone.Execute();
 		});
 	});
@@ -181,7 +181,7 @@ void UTbSame2SameEnum2InterfaceMsgBusSpec::Define()
 		// Do implement test here
 		AsyncTask(ENamedThreads::AnyThread, [this, TestDone]()
 			{
-			ImplFixture->GetImplementation()->Execute_Func2(ImplFixture->GetImplementation().GetObject(), ETbSame2Enum1::TS2E1_VALUE1, ETbSame2Enum2::TS2E2_VALUE1);
+			ImplFixture->GetImplementation()->Execute_Func2(ImplFixture->GetImplementation().GetObject(), ETbSame2Enum1::TS2E1_Value1, ETbSame2Enum2::TS2E2_Value1);
 			TestDone.Execute();
 		});
 	});
@@ -193,7 +193,7 @@ void UTbSame2SameEnum2InterfaceMsgBusSpec::Define()
 		TbSame2SameEnum2InterfaceSignals->OnSig1Signal.AddDynamic(ImplFixture->GetHelper().Get(), &UTbSame2SameEnum2InterfaceMsgBusHelper::Sig1SignalCb);
 
 		// use different test value
-		ETbSame2Enum1 Param1TestValue = ETbSame2Enum1::TS2E1_VALUE2;
+		ETbSame2Enum1 Param1TestValue = ETbSame2Enum1::TS2E1_Value2;
 		TbSame2SameEnum2InterfaceSignals->BroadcastSig1Signal(Param1TestValue);
 	});
 
@@ -204,8 +204,8 @@ void UTbSame2SameEnum2InterfaceMsgBusSpec::Define()
 		TbSame2SameEnum2InterfaceSignals->OnSig2Signal.AddDynamic(ImplFixture->GetHelper().Get(), &UTbSame2SameEnum2InterfaceMsgBusHelper::Sig2SignalCb);
 
 		// use different test value
-		ETbSame2Enum1 Param1TestValue = ETbSame2Enum1::TS2E1_VALUE2;
-		ETbSame2Enum2 Param2TestValue = ETbSame2Enum2::TS2E2_VALUE2;
+		ETbSame2Enum1 Param1TestValue = ETbSame2Enum1::TS2E1_Value2;
+		ETbSame2Enum2 Param2TestValue = ETbSame2Enum2::TS2E2_Value2;
 		TbSame2SameEnum2InterfaceSignals->BroadcastSig2Signal(Param1TestValue, Param2TestValue);
 	});
 }

--- a/goldenmaster/Plugins/TbSame2/Source/TbSame2/Private/Tests/TbSame2SameEnum2InterfaceMsgBusFixture.cpp
+++ b/goldenmaster/Plugins/TbSame2/Source/TbSame2/Private/Tests/TbSame2SameEnum2InterfaceMsgBusFixture.cpp
@@ -45,9 +45,9 @@ void UTbSame2SameEnum2InterfaceMsgBusHelper::SetTestDone(const FDoneDelegate& In
 
 void UTbSame2SameEnum2InterfaceMsgBusHelper::Prop1PropertyCb(ETbSame2Enum1 InProp1)
 {
-	ETbSame2Enum1 TestValue = ETbSame2Enum1::TS2E1_VALUE1;
+	ETbSame2Enum1 TestValue = ETbSame2Enum1::TS2E1_Value1;
 	// use different test value
-	TestValue = ETbSame2Enum1::TS2E1_VALUE2;
+	TestValue = ETbSame2Enum1::TS2E1_Value2;
 	Spec->TestEqual(TEXT("Delegate parameter should be the same value as set by the setter"), InProp1, TestValue);
 	if (TSharedPtr<FTbSame2SameEnum2InterfaceMsgBusFixture> PinnedImplFixture = ImplFixture.Pin())
 	{
@@ -58,9 +58,9 @@ void UTbSame2SameEnum2InterfaceMsgBusHelper::Prop1PropertyCb(ETbSame2Enum1 InPro
 
 void UTbSame2SameEnum2InterfaceMsgBusHelper::Prop1PropertyChangeLocalCheckRemoteCb(ETbSame2Enum1 InProp1)
 {
-	ETbSame2Enum1 TestValue = ETbSame2Enum1::TS2E1_VALUE1;
+	ETbSame2Enum1 TestValue = ETbSame2Enum1::TS2E1_Value1;
 	// use different test value
-	TestValue = ETbSame2Enum1::TS2E1_VALUE2;
+	TestValue = ETbSame2Enum1::TS2E1_Value2;
 	Spec->TestEqual(TEXT("Delegate parameter should be the same value as set by the setter"), InProp1, TestValue);
 	if (TSharedPtr<FTbSame2SameEnum2InterfaceMsgBusFixture> PinnedImplFixture = ImplFixture.Pin())
 	{
@@ -79,9 +79,9 @@ void UTbSame2SameEnum2InterfaceMsgBusHelper::Prop1PropertyChangeLocalChangeRemot
 
 	if (count % 2 != 0)
 	{
-		ETbSame2Enum1 TestValue = ETbSame2Enum1::TS2E1_VALUE1;
+		ETbSame2Enum1 TestValue = ETbSame2Enum1::TS2E1_Value1;
 		// use different test value
-		TestValue = ETbSame2Enum1::TS2E1_VALUE2;
+		TestValue = ETbSame2Enum1::TS2E1_Value2;
 		Spec->TestEqual(TEXT("Delegate parameter should be the same value as set by the setter"), InProp1, TestValue);
 		if (TSharedPtr<FTbSame2SameEnum2InterfaceMsgBusFixture> PinnedImplFixture = ImplFixture.Pin())
 		{
@@ -89,7 +89,7 @@ void UTbSame2SameEnum2InterfaceMsgBusHelper::Prop1PropertyChangeLocalChangeRemot
 		}
 
 		// now set it to the default value
-		TestValue = ETbSame2Enum1::TS2E1_VALUE1; // default value
+		TestValue = ETbSame2Enum1::TS2E1_Value1; // default value
 		if (TSharedPtr<FTbSame2SameEnum2InterfaceMsgBusFixture> PinnedImplFixture = ImplFixture.Pin())
 		{
 			PinnedImplFixture->GetImplementation()->Execute_SetProp1(PinnedImplFixture->GetImplementation().GetObject(), TestValue);
@@ -97,7 +97,7 @@ void UTbSame2SameEnum2InterfaceMsgBusHelper::Prop1PropertyChangeLocalChangeRemot
 	}
 	else
 	{
-		ETbSame2Enum1 TestValue = ETbSame2Enum1::TS2E1_VALUE1; // default value
+		ETbSame2Enum1 TestValue = ETbSame2Enum1::TS2E1_Value1; // default value
 		Spec->TestEqual(TEXT("Delegate parameter should be the same value as set by the setter"), InProp1, TestValue);
 		if (TSharedPtr<FTbSame2SameEnum2InterfaceMsgBusFixture> PinnedImplFixture = ImplFixture.Pin())
 		{
@@ -109,9 +109,9 @@ void UTbSame2SameEnum2InterfaceMsgBusHelper::Prop1PropertyChangeLocalChangeRemot
 
 void UTbSame2SameEnum2InterfaceMsgBusHelper::Prop2PropertyCb(ETbSame2Enum2 InProp2)
 {
-	ETbSame2Enum2 TestValue = ETbSame2Enum2::TS2E2_VALUE1;
+	ETbSame2Enum2 TestValue = ETbSame2Enum2::TS2E2_Value1;
 	// use different test value
-	TestValue = ETbSame2Enum2::TS2E2_VALUE2;
+	TestValue = ETbSame2Enum2::TS2E2_Value2;
 	Spec->TestEqual(TEXT("Delegate parameter should be the same value as set by the setter"), InProp2, TestValue);
 	if (TSharedPtr<FTbSame2SameEnum2InterfaceMsgBusFixture> PinnedImplFixture = ImplFixture.Pin())
 	{
@@ -122,9 +122,9 @@ void UTbSame2SameEnum2InterfaceMsgBusHelper::Prop2PropertyCb(ETbSame2Enum2 InPro
 
 void UTbSame2SameEnum2InterfaceMsgBusHelper::Prop2PropertyChangeLocalCheckRemoteCb(ETbSame2Enum2 InProp2)
 {
-	ETbSame2Enum2 TestValue = ETbSame2Enum2::TS2E2_VALUE1;
+	ETbSame2Enum2 TestValue = ETbSame2Enum2::TS2E2_Value1;
 	// use different test value
-	TestValue = ETbSame2Enum2::TS2E2_VALUE2;
+	TestValue = ETbSame2Enum2::TS2E2_Value2;
 	Spec->TestEqual(TEXT("Delegate parameter should be the same value as set by the setter"), InProp2, TestValue);
 	if (TSharedPtr<FTbSame2SameEnum2InterfaceMsgBusFixture> PinnedImplFixture = ImplFixture.Pin())
 	{
@@ -143,9 +143,9 @@ void UTbSame2SameEnum2InterfaceMsgBusHelper::Prop2PropertyChangeLocalChangeRemot
 
 	if (count % 2 != 0)
 	{
-		ETbSame2Enum2 TestValue = ETbSame2Enum2::TS2E2_VALUE1;
+		ETbSame2Enum2 TestValue = ETbSame2Enum2::TS2E2_Value1;
 		// use different test value
-		TestValue = ETbSame2Enum2::TS2E2_VALUE2;
+		TestValue = ETbSame2Enum2::TS2E2_Value2;
 		Spec->TestEqual(TEXT("Delegate parameter should be the same value as set by the setter"), InProp2, TestValue);
 		if (TSharedPtr<FTbSame2SameEnum2InterfaceMsgBusFixture> PinnedImplFixture = ImplFixture.Pin())
 		{
@@ -153,7 +153,7 @@ void UTbSame2SameEnum2InterfaceMsgBusHelper::Prop2PropertyChangeLocalChangeRemot
 		}
 
 		// now set it to the default value
-		TestValue = ETbSame2Enum2::TS2E2_VALUE1; // default value
+		TestValue = ETbSame2Enum2::TS2E2_Value1; // default value
 		if (TSharedPtr<FTbSame2SameEnum2InterfaceMsgBusFixture> PinnedImplFixture = ImplFixture.Pin())
 		{
 			PinnedImplFixture->GetImplementation()->Execute_SetProp2(PinnedImplFixture->GetImplementation().GetObject(), TestValue);
@@ -161,7 +161,7 @@ void UTbSame2SameEnum2InterfaceMsgBusHelper::Prop2PropertyChangeLocalChangeRemot
 	}
 	else
 	{
-		ETbSame2Enum2 TestValue = ETbSame2Enum2::TS2E2_VALUE1; // default value
+		ETbSame2Enum2 TestValue = ETbSame2Enum2::TS2E2_Value1; // default value
 		Spec->TestEqual(TEXT("Delegate parameter should be the same value as set by the setter"), InProp2, TestValue);
 		if (TSharedPtr<FTbSame2SameEnum2InterfaceMsgBusFixture> PinnedImplFixture = ImplFixture.Pin())
 		{
@@ -174,7 +174,7 @@ void UTbSame2SameEnum2InterfaceMsgBusHelper::Prop2PropertyChangeLocalChangeRemot
 void UTbSame2SameEnum2InterfaceMsgBusHelper::Sig1SignalCb(ETbSame2Enum1 InParam1)
 {
 	// known test value
-	ETbSame2Enum1 Param1TestValue = ETbSame2Enum1::TS2E1_VALUE2;
+	ETbSame2Enum1 Param1TestValue = ETbSame2Enum1::TS2E1_Value2;
 	Spec->TestEqual(TEXT("Parameter should be the same value as sent by the signal"), InParam1, Param1TestValue);
 	testDoneDelegate.Execute();
 }
@@ -182,9 +182,9 @@ void UTbSame2SameEnum2InterfaceMsgBusHelper::Sig1SignalCb(ETbSame2Enum1 InParam1
 void UTbSame2SameEnum2InterfaceMsgBusHelper::Sig2SignalCb(ETbSame2Enum1 InParam1, ETbSame2Enum2 InParam2)
 {
 	// known test value
-	ETbSame2Enum1 Param1TestValue = ETbSame2Enum1::TS2E1_VALUE2;
+	ETbSame2Enum1 Param1TestValue = ETbSame2Enum1::TS2E1_Value2;
 	Spec->TestEqual(TEXT("Parameter should be the same value as sent by the signal"), InParam1, Param1TestValue);
-	ETbSame2Enum2 Param2TestValue = ETbSame2Enum2::TS2E2_VALUE2;
+	ETbSame2Enum2 Param2TestValue = ETbSame2Enum2::TS2E2_Value2;
 	Spec->TestEqual(TEXT("Parameter should be the same value as sent by the signal"), InParam2, Param2TestValue);
 	testDoneDelegate.Execute();
 }

--- a/goldenmaster/Plugins/TbSame2/Source/TbSame2/Private/Tests/TbSame2SameEnum2InterfaceOLink.spec.cpp
+++ b/goldenmaster/Plugins/TbSame2/Source/TbSame2/Private/Tests/TbSame2SameEnum2InterfaceOLink.spec.cpp
@@ -85,35 +85,35 @@ void UTbSame2SameEnum2InterfaceOLinkSpec::Define()
 	It("Property.Prop1.Default", [this]()
 		{
 		// Do implement test here
-		ETbSame2Enum1 TestValue = ETbSame2Enum1::TS2E1_VALUE1; // default value
+		ETbSame2Enum1 TestValue = ETbSame2Enum1::TS2E1_Value1; // default value
 		TestEqual(TEXT("Getter should return the default value"), ImplFixture->GetImplementation()->Execute_GetProp1(ImplFixture->GetImplementation().GetObject()), TestValue);
 	});
 
 	LatentIt("Property.Prop1.Change", EAsyncExecution::ThreadPool, [this](const FDoneDelegate TestDone)
 		{
 		// Do implement test here
-		ETbSame2Enum1 TestValue = ETbSame2Enum1::TS2E1_VALUE1; // default value
+		ETbSame2Enum1 TestValue = ETbSame2Enum1::TS2E1_Value1; // default value
 		TestEqual(TEXT("Getter should return the default value"), ImplFixture->GetImplementation()->Execute_GetProp1(ImplFixture->GetImplementation().GetObject()), TestValue);
 
 		ImplFixture->GetHelper()->SetTestDone(TestDone);
 		UTbSame2SameEnum2InterfaceSignals* TbSame2SameEnum2InterfaceSignals = ImplFixture->GetImplementation()->Execute__GetSignals(ImplFixture->GetImplementation().GetObject());
 		TbSame2SameEnum2InterfaceSignals->OnProp1Changed.AddDynamic(ImplFixture->GetHelper().Get(), &UTbSame2SameEnum2InterfaceOLinkHelper::Prop1PropertyCb);
 		// use different test value
-		TestValue = ETbSame2Enum1::TS2E1_VALUE2;
+		TestValue = ETbSame2Enum1::TS2E1_Value2;
 		ImplFixture->GetImplementation()->Execute_SetProp1(ImplFixture->GetImplementation().GetObject(), TestValue);
 	});
 
 	LatentIt("Property.Prop1.ChangeLocalCheckRemote", EAsyncExecution::ThreadPool, [this](const FDoneDelegate TestDone)
 		{
 		// Do implement test here
-		ETbSame2Enum1 TestValue = ETbSame2Enum1::TS2E1_VALUE1; // default value
+		ETbSame2Enum1 TestValue = ETbSame2Enum1::TS2E1_Value1; // default value
 		TestEqual(TEXT("Getter should return the default value"), ImplFixture->GetImplementation()->Execute_GetProp1(ImplFixture->GetImplementation().GetObject()), TestValue);
 
 		ImplFixture->GetHelper()->SetTestDone(TestDone);
 		UTbSame2SameEnum2InterfaceSignals* TbSame2SameEnum2InterfaceSignals = ImplFixture->GetImplementation()->Execute__GetSignals(ImplFixture->GetImplementation().GetObject());
 		TbSame2SameEnum2InterfaceSignals->OnProp1Changed.AddDynamic(ImplFixture->GetHelper().Get(), &UTbSame2SameEnum2InterfaceOLinkHelper::Prop1PropertyChangeLocalCheckRemoteCb);
 		// use different test value
-		TestValue = ETbSame2Enum1::TS2E1_VALUE2;
+		TestValue = ETbSame2Enum1::TS2E1_Value2;
 		auto service = ImplFixture->GetGameInstance()->GetSubsystem<UTbSame2SameEnum2Interface>();
 		service->Execute_SetProp1(service, TestValue);
 	});
@@ -121,14 +121,14 @@ void UTbSame2SameEnum2InterfaceOLinkSpec::Define()
 	LatentIt("Property.Prop1.ChangeLocalChangeBackRemote", EAsyncExecution::ThreadPool, [this](const FDoneDelegate TestDone)
 		{
 		// Do implement test here
-		ETbSame2Enum1 TestValue = ETbSame2Enum1::TS2E1_VALUE1; // default value
+		ETbSame2Enum1 TestValue = ETbSame2Enum1::TS2E1_Value1; // default value
 		TestEqual(TEXT("Getter should return the default value"), ImplFixture->GetImplementation()->Execute_GetProp1(ImplFixture->GetImplementation().GetObject()), TestValue);
 
 		ImplFixture->GetHelper()->SetTestDone(TestDone);
 		UTbSame2SameEnum2InterfaceSignals* TbSame2SameEnum2InterfaceSignals = ImplFixture->GetImplementation()->Execute__GetSignals(ImplFixture->GetImplementation().GetObject());
 		TbSame2SameEnum2InterfaceSignals->OnProp1Changed.AddDynamic(ImplFixture->GetHelper().Get(), &UTbSame2SameEnum2InterfaceOLinkHelper::Prop1PropertyChangeLocalChangeRemoteCb);
 		// use different test value
-		TestValue = ETbSame2Enum1::TS2E1_VALUE2;
+		TestValue = ETbSame2Enum1::TS2E1_Value2;
 		auto service = ImplFixture->GetGameInstance()->GetSubsystem<UTbSame2SameEnum2Interface>();
 		service->Execute_SetProp1(service, TestValue);
 	});
@@ -136,35 +136,35 @@ void UTbSame2SameEnum2InterfaceOLinkSpec::Define()
 	It("Property.Prop2.Default", [this]()
 		{
 		// Do implement test here
-		ETbSame2Enum2 TestValue = ETbSame2Enum2::TS2E2_VALUE1; // default value
+		ETbSame2Enum2 TestValue = ETbSame2Enum2::TS2E2_Value1; // default value
 		TestEqual(TEXT("Getter should return the default value"), ImplFixture->GetImplementation()->Execute_GetProp2(ImplFixture->GetImplementation().GetObject()), TestValue);
 	});
 
 	LatentIt("Property.Prop2.Change", EAsyncExecution::ThreadPool, [this](const FDoneDelegate TestDone)
 		{
 		// Do implement test here
-		ETbSame2Enum2 TestValue = ETbSame2Enum2::TS2E2_VALUE1; // default value
+		ETbSame2Enum2 TestValue = ETbSame2Enum2::TS2E2_Value1; // default value
 		TestEqual(TEXT("Getter should return the default value"), ImplFixture->GetImplementation()->Execute_GetProp2(ImplFixture->GetImplementation().GetObject()), TestValue);
 
 		ImplFixture->GetHelper()->SetTestDone(TestDone);
 		UTbSame2SameEnum2InterfaceSignals* TbSame2SameEnum2InterfaceSignals = ImplFixture->GetImplementation()->Execute__GetSignals(ImplFixture->GetImplementation().GetObject());
 		TbSame2SameEnum2InterfaceSignals->OnProp2Changed.AddDynamic(ImplFixture->GetHelper().Get(), &UTbSame2SameEnum2InterfaceOLinkHelper::Prop2PropertyCb);
 		// use different test value
-		TestValue = ETbSame2Enum2::TS2E2_VALUE2;
+		TestValue = ETbSame2Enum2::TS2E2_Value2;
 		ImplFixture->GetImplementation()->Execute_SetProp2(ImplFixture->GetImplementation().GetObject(), TestValue);
 	});
 
 	LatentIt("Property.Prop2.ChangeLocalCheckRemote", EAsyncExecution::ThreadPool, [this](const FDoneDelegate TestDone)
 		{
 		// Do implement test here
-		ETbSame2Enum2 TestValue = ETbSame2Enum2::TS2E2_VALUE1; // default value
+		ETbSame2Enum2 TestValue = ETbSame2Enum2::TS2E2_Value1; // default value
 		TestEqual(TEXT("Getter should return the default value"), ImplFixture->GetImplementation()->Execute_GetProp2(ImplFixture->GetImplementation().GetObject()), TestValue);
 
 		ImplFixture->GetHelper()->SetTestDone(TestDone);
 		UTbSame2SameEnum2InterfaceSignals* TbSame2SameEnum2InterfaceSignals = ImplFixture->GetImplementation()->Execute__GetSignals(ImplFixture->GetImplementation().GetObject());
 		TbSame2SameEnum2InterfaceSignals->OnProp2Changed.AddDynamic(ImplFixture->GetHelper().Get(), &UTbSame2SameEnum2InterfaceOLinkHelper::Prop2PropertyChangeLocalCheckRemoteCb);
 		// use different test value
-		TestValue = ETbSame2Enum2::TS2E2_VALUE2;
+		TestValue = ETbSame2Enum2::TS2E2_Value2;
 		auto service = ImplFixture->GetGameInstance()->GetSubsystem<UTbSame2SameEnum2Interface>();
 		service->Execute_SetProp2(service, TestValue);
 	});
@@ -172,14 +172,14 @@ void UTbSame2SameEnum2InterfaceOLinkSpec::Define()
 	LatentIt("Property.Prop2.ChangeLocalChangeBackRemote", EAsyncExecution::ThreadPool, [this](const FDoneDelegate TestDone)
 		{
 		// Do implement test here
-		ETbSame2Enum2 TestValue = ETbSame2Enum2::TS2E2_VALUE1; // default value
+		ETbSame2Enum2 TestValue = ETbSame2Enum2::TS2E2_Value1; // default value
 		TestEqual(TEXT("Getter should return the default value"), ImplFixture->GetImplementation()->Execute_GetProp2(ImplFixture->GetImplementation().GetObject()), TestValue);
 
 		ImplFixture->GetHelper()->SetTestDone(TestDone);
 		UTbSame2SameEnum2InterfaceSignals* TbSame2SameEnum2InterfaceSignals = ImplFixture->GetImplementation()->Execute__GetSignals(ImplFixture->GetImplementation().GetObject());
 		TbSame2SameEnum2InterfaceSignals->OnProp2Changed.AddDynamic(ImplFixture->GetHelper().Get(), &UTbSame2SameEnum2InterfaceOLinkHelper::Prop2PropertyChangeLocalChangeRemoteCb);
 		// use different test value
-		TestValue = ETbSame2Enum2::TS2E2_VALUE2;
+		TestValue = ETbSame2Enum2::TS2E2_Value2;
 		auto service = ImplFixture->GetGameInstance()->GetSubsystem<UTbSame2SameEnum2Interface>();
 		service->Execute_SetProp2(service, TestValue);
 	});
@@ -189,7 +189,7 @@ void UTbSame2SameEnum2InterfaceOLinkSpec::Define()
 		// Do implement test here
 		AsyncTask(ENamedThreads::AnyThread, [this, TestDone]()
 			{
-			ImplFixture->GetImplementation()->Execute_Func1(ImplFixture->GetImplementation().GetObject(), ETbSame2Enum1::TS2E1_VALUE1);
+			ImplFixture->GetImplementation()->Execute_Func1(ImplFixture->GetImplementation().GetObject(), ETbSame2Enum1::TS2E1_Value1);
 			TestDone.Execute();
 		});
 	});
@@ -199,7 +199,7 @@ void UTbSame2SameEnum2InterfaceOLinkSpec::Define()
 		// Do implement test here
 		AsyncTask(ENamedThreads::AnyThread, [this, TestDone]()
 			{
-			ImplFixture->GetImplementation()->Execute_Func2(ImplFixture->GetImplementation().GetObject(), ETbSame2Enum1::TS2E1_VALUE1, ETbSame2Enum2::TS2E2_VALUE1);
+			ImplFixture->GetImplementation()->Execute_Func2(ImplFixture->GetImplementation().GetObject(), ETbSame2Enum1::TS2E1_Value1, ETbSame2Enum2::TS2E2_Value1);
 			TestDone.Execute();
 		});
 	});
@@ -211,7 +211,7 @@ void UTbSame2SameEnum2InterfaceOLinkSpec::Define()
 		TbSame2SameEnum2InterfaceSignals->OnSig1Signal.AddDynamic(ImplFixture->GetHelper().Get(), &UTbSame2SameEnum2InterfaceOLinkHelper::Sig1SignalCb);
 
 		// use different test value
-		ETbSame2Enum1 Param1TestValue = ETbSame2Enum1::TS2E1_VALUE2;
+		ETbSame2Enum1 Param1TestValue = ETbSame2Enum1::TS2E1_Value2;
 		TbSame2SameEnum2InterfaceSignals->BroadcastSig1Signal(Param1TestValue);
 	});
 
@@ -222,8 +222,8 @@ void UTbSame2SameEnum2InterfaceOLinkSpec::Define()
 		TbSame2SameEnum2InterfaceSignals->OnSig2Signal.AddDynamic(ImplFixture->GetHelper().Get(), &UTbSame2SameEnum2InterfaceOLinkHelper::Sig2SignalCb);
 
 		// use different test value
-		ETbSame2Enum1 Param1TestValue = ETbSame2Enum1::TS2E1_VALUE2;
-		ETbSame2Enum2 Param2TestValue = ETbSame2Enum2::TS2E2_VALUE2;
+		ETbSame2Enum1 Param1TestValue = ETbSame2Enum1::TS2E1_Value2;
+		ETbSame2Enum2 Param2TestValue = ETbSame2Enum2::TS2E2_Value2;
 		TbSame2SameEnum2InterfaceSignals->BroadcastSig2Signal(Param1TestValue, Param2TestValue);
 	});
 }

--- a/goldenmaster/Plugins/TbSame2/Source/TbSame2/Private/Tests/TbSame2SameEnum2InterfaceOLinkFixture.cpp
+++ b/goldenmaster/Plugins/TbSame2/Source/TbSame2/Private/Tests/TbSame2SameEnum2InterfaceOLinkFixture.cpp
@@ -42,9 +42,9 @@ void UTbSame2SameEnum2InterfaceOLinkHelper::SetTestDone(const FDoneDelegate& InD
 
 void UTbSame2SameEnum2InterfaceOLinkHelper::Prop1PropertyCb(ETbSame2Enum1 InProp1)
 {
-	ETbSame2Enum1 TestValue = ETbSame2Enum1::TS2E1_VALUE1;
+	ETbSame2Enum1 TestValue = ETbSame2Enum1::TS2E1_Value1;
 	// use different test value
-	TestValue = ETbSame2Enum1::TS2E1_VALUE2;
+	TestValue = ETbSame2Enum1::TS2E1_Value2;
 	Spec->TestEqual(TEXT("Delegate parameter should be the same value as set by the setter"), InProp1, TestValue);
 	if (TSharedPtr<FTbSame2SameEnum2InterfaceOLinkFixture> PinnedImplFixture = ImplFixture.Pin())
 	{
@@ -55,9 +55,9 @@ void UTbSame2SameEnum2InterfaceOLinkHelper::Prop1PropertyCb(ETbSame2Enum1 InProp
 
 void UTbSame2SameEnum2InterfaceOLinkHelper::Prop1PropertyChangeLocalCheckRemoteCb(ETbSame2Enum1 InProp1)
 {
-	ETbSame2Enum1 TestValue = ETbSame2Enum1::TS2E1_VALUE1;
+	ETbSame2Enum1 TestValue = ETbSame2Enum1::TS2E1_Value1;
 	// use different test value
-	TestValue = ETbSame2Enum1::TS2E1_VALUE2;
+	TestValue = ETbSame2Enum1::TS2E1_Value2;
 	Spec->TestEqual(TEXT("Delegate parameter should be the same value as set by the setter"), InProp1, TestValue);
 	if (TSharedPtr<FTbSame2SameEnum2InterfaceOLinkFixture> PinnedImplFixture = ImplFixture.Pin())
 	{
@@ -76,9 +76,9 @@ void UTbSame2SameEnum2InterfaceOLinkHelper::Prop1PropertyChangeLocalChangeRemote
 
 	if (count % 2 != 0)
 	{
-		ETbSame2Enum1 TestValue = ETbSame2Enum1::TS2E1_VALUE1;
+		ETbSame2Enum1 TestValue = ETbSame2Enum1::TS2E1_Value1;
 		// use different test value
-		TestValue = ETbSame2Enum1::TS2E1_VALUE2;
+		TestValue = ETbSame2Enum1::TS2E1_Value2;
 		Spec->TestEqual(TEXT("Delegate parameter should be the same value as set by the setter"), InProp1, TestValue);
 		if (TSharedPtr<FTbSame2SameEnum2InterfaceOLinkFixture> PinnedImplFixture = ImplFixture.Pin())
 		{
@@ -86,7 +86,7 @@ void UTbSame2SameEnum2InterfaceOLinkHelper::Prop1PropertyChangeLocalChangeRemote
 		}
 
 		// now set it to the default value
-		TestValue = ETbSame2Enum1::TS2E1_VALUE1; // default value
+		TestValue = ETbSame2Enum1::TS2E1_Value1; // default value
 		if (TSharedPtr<FTbSame2SameEnum2InterfaceOLinkFixture> PinnedImplFixture = ImplFixture.Pin())
 		{
 			PinnedImplFixture->GetImplementation()->Execute_SetProp1(PinnedImplFixture->GetImplementation().GetObject(), TestValue);
@@ -94,7 +94,7 @@ void UTbSame2SameEnum2InterfaceOLinkHelper::Prop1PropertyChangeLocalChangeRemote
 	}
 	else
 	{
-		ETbSame2Enum1 TestValue = ETbSame2Enum1::TS2E1_VALUE1; // default value
+		ETbSame2Enum1 TestValue = ETbSame2Enum1::TS2E1_Value1; // default value
 		Spec->TestEqual(TEXT("Delegate parameter should be the same value as set by the setter"), InProp1, TestValue);
 		if (TSharedPtr<FTbSame2SameEnum2InterfaceOLinkFixture> PinnedImplFixture = ImplFixture.Pin())
 		{
@@ -106,9 +106,9 @@ void UTbSame2SameEnum2InterfaceOLinkHelper::Prop1PropertyChangeLocalChangeRemote
 
 void UTbSame2SameEnum2InterfaceOLinkHelper::Prop2PropertyCb(ETbSame2Enum2 InProp2)
 {
-	ETbSame2Enum2 TestValue = ETbSame2Enum2::TS2E2_VALUE1;
+	ETbSame2Enum2 TestValue = ETbSame2Enum2::TS2E2_Value1;
 	// use different test value
-	TestValue = ETbSame2Enum2::TS2E2_VALUE2;
+	TestValue = ETbSame2Enum2::TS2E2_Value2;
 	Spec->TestEqual(TEXT("Delegate parameter should be the same value as set by the setter"), InProp2, TestValue);
 	if (TSharedPtr<FTbSame2SameEnum2InterfaceOLinkFixture> PinnedImplFixture = ImplFixture.Pin())
 	{
@@ -119,9 +119,9 @@ void UTbSame2SameEnum2InterfaceOLinkHelper::Prop2PropertyCb(ETbSame2Enum2 InProp
 
 void UTbSame2SameEnum2InterfaceOLinkHelper::Prop2PropertyChangeLocalCheckRemoteCb(ETbSame2Enum2 InProp2)
 {
-	ETbSame2Enum2 TestValue = ETbSame2Enum2::TS2E2_VALUE1;
+	ETbSame2Enum2 TestValue = ETbSame2Enum2::TS2E2_Value1;
 	// use different test value
-	TestValue = ETbSame2Enum2::TS2E2_VALUE2;
+	TestValue = ETbSame2Enum2::TS2E2_Value2;
 	Spec->TestEqual(TEXT("Delegate parameter should be the same value as set by the setter"), InProp2, TestValue);
 	if (TSharedPtr<FTbSame2SameEnum2InterfaceOLinkFixture> PinnedImplFixture = ImplFixture.Pin())
 	{
@@ -140,9 +140,9 @@ void UTbSame2SameEnum2InterfaceOLinkHelper::Prop2PropertyChangeLocalChangeRemote
 
 	if (count % 2 != 0)
 	{
-		ETbSame2Enum2 TestValue = ETbSame2Enum2::TS2E2_VALUE1;
+		ETbSame2Enum2 TestValue = ETbSame2Enum2::TS2E2_Value1;
 		// use different test value
-		TestValue = ETbSame2Enum2::TS2E2_VALUE2;
+		TestValue = ETbSame2Enum2::TS2E2_Value2;
 		Spec->TestEqual(TEXT("Delegate parameter should be the same value as set by the setter"), InProp2, TestValue);
 		if (TSharedPtr<FTbSame2SameEnum2InterfaceOLinkFixture> PinnedImplFixture = ImplFixture.Pin())
 		{
@@ -150,7 +150,7 @@ void UTbSame2SameEnum2InterfaceOLinkHelper::Prop2PropertyChangeLocalChangeRemote
 		}
 
 		// now set it to the default value
-		TestValue = ETbSame2Enum2::TS2E2_VALUE1; // default value
+		TestValue = ETbSame2Enum2::TS2E2_Value1; // default value
 		if (TSharedPtr<FTbSame2SameEnum2InterfaceOLinkFixture> PinnedImplFixture = ImplFixture.Pin())
 		{
 			PinnedImplFixture->GetImplementation()->Execute_SetProp2(PinnedImplFixture->GetImplementation().GetObject(), TestValue);
@@ -158,7 +158,7 @@ void UTbSame2SameEnum2InterfaceOLinkHelper::Prop2PropertyChangeLocalChangeRemote
 	}
 	else
 	{
-		ETbSame2Enum2 TestValue = ETbSame2Enum2::TS2E2_VALUE1; // default value
+		ETbSame2Enum2 TestValue = ETbSame2Enum2::TS2E2_Value1; // default value
 		Spec->TestEqual(TEXT("Delegate parameter should be the same value as set by the setter"), InProp2, TestValue);
 		if (TSharedPtr<FTbSame2SameEnum2InterfaceOLinkFixture> PinnedImplFixture = ImplFixture.Pin())
 		{
@@ -171,7 +171,7 @@ void UTbSame2SameEnum2InterfaceOLinkHelper::Prop2PropertyChangeLocalChangeRemote
 void UTbSame2SameEnum2InterfaceOLinkHelper::Sig1SignalCb(ETbSame2Enum1 InParam1)
 {
 	// known test value
-	ETbSame2Enum1 Param1TestValue = ETbSame2Enum1::TS2E1_VALUE2;
+	ETbSame2Enum1 Param1TestValue = ETbSame2Enum1::TS2E1_Value2;
 	Spec->TestEqual(TEXT("Parameter should be the same value as sent by the signal"), InParam1, Param1TestValue);
 	testDoneDelegate.Execute();
 }
@@ -179,9 +179,9 @@ void UTbSame2SameEnum2InterfaceOLinkHelper::Sig1SignalCb(ETbSame2Enum1 InParam1)
 void UTbSame2SameEnum2InterfaceOLinkHelper::Sig2SignalCb(ETbSame2Enum1 InParam1, ETbSame2Enum2 InParam2)
 {
 	// known test value
-	ETbSame2Enum1 Param1TestValue = ETbSame2Enum1::TS2E1_VALUE2;
+	ETbSame2Enum1 Param1TestValue = ETbSame2Enum1::TS2E1_Value2;
 	Spec->TestEqual(TEXT("Parameter should be the same value as sent by the signal"), InParam1, Param1TestValue);
-	ETbSame2Enum2 Param2TestValue = ETbSame2Enum2::TS2E2_VALUE2;
+	ETbSame2Enum2 Param2TestValue = ETbSame2Enum2::TS2E2_Value2;
 	Spec->TestEqual(TEXT("Parameter should be the same value as sent by the signal"), InParam2, Param2TestValue);
 	testDoneDelegate.Execute();
 }

--- a/goldenmaster/Plugins/TbSame2/Source/TbSame2/Public/Generated/MsgBus/TbSame2SameEnum1InterfaceMsgBusMessages.h
+++ b/goldenmaster/Plugins/TbSame2/Source/TbSame2/Public/Generated/MsgBus/TbSame2SameEnum1InterfaceMsgBusMessages.h
@@ -52,7 +52,7 @@ struct FTbSame2SameEnum1InterfaceInitMessage
 	int32 _ClientPingIntervalMS = 100;
 
 	UPROPERTY()
-	ETbSame2Enum1 Prop1 = ETbSame2Enum1::TS2E1_VALUE1;
+	ETbSame2Enum1 Prop1 = ETbSame2Enum1::TS2E1_Value1;
 };
 
 USTRUCT()
@@ -91,7 +91,7 @@ struct FTbSame2SameEnum1InterfaceSig1SignalMessage
 	GENERATED_BODY()
 
 	UPROPERTY()
-	ETbSame2Enum1 Param1 = ETbSame2Enum1::TS2E1_VALUE1;
+	ETbSame2Enum1 Param1 = ETbSame2Enum1::TS2E1_Value1;
 };
 
 USTRUCT()
@@ -100,7 +100,7 @@ struct FTbSame2SameEnum1InterfaceSetProp1RequestMessage
 	GENERATED_BODY()
 
 	UPROPERTY()
-	ETbSame2Enum1 Prop1 = ETbSame2Enum1::TS2E1_VALUE1;
+	ETbSame2Enum1 Prop1 = ETbSame2Enum1::TS2E1_Value1;
 };
 
 USTRUCT()
@@ -109,7 +109,7 @@ struct FTbSame2SameEnum1InterfaceProp1ChangedMessage
 	GENERATED_BODY()
 
 	UPROPERTY()
-	ETbSame2Enum1 Prop1 = ETbSame2Enum1::TS2E1_VALUE1;
+	ETbSame2Enum1 Prop1 = ETbSame2Enum1::TS2E1_Value1;
 };
 
 USTRUCT()
@@ -121,7 +121,7 @@ struct FTbSame2SameEnum1InterfaceFunc1RequestMessage
 	FGuid ResponseId;
 
 	UPROPERTY()
-	ETbSame2Enum1 Param1 = ETbSame2Enum1::TS2E1_VALUE1;
+	ETbSame2Enum1 Param1 = ETbSame2Enum1::TS2E1_Value1;
 };
 
 USTRUCT()
@@ -133,5 +133,5 @@ struct FTbSame2SameEnum1InterfaceFunc1ReplyMessage
 	FGuid ResponseId;
 
 	UPROPERTY()
-	ETbSame2Enum1 Result = ETbSame2Enum1::TS2E1_VALUE1;
+	ETbSame2Enum1 Result = ETbSame2Enum1::TS2E1_Value1;
 };

--- a/goldenmaster/Plugins/TbSame2/Source/TbSame2/Public/Generated/MsgBus/TbSame2SameEnum2InterfaceMsgBusMessages.h
+++ b/goldenmaster/Plugins/TbSame2/Source/TbSame2/Public/Generated/MsgBus/TbSame2SameEnum2InterfaceMsgBusMessages.h
@@ -52,10 +52,10 @@ struct FTbSame2SameEnum2InterfaceInitMessage
 	int32 _ClientPingIntervalMS = 100;
 
 	UPROPERTY()
-	ETbSame2Enum1 Prop1 = ETbSame2Enum1::TS2E1_VALUE1;
+	ETbSame2Enum1 Prop1 = ETbSame2Enum1::TS2E1_Value1;
 
 	UPROPERTY()
-	ETbSame2Enum2 Prop2 = ETbSame2Enum2::TS2E2_VALUE1;
+	ETbSame2Enum2 Prop2 = ETbSame2Enum2::TS2E2_Value1;
 };
 
 USTRUCT()
@@ -94,7 +94,7 @@ struct FTbSame2SameEnum2InterfaceSig1SignalMessage
 	GENERATED_BODY()
 
 	UPROPERTY()
-	ETbSame2Enum1 Param1 = ETbSame2Enum1::TS2E1_VALUE1;
+	ETbSame2Enum1 Param1 = ETbSame2Enum1::TS2E1_Value1;
 };
 
 USTRUCT()
@@ -103,10 +103,10 @@ struct FTbSame2SameEnum2InterfaceSig2SignalMessage
 	GENERATED_BODY()
 
 	UPROPERTY()
-	ETbSame2Enum1 Param1 = ETbSame2Enum1::TS2E1_VALUE1;
+	ETbSame2Enum1 Param1 = ETbSame2Enum1::TS2E1_Value1;
 
 	UPROPERTY()
-	ETbSame2Enum2 Param2 = ETbSame2Enum2::TS2E2_VALUE1;
+	ETbSame2Enum2 Param2 = ETbSame2Enum2::TS2E2_Value1;
 };
 
 USTRUCT()
@@ -115,7 +115,7 @@ struct FTbSame2SameEnum2InterfaceSetProp1RequestMessage
 	GENERATED_BODY()
 
 	UPROPERTY()
-	ETbSame2Enum1 Prop1 = ETbSame2Enum1::TS2E1_VALUE1;
+	ETbSame2Enum1 Prop1 = ETbSame2Enum1::TS2E1_Value1;
 };
 
 USTRUCT()
@@ -124,7 +124,7 @@ struct FTbSame2SameEnum2InterfaceProp1ChangedMessage
 	GENERATED_BODY()
 
 	UPROPERTY()
-	ETbSame2Enum1 Prop1 = ETbSame2Enum1::TS2E1_VALUE1;
+	ETbSame2Enum1 Prop1 = ETbSame2Enum1::TS2E1_Value1;
 };
 
 USTRUCT()
@@ -133,7 +133,7 @@ struct FTbSame2SameEnum2InterfaceSetProp2RequestMessage
 	GENERATED_BODY()
 
 	UPROPERTY()
-	ETbSame2Enum2 Prop2 = ETbSame2Enum2::TS2E2_VALUE1;
+	ETbSame2Enum2 Prop2 = ETbSame2Enum2::TS2E2_Value1;
 };
 
 USTRUCT()
@@ -142,7 +142,7 @@ struct FTbSame2SameEnum2InterfaceProp2ChangedMessage
 	GENERATED_BODY()
 
 	UPROPERTY()
-	ETbSame2Enum2 Prop2 = ETbSame2Enum2::TS2E2_VALUE1;
+	ETbSame2Enum2 Prop2 = ETbSame2Enum2::TS2E2_Value1;
 };
 
 USTRUCT()
@@ -154,7 +154,7 @@ struct FTbSame2SameEnum2InterfaceFunc1RequestMessage
 	FGuid ResponseId;
 
 	UPROPERTY()
-	ETbSame2Enum1 Param1 = ETbSame2Enum1::TS2E1_VALUE1;
+	ETbSame2Enum1 Param1 = ETbSame2Enum1::TS2E1_Value1;
 };
 
 USTRUCT()
@@ -166,7 +166,7 @@ struct FTbSame2SameEnum2InterfaceFunc1ReplyMessage
 	FGuid ResponseId;
 
 	UPROPERTY()
-	ETbSame2Enum1 Result = ETbSame2Enum1::TS2E1_VALUE1;
+	ETbSame2Enum1 Result = ETbSame2Enum1::TS2E1_Value1;
 };
 
 USTRUCT()
@@ -178,10 +178,10 @@ struct FTbSame2SameEnum2InterfaceFunc2RequestMessage
 	FGuid ResponseId;
 
 	UPROPERTY()
-	ETbSame2Enum1 Param1 = ETbSame2Enum1::TS2E1_VALUE1;
+	ETbSame2Enum1 Param1 = ETbSame2Enum1::TS2E1_Value1;
 
 	UPROPERTY()
-	ETbSame2Enum2 Param2 = ETbSame2Enum2::TS2E2_VALUE1;
+	ETbSame2Enum2 Param2 = ETbSame2Enum2::TS2E2_Value1;
 };
 
 USTRUCT()
@@ -193,5 +193,5 @@ struct FTbSame2SameEnum2InterfaceFunc2ReplyMessage
 	FGuid ResponseId;
 
 	UPROPERTY()
-	ETbSame2Enum1 Result = ETbSame2Enum1::TS2E1_VALUE1;
+	ETbSame2Enum1 Result = ETbSame2Enum1::TS2E1_Value1;
 };

--- a/goldenmaster/Plugins/TbSame2/Source/TbSame2/Public/Generated/api/AbstractTbSame2SameEnum1Interface.h
+++ b/goldenmaster/Plugins/TbSame2/Source/TbSame2/Public/Generated/api/AbstractTbSame2SameEnum1Interface.h
@@ -42,10 +42,10 @@ public:
 
 	// methods
 	virtual void Func1Async_Implementation(UObject* WorldContextObject, FLatentActionInfo LatentInfo, ETbSame2Enum1& Result, ETbSame2Enum1 Param1) override;
-	virtual ETbSame2Enum1 Func1_Implementation(ETbSame2Enum1 Param1) override PURE_VIRTUAL(UAbstractTbSame2SameEnum1Interface::Func1_Implementation, return ETbSame2Enum1::TS2E1_VALUE1;);
+	virtual ETbSame2Enum1 Func1_Implementation(ETbSame2Enum1 Param1) override PURE_VIRTUAL(UAbstractTbSame2SameEnum1Interface::Func1_Implementation, return ETbSame2Enum1::TS2E1_Value1;);
 
 	// properties
-	virtual ETbSame2Enum1 GetProp1_Implementation() const override PURE_VIRTUAL(UAbstractTbSame2SameEnum1Interface::GetProp1_Implementation, return ETbSame2Enum1::TS2E1_VALUE1;);
+	virtual ETbSame2Enum1 GetProp1_Implementation() const override PURE_VIRTUAL(UAbstractTbSame2SameEnum1Interface::GetProp1_Implementation, return ETbSame2Enum1::TS2E1_Value1;);
 	virtual void SetProp1_Implementation(ETbSame2Enum1 InProp1) override PURE_VIRTUAL(UAbstractTbSame2SameEnum1Interface::SetProp1_Implementation, return;);
 
 	virtual bool IsInitialized() const;
@@ -55,7 +55,7 @@ protected:
 
 	// properties - local copy
 	UPROPERTY(EditAnywhere, BlueprintGetter = GetProp1_Private, BlueprintSetter = SetProp1_Private, Category = "ApiGear|TbSame2|SameEnum1Interface")
-	ETbSame2Enum1 Prop1{ETbSame2Enum1::TS2E1_VALUE1};
+	ETbSame2Enum1 Prop1{ETbSame2Enum1::TS2E1_Value1};
 
 	UFUNCTION(BlueprintGetter, Category = "ApiGear|TbSame2|SameEnum1Interface|Properties", BlueprintInternalUseOnly)
 	ETbSame2Enum1 GetProp1_Private() const;

--- a/goldenmaster/Plugins/TbSame2/Source/TbSame2/Public/Generated/api/AbstractTbSame2SameEnum2Interface.h
+++ b/goldenmaster/Plugins/TbSame2/Source/TbSame2/Public/Generated/api/AbstractTbSame2SameEnum2Interface.h
@@ -42,16 +42,16 @@ public:
 
 	// methods
 	virtual void Func1Async_Implementation(UObject* WorldContextObject, FLatentActionInfo LatentInfo, ETbSame2Enum1& Result, ETbSame2Enum1 Param1) override;
-	virtual ETbSame2Enum1 Func1_Implementation(ETbSame2Enum1 Param1) override PURE_VIRTUAL(UAbstractTbSame2SameEnum2Interface::Func1_Implementation, return ETbSame2Enum1::TS2E1_VALUE1;);
+	virtual ETbSame2Enum1 Func1_Implementation(ETbSame2Enum1 Param1) override PURE_VIRTUAL(UAbstractTbSame2SameEnum2Interface::Func1_Implementation, return ETbSame2Enum1::TS2E1_Value1;);
 
 	virtual void Func2Async_Implementation(UObject* WorldContextObject, FLatentActionInfo LatentInfo, ETbSame2Enum1& Result, ETbSame2Enum1 Param1, ETbSame2Enum2 Param2) override;
-	virtual ETbSame2Enum1 Func2_Implementation(ETbSame2Enum1 Param1, ETbSame2Enum2 Param2) override PURE_VIRTUAL(UAbstractTbSame2SameEnum2Interface::Func2_Implementation, return ETbSame2Enum1::TS2E1_VALUE1;);
+	virtual ETbSame2Enum1 Func2_Implementation(ETbSame2Enum1 Param1, ETbSame2Enum2 Param2) override PURE_VIRTUAL(UAbstractTbSame2SameEnum2Interface::Func2_Implementation, return ETbSame2Enum1::TS2E1_Value1;);
 
 	// properties
-	virtual ETbSame2Enum1 GetProp1_Implementation() const override PURE_VIRTUAL(UAbstractTbSame2SameEnum2Interface::GetProp1_Implementation, return ETbSame2Enum1::TS2E1_VALUE1;);
+	virtual ETbSame2Enum1 GetProp1_Implementation() const override PURE_VIRTUAL(UAbstractTbSame2SameEnum2Interface::GetProp1_Implementation, return ETbSame2Enum1::TS2E1_Value1;);
 	virtual void SetProp1_Implementation(ETbSame2Enum1 InProp1) override PURE_VIRTUAL(UAbstractTbSame2SameEnum2Interface::SetProp1_Implementation, return;);
 
-	virtual ETbSame2Enum2 GetProp2_Implementation() const override PURE_VIRTUAL(UAbstractTbSame2SameEnum2Interface::GetProp2_Implementation, return ETbSame2Enum2::TS2E2_VALUE1;);
+	virtual ETbSame2Enum2 GetProp2_Implementation() const override PURE_VIRTUAL(UAbstractTbSame2SameEnum2Interface::GetProp2_Implementation, return ETbSame2Enum2::TS2E2_Value1;);
 	virtual void SetProp2_Implementation(ETbSame2Enum2 InProp2) override PURE_VIRTUAL(UAbstractTbSame2SameEnum2Interface::SetProp2_Implementation, return;);
 
 	virtual bool IsInitialized() const;
@@ -61,7 +61,7 @@ protected:
 
 	// properties - local copy
 	UPROPERTY(EditAnywhere, BlueprintGetter = GetProp1_Private, BlueprintSetter = SetProp1_Private, Category = "ApiGear|TbSame2|SameEnum2Interface")
-	ETbSame2Enum1 Prop1{ETbSame2Enum1::TS2E1_VALUE1};
+	ETbSame2Enum1 Prop1{ETbSame2Enum1::TS2E1_Value1};
 
 	UFUNCTION(BlueprintGetter, Category = "ApiGear|TbSame2|SameEnum2Interface|Properties", BlueprintInternalUseOnly)
 	ETbSame2Enum1 GetProp1_Private() const;
@@ -70,7 +70,7 @@ protected:
 	void SetProp1_Private(ETbSame2Enum1 InProp1);
 
 	UPROPERTY(EditAnywhere, BlueprintGetter = GetProp2_Private, BlueprintSetter = SetProp2_Private, Category = "ApiGear|TbSame2|SameEnum2Interface")
-	ETbSame2Enum2 Prop2{ETbSame2Enum2::TS2E2_VALUE1};
+	ETbSame2Enum2 Prop2{ETbSame2Enum2::TS2E2_Value1};
 
 	UFUNCTION(BlueprintGetter, Category = "ApiGear|TbSame2|SameEnum2Interface|Properties", BlueprintInternalUseOnly)
 	ETbSame2Enum2 GetProp2_Private() const;

--- a/goldenmaster/Plugins/TbSame2/Source/TbSame2/Public/Generated/api/TbSame2_data.h
+++ b/goldenmaster/Plugins/TbSame2/Source/TbSame2/Public/Generated/api/TbSame2_data.h
@@ -28,9 +28,9 @@ limitations under the License.
 UENUM(BlueprintType)
 enum class ETbSame2Enum1 : uint8
 {
-	TS2E1_VALUE1 = 1 UMETA(Displayname = "value1"),
-	TS2E1_VALUE2 = 2 UMETA(Displayname = "value2"),
-	UNSPECIFIED = 0 UMETA(Hidden)
+	TS2E1_Value1 = 1 UMETA(Displayname = "value1"),
+	TS2E1_Value2 = 2 UMETA(Displayname = "value2"),
+	Unspecified = 0 UMETA(Hidden)
 };
 
 /**
@@ -39,9 +39,9 @@ enum class ETbSame2Enum1 : uint8
 UENUM(BlueprintType)
 enum class ETbSame2Enum2 : uint8
 {
-	TS2E2_VALUE1 = 1 UMETA(Displayname = "value1"),
-	TS2E2_VALUE2 = 2 UMETA(Displayname = "value2"),
-	UNSPECIFIED = 0 UMETA(Hidden)
+	TS2E2_Value1 = 1 UMETA(Displayname = "value1"),
+	TS2E2_Value2 = 2 UMETA(Displayname = "value2"),
+	Unspecified = 0 UMETA(Hidden)
 };
 
 /**

--- a/goldenmaster/Plugins/Testbed1/Source/Testbed1/Private/Generated/api/Testbed1_data.cpp
+++ b/goldenmaster/Plugins/Testbed1/Source/Testbed1/Private/Generated/api/Testbed1_data.cpp
@@ -27,19 +27,19 @@ bool UTestbed1Library::toTestbed1Enum0(ETestbed1Enum0& ConvertedEnum, uint8 InVa
 	switch (InValue)
 	{
 	case 0:
-		ConvertedEnum = ETestbed1Enum0::T1E0_VALUE0;
+		ConvertedEnum = ETestbed1Enum0::T1E0_Value0;
 		bSuccessful = true;
 		break;
 	case 1:
-		ConvertedEnum = ETestbed1Enum0::T1E0_VALUE1;
+		ConvertedEnum = ETestbed1Enum0::T1E0_Value1;
 		bSuccessful = true;
 		break;
 	case 2:
-		ConvertedEnum = ETestbed1Enum0::T1E0_VALUE2;
+		ConvertedEnum = ETestbed1Enum0::T1E0_Value2;
 		bSuccessful = true;
 		break;
 	default:
-		ConvertedEnum = ETestbed1Enum0::T1E0_VALUE0;
+		ConvertedEnum = ETestbed1Enum0::T1E0_Value0;
 	}
 	return bSuccessful;
 }

--- a/goldenmaster/Plugins/Testbed1/Source/Testbed1/Private/Tests/Testbed1StructArrayInterfaceImpl.spec.cpp
+++ b/goldenmaster/Plugins/Testbed1/Source/Testbed1/Private/Tests/Testbed1StructArrayInterfaceImpl.spec.cpp
@@ -148,7 +148,7 @@ void UTestbed1StructArrayInterfaceImplSpec::Define()
 		UTestbed1StructArrayInterfaceSignals* Testbed1StructArrayInterfaceSignals = ImplFixture->GetImplementation()->Execute__GetSignals(ImplFixture->GetImplementation().GetObject());
 		Testbed1StructArrayInterfaceSignals->OnPropEnumChanged.AddDynamic(ImplFixture->GetHelper().Get(), &UTestbed1StructArrayInterfaceImplHelper::PropEnumPropertyCb);
 		// use different test value
-		TestValue.Add(ETestbed1Enum0::T1E0_VALUE1);
+		TestValue.Add(ETestbed1Enum0::T1E0_Value1);
 		ImplFixture->GetImplementation()->Execute_SetPropEnum(ImplFixture->GetImplementation().GetObject(), TestValue);
 	});
 
@@ -234,7 +234,7 @@ void UTestbed1StructArrayInterfaceImplSpec::Define()
 
 		// use different test value
 		TArray<ETestbed1Enum0> ParamEnumTestValue = TArray<ETestbed1Enum0>(); // default value
-		ParamEnumTestValue.Add(ETestbed1Enum0::T1E0_VALUE1);
+		ParamEnumTestValue.Add(ETestbed1Enum0::T1E0_Value1);
 		Testbed1StructArrayInterfaceSignals->BroadcastSigEnumSignal(ParamEnumTestValue);
 	});
 }

--- a/goldenmaster/Plugins/Testbed1/Source/Testbed1/Private/Tests/Testbed1StructArrayInterfaceImplFixture.cpp
+++ b/goldenmaster/Plugins/Testbed1/Source/Testbed1/Private/Tests/Testbed1StructArrayInterfaceImplFixture.cpp
@@ -93,7 +93,7 @@ void UTestbed1StructArrayInterfaceImplHelper::PropEnumPropertyCb(const TArray<ET
 {
 	TArray<ETestbed1Enum0> TestValue = TArray<ETestbed1Enum0>();
 	// use different test value
-	TestValue.Add(ETestbed1Enum0::T1E0_VALUE1);
+	TestValue.Add(ETestbed1Enum0::T1E0_Value1);
 	Spec->TestEqual(TEXT("Delegate parameter should be the same value as set by the setter"), InPropEnum, TestValue);
 	if (TSharedPtr<FTestbed1StructArrayInterfaceImplFixture> PinnedImplFixture = ImplFixture.Pin())
 	{
@@ -138,7 +138,7 @@ void UTestbed1StructArrayInterfaceImplHelper::SigEnumSignalCb(const TArray<ETest
 {
 	// known test value
 	TArray<ETestbed1Enum0> ParamEnumTestValue = TArray<ETestbed1Enum0>(); // default value
-	ParamEnumTestValue.Add(ETestbed1Enum0::T1E0_VALUE1);
+	ParamEnumTestValue.Add(ETestbed1Enum0::T1E0_Value1);
 	Spec->TestEqual(TEXT("Parameter should be the same value as sent by the signal"), InParamEnum, ParamEnumTestValue);
 	testDoneDelegate.Execute();
 }

--- a/goldenmaster/Plugins/Testbed1/Source/Testbed1/Private/Tests/Testbed1StructArrayInterfaceMsgBus.spec.cpp
+++ b/goldenmaster/Plugins/Testbed1/Source/Testbed1/Private/Tests/Testbed1StructArrayInterfaceMsgBus.spec.cpp
@@ -285,7 +285,7 @@ void UTestbed1StructArrayInterfaceMsgBusSpec::Define()
 		UTestbed1StructArrayInterfaceSignals* Testbed1StructArrayInterfaceSignals = ImplFixture->GetImplementation()->Execute__GetSignals(ImplFixture->GetImplementation().GetObject());
 		Testbed1StructArrayInterfaceSignals->OnPropEnumChanged.AddDynamic(ImplFixture->GetHelper().Get(), &UTestbed1StructArrayInterfaceMsgBusHelper::PropEnumPropertyCb);
 		// use different test value
-		TestValue.Add(ETestbed1Enum0::T1E0_VALUE1);
+		TestValue.Add(ETestbed1Enum0::T1E0_Value1);
 		ImplFixture->GetImplementation()->Execute_SetPropEnum(ImplFixture->GetImplementation().GetObject(), TestValue);
 	});
 
@@ -299,7 +299,7 @@ void UTestbed1StructArrayInterfaceMsgBusSpec::Define()
 		UTestbed1StructArrayInterfaceSignals* Testbed1StructArrayInterfaceSignals = ImplFixture->GetImplementation()->Execute__GetSignals(ImplFixture->GetImplementation().GetObject());
 		Testbed1StructArrayInterfaceSignals->OnPropEnumChanged.AddDynamic(ImplFixture->GetHelper().Get(), &UTestbed1StructArrayInterfaceMsgBusHelper::PropEnumPropertyChangeLocalCheckRemoteCb);
 		// use different test value
-		TestValue.Add(ETestbed1Enum0::T1E0_VALUE1);
+		TestValue.Add(ETestbed1Enum0::T1E0_Value1);
 		auto service = ImplFixture->GetGameInstance()->GetSubsystem<UTestbed1StructArrayInterface>();
 		service->Execute_SetPropEnum(service, TestValue);
 	});
@@ -314,7 +314,7 @@ void UTestbed1StructArrayInterfaceMsgBusSpec::Define()
 		UTestbed1StructArrayInterfaceSignals* Testbed1StructArrayInterfaceSignals = ImplFixture->GetImplementation()->Execute__GetSignals(ImplFixture->GetImplementation().GetObject());
 		Testbed1StructArrayInterfaceSignals->OnPropEnumChanged.AddDynamic(ImplFixture->GetHelper().Get(), &UTestbed1StructArrayInterfaceMsgBusHelper::PropEnumPropertyChangeLocalChangeRemoteCb);
 		// use different test value
-		TestValue.Add(ETestbed1Enum0::T1E0_VALUE1);
+		TestValue.Add(ETestbed1Enum0::T1E0_Value1);
 		auto service = ImplFixture->GetGameInstance()->GetSubsystem<UTestbed1StructArrayInterface>();
 		service->Execute_SetPropEnum(service, TestValue);
 	});
@@ -421,7 +421,7 @@ void UTestbed1StructArrayInterfaceMsgBusSpec::Define()
 
 		// use different test value
 		TArray<ETestbed1Enum0> ParamEnumTestValue = TArray<ETestbed1Enum0>(); // default value
-		ParamEnumTestValue.Add(ETestbed1Enum0::T1E0_VALUE1);
+		ParamEnumTestValue.Add(ETestbed1Enum0::T1E0_Value1);
 		Testbed1StructArrayInterfaceSignals->BroadcastSigEnumSignal(ParamEnumTestValue);
 	});
 }

--- a/goldenmaster/Plugins/Testbed1/Source/Testbed1/Private/Tests/Testbed1StructArrayInterfaceMsgBusFixture.cpp
+++ b/goldenmaster/Plugins/Testbed1/Source/Testbed1/Private/Tests/Testbed1StructArrayInterfaceMsgBusFixture.cpp
@@ -303,7 +303,7 @@ void UTestbed1StructArrayInterfaceMsgBusHelper::PropEnumPropertyCb(const TArray<
 {
 	TArray<ETestbed1Enum0> TestValue = TArray<ETestbed1Enum0>();
 	// use different test value
-	TestValue.Add(ETestbed1Enum0::T1E0_VALUE1);
+	TestValue.Add(ETestbed1Enum0::T1E0_Value1);
 	Spec->TestEqual(TEXT("Delegate parameter should be the same value as set by the setter"), InPropEnum, TestValue);
 	if (TSharedPtr<FTestbed1StructArrayInterfaceMsgBusFixture> PinnedImplFixture = ImplFixture.Pin())
 	{
@@ -316,7 +316,7 @@ void UTestbed1StructArrayInterfaceMsgBusHelper::PropEnumPropertyChangeLocalCheck
 {
 	TArray<ETestbed1Enum0> TestValue = TArray<ETestbed1Enum0>();
 	// use different test value
-	TestValue.Add(ETestbed1Enum0::T1E0_VALUE1);
+	TestValue.Add(ETestbed1Enum0::T1E0_Value1);
 	Spec->TestEqual(TEXT("Delegate parameter should be the same value as set by the setter"), InPropEnum, TestValue);
 	if (TSharedPtr<FTestbed1StructArrayInterfaceMsgBusFixture> PinnedImplFixture = ImplFixture.Pin())
 	{
@@ -337,7 +337,7 @@ void UTestbed1StructArrayInterfaceMsgBusHelper::PropEnumPropertyChangeLocalChang
 	{
 		TArray<ETestbed1Enum0> TestValue = TArray<ETestbed1Enum0>();
 		// use different test value
-		TestValue.Add(ETestbed1Enum0::T1E0_VALUE1);
+		TestValue.Add(ETestbed1Enum0::T1E0_Value1);
 		Spec->TestEqual(TEXT("Delegate parameter should be the same value as set by the setter"), InPropEnum, TestValue);
 		if (TSharedPtr<FTestbed1StructArrayInterfaceMsgBusFixture> PinnedImplFixture = ImplFixture.Pin())
 		{
@@ -399,7 +399,7 @@ void UTestbed1StructArrayInterfaceMsgBusHelper::SigEnumSignalCb(const TArray<ETe
 {
 	// known test value
 	TArray<ETestbed1Enum0> ParamEnumTestValue = TArray<ETestbed1Enum0>(); // default value
-	ParamEnumTestValue.Add(ETestbed1Enum0::T1E0_VALUE1);
+	ParamEnumTestValue.Add(ETestbed1Enum0::T1E0_Value1);
 	Spec->TestEqual(TEXT("Parameter should be the same value as sent by the signal"), InParamEnum, ParamEnumTestValue);
 	testDoneDelegate.Execute();
 }

--- a/goldenmaster/Plugins/Testbed1/Source/Testbed1/Private/Tests/Testbed1StructArrayInterfaceOLink.spec.cpp
+++ b/goldenmaster/Plugins/Testbed1/Source/Testbed1/Private/Tests/Testbed1StructArrayInterfaceOLink.spec.cpp
@@ -303,7 +303,7 @@ void UTestbed1StructArrayInterfaceOLinkSpec::Define()
 		UTestbed1StructArrayInterfaceSignals* Testbed1StructArrayInterfaceSignals = ImplFixture->GetImplementation()->Execute__GetSignals(ImplFixture->GetImplementation().GetObject());
 		Testbed1StructArrayInterfaceSignals->OnPropEnumChanged.AddDynamic(ImplFixture->GetHelper().Get(), &UTestbed1StructArrayInterfaceOLinkHelper::PropEnumPropertyCb);
 		// use different test value
-		TestValue.Add(ETestbed1Enum0::T1E0_VALUE1);
+		TestValue.Add(ETestbed1Enum0::T1E0_Value1);
 		ImplFixture->GetImplementation()->Execute_SetPropEnum(ImplFixture->GetImplementation().GetObject(), TestValue);
 	});
 
@@ -317,7 +317,7 @@ void UTestbed1StructArrayInterfaceOLinkSpec::Define()
 		UTestbed1StructArrayInterfaceSignals* Testbed1StructArrayInterfaceSignals = ImplFixture->GetImplementation()->Execute__GetSignals(ImplFixture->GetImplementation().GetObject());
 		Testbed1StructArrayInterfaceSignals->OnPropEnumChanged.AddDynamic(ImplFixture->GetHelper().Get(), &UTestbed1StructArrayInterfaceOLinkHelper::PropEnumPropertyChangeLocalCheckRemoteCb);
 		// use different test value
-		TestValue.Add(ETestbed1Enum0::T1E0_VALUE1);
+		TestValue.Add(ETestbed1Enum0::T1E0_Value1);
 		auto service = ImplFixture->GetGameInstance()->GetSubsystem<UTestbed1StructArrayInterface>();
 		service->Execute_SetPropEnum(service, TestValue);
 	});
@@ -332,7 +332,7 @@ void UTestbed1StructArrayInterfaceOLinkSpec::Define()
 		UTestbed1StructArrayInterfaceSignals* Testbed1StructArrayInterfaceSignals = ImplFixture->GetImplementation()->Execute__GetSignals(ImplFixture->GetImplementation().GetObject());
 		Testbed1StructArrayInterfaceSignals->OnPropEnumChanged.AddDynamic(ImplFixture->GetHelper().Get(), &UTestbed1StructArrayInterfaceOLinkHelper::PropEnumPropertyChangeLocalChangeRemoteCb);
 		// use different test value
-		TestValue.Add(ETestbed1Enum0::T1E0_VALUE1);
+		TestValue.Add(ETestbed1Enum0::T1E0_Value1);
 		auto service = ImplFixture->GetGameInstance()->GetSubsystem<UTestbed1StructArrayInterface>();
 		service->Execute_SetPropEnum(service, TestValue);
 	});
@@ -439,7 +439,7 @@ void UTestbed1StructArrayInterfaceOLinkSpec::Define()
 
 		// use different test value
 		TArray<ETestbed1Enum0> ParamEnumTestValue = TArray<ETestbed1Enum0>(); // default value
-		ParamEnumTestValue.Add(ETestbed1Enum0::T1E0_VALUE1);
+		ParamEnumTestValue.Add(ETestbed1Enum0::T1E0_Value1);
 		Testbed1StructArrayInterfaceSignals->BroadcastSigEnumSignal(ParamEnumTestValue);
 	});
 }

--- a/goldenmaster/Plugins/Testbed1/Source/Testbed1/Private/Tests/Testbed1StructArrayInterfaceOLinkFixture.cpp
+++ b/goldenmaster/Plugins/Testbed1/Source/Testbed1/Private/Tests/Testbed1StructArrayInterfaceOLinkFixture.cpp
@@ -300,7 +300,7 @@ void UTestbed1StructArrayInterfaceOLinkHelper::PropEnumPropertyCb(const TArray<E
 {
 	TArray<ETestbed1Enum0> TestValue = TArray<ETestbed1Enum0>();
 	// use different test value
-	TestValue.Add(ETestbed1Enum0::T1E0_VALUE1);
+	TestValue.Add(ETestbed1Enum0::T1E0_Value1);
 	Spec->TestEqual(TEXT("Delegate parameter should be the same value as set by the setter"), InPropEnum, TestValue);
 	if (TSharedPtr<FTestbed1StructArrayInterfaceOLinkFixture> PinnedImplFixture = ImplFixture.Pin())
 	{
@@ -313,7 +313,7 @@ void UTestbed1StructArrayInterfaceOLinkHelper::PropEnumPropertyChangeLocalCheckR
 {
 	TArray<ETestbed1Enum0> TestValue = TArray<ETestbed1Enum0>();
 	// use different test value
-	TestValue.Add(ETestbed1Enum0::T1E0_VALUE1);
+	TestValue.Add(ETestbed1Enum0::T1E0_Value1);
 	Spec->TestEqual(TEXT("Delegate parameter should be the same value as set by the setter"), InPropEnum, TestValue);
 	if (TSharedPtr<FTestbed1StructArrayInterfaceOLinkFixture> PinnedImplFixture = ImplFixture.Pin())
 	{
@@ -334,7 +334,7 @@ void UTestbed1StructArrayInterfaceOLinkHelper::PropEnumPropertyChangeLocalChange
 	{
 		TArray<ETestbed1Enum0> TestValue = TArray<ETestbed1Enum0>();
 		// use different test value
-		TestValue.Add(ETestbed1Enum0::T1E0_VALUE1);
+		TestValue.Add(ETestbed1Enum0::T1E0_Value1);
 		Spec->TestEqual(TEXT("Delegate parameter should be the same value as set by the setter"), InPropEnum, TestValue);
 		if (TSharedPtr<FTestbed1StructArrayInterfaceOLinkFixture> PinnedImplFixture = ImplFixture.Pin())
 		{
@@ -396,7 +396,7 @@ void UTestbed1StructArrayInterfaceOLinkHelper::SigEnumSignalCb(const TArray<ETes
 {
 	// known test value
 	TArray<ETestbed1Enum0> ParamEnumTestValue = TArray<ETestbed1Enum0>(); // default value
-	ParamEnumTestValue.Add(ETestbed1Enum0::T1E0_VALUE1);
+	ParamEnumTestValue.Add(ETestbed1Enum0::T1E0_Value1);
 	Spec->TestEqual(TEXT("Parameter should be the same value as sent by the signal"), InParamEnum, ParamEnumTestValue);
 	testDoneDelegate.Execute();
 }

--- a/goldenmaster/Plugins/Testbed1/Source/Testbed1/Private/Tests/Testbed1TestsCommon.cpp
+++ b/goldenmaster/Plugins/Testbed1/Source/Testbed1/Private/Tests/Testbed1TestsCommon.cpp
@@ -113,7 +113,7 @@ FTestbed1StructEnum createTestFTestbed1StructEnum()
 {
 	FTestbed1StructEnum TestValue;
 
-	TestValue.fieldEnum = ETestbed1Enum0::T1E0_VALUE1;
+	TestValue.fieldEnum = ETestbed1Enum0::T1E0_Value1;
 
 	return TestValue;
 }
@@ -221,7 +221,7 @@ FTestbed1StructEnumWithArray createTestFTestbed1StructEnumWithArray()
 {
 	FTestbed1StructEnumWithArray TestValue;
 
-	TestValue.fieldEnum.Add(ETestbed1Enum0::T1E0_VALUE1);
+	TestValue.fieldEnum.Add(ETestbed1Enum0::T1E0_Value1);
 
 	return TestValue;
 }

--- a/goldenmaster/Plugins/Testbed1/Source/Testbed1/Public/Generated/api/Testbed1_data.h
+++ b/goldenmaster/Plugins/Testbed1/Source/Testbed1/Public/Generated/api/Testbed1_data.h
@@ -28,9 +28,9 @@ limitations under the License.
 UENUM(BlueprintType)
 enum class ETestbed1Enum0 : uint8
 {
-	T1E0_VALUE0 = 0 UMETA(Displayname = "value0"),
-	T1E0_VALUE1 = 1 UMETA(Displayname = "value1"),
-	T1E0_VALUE2 = 2 UMETA(Displayname = "value2")
+	T1E0_Value0 = 0 UMETA(Displayname = "value0"),
+	T1E0_Value1 = 1 UMETA(Displayname = "value1"),
+	T1E0_Value2 = 2 UMETA(Displayname = "value2")
 };
 
 /**
@@ -227,7 +227,7 @@ struct TESTBED1_API FTestbed1StructEnum : public FTableRowBase
 	GENERATED_BODY()
 
 	UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "ApiGear|Testbed1")
-	ETestbed1Enum0 fieldEnum{ETestbed1Enum0::T1E0_VALUE0};
+	ETestbed1Enum0 fieldEnum{ETestbed1Enum0::T1E0_Value0};
 
 	/**
 	 * FTestbed1StructEnum to JSON formatted FString

--- a/goldenmaster/Plugins/Testbed2/Source/Testbed2/Private/Generated/api/Testbed2_data.cpp
+++ b/goldenmaster/Plugins/Testbed2/Source/Testbed2/Private/Generated/api/Testbed2_data.cpp
@@ -27,23 +27,23 @@ bool UTestbed2Library::toTestbed2Enum1(ETestbed2Enum1& ConvertedEnum, uint8 InVa
 	switch (InValue)
 	{
 	case 1:
-		ConvertedEnum = ETestbed2Enum1::T2E1_VALUE1;
+		ConvertedEnum = ETestbed2Enum1::T2E1_Value1;
 		bSuccessful = true;
 		break;
 	case 2:
-		ConvertedEnum = ETestbed2Enum1::T2E1_VALUE2;
+		ConvertedEnum = ETestbed2Enum1::T2E1_Value2;
 		bSuccessful = true;
 		break;
 	case 3:
-		ConvertedEnum = ETestbed2Enum1::T2E1_VALUE3;
+		ConvertedEnum = ETestbed2Enum1::T2E1_Value3;
 		bSuccessful = true;
 		break;
 	case 4:
-		ConvertedEnum = ETestbed2Enum1::T2E1_VALUE4;
+		ConvertedEnum = ETestbed2Enum1::T2E1_Value4;
 		bSuccessful = true;
 		break;
 	default:
-		ConvertedEnum = ETestbed2Enum1::T2E1_VALUE1;
+		ConvertedEnum = ETestbed2Enum1::T2E1_Value1;
 	}
 	return bSuccessful;
 }
@@ -56,23 +56,23 @@ bool UTestbed2Library::toTestbed2Enum2(ETestbed2Enum2& ConvertedEnum, uint8 InVa
 	switch (InValue)
 	{
 	case 1:
-		ConvertedEnum = ETestbed2Enum2::T2E2_VALUE1;
+		ConvertedEnum = ETestbed2Enum2::T2E2_Value1;
 		bSuccessful = true;
 		break;
 	case 2:
-		ConvertedEnum = ETestbed2Enum2::T2E2_VALUE2;
+		ConvertedEnum = ETestbed2Enum2::T2E2_Value2;
 		bSuccessful = true;
 		break;
 	case 3:
-		ConvertedEnum = ETestbed2Enum2::T2E2_VALUE3;
+		ConvertedEnum = ETestbed2Enum2::T2E2_Value3;
 		bSuccessful = true;
 		break;
 	case 4:
-		ConvertedEnum = ETestbed2Enum2::T2E2_VALUE4;
+		ConvertedEnum = ETestbed2Enum2::T2E2_Value4;
 		bSuccessful = true;
 		break;
 	default:
-		ConvertedEnum = ETestbed2Enum2::T2E2_VALUE1;
+		ConvertedEnum = ETestbed2Enum2::T2E2_Value1;
 	}
 	return bSuccessful;
 }
@@ -85,23 +85,23 @@ bool UTestbed2Library::toTestbed2Enum3(ETestbed2Enum3& ConvertedEnum, uint8 InVa
 	switch (InValue)
 	{
 	case 1:
-		ConvertedEnum = ETestbed2Enum3::T2E3_VALUE1;
+		ConvertedEnum = ETestbed2Enum3::T2E3_Value1;
 		bSuccessful = true;
 		break;
 	case 2:
-		ConvertedEnum = ETestbed2Enum3::T2E3_VALUE2;
+		ConvertedEnum = ETestbed2Enum3::T2E3_Value2;
 		bSuccessful = true;
 		break;
 	case 3:
-		ConvertedEnum = ETestbed2Enum3::T2E3_VALUE3;
+		ConvertedEnum = ETestbed2Enum3::T2E3_Value3;
 		bSuccessful = true;
 		break;
 	case 4:
-		ConvertedEnum = ETestbed2Enum3::T2E3_VALUE4;
+		ConvertedEnum = ETestbed2Enum3::T2E3_Value4;
 		bSuccessful = true;
 		break;
 	default:
-		ConvertedEnum = ETestbed2Enum3::T2E3_VALUE1;
+		ConvertedEnum = ETestbed2Enum3::T2E3_Value1;
 	}
 	return bSuccessful;
 }

--- a/goldenmaster/Plugins/Testbed2/Source/Testbed2/Public/Generated/api/Testbed2_data.h
+++ b/goldenmaster/Plugins/Testbed2/Source/Testbed2/Public/Generated/api/Testbed2_data.h
@@ -28,11 +28,11 @@ limitations under the License.
 UENUM(BlueprintType)
 enum class ETestbed2Enum1 : uint8
 {
-	T2E1_VALUE1 = 1 UMETA(Displayname = "value1"),
-	T2E1_VALUE2 = 2 UMETA(Displayname = "value2"),
-	T2E1_VALUE3 = 3 UMETA(Displayname = "value3"),
-	T2E1_VALUE4 = 4 UMETA(Displayname = "value4"),
-	UNSPECIFIED = 0 UMETA(Hidden)
+	T2E1_Value1 = 1 UMETA(Displayname = "value1"),
+	T2E1_Value2 = 2 UMETA(Displayname = "value2"),
+	T2E1_Value3 = 3 UMETA(Displayname = "value3"),
+	T2E1_Value4 = 4 UMETA(Displayname = "value4"),
+	Unspecified = 0 UMETA(Hidden)
 };
 
 /**
@@ -41,11 +41,11 @@ enum class ETestbed2Enum1 : uint8
 UENUM(BlueprintType)
 enum class ETestbed2Enum2 : uint8
 {
-	T2E2_VALUE1 = 1 UMETA(Displayname = "value1"),
-	T2E2_VALUE2 = 2 UMETA(Displayname = "value2"),
-	T2E2_VALUE3 = 3 UMETA(Displayname = "value3"),
-	T2E2_VALUE4 = 4 UMETA(Displayname = "value4"),
-	UNSPECIFIED = 0 UMETA(Hidden)
+	T2E2_Value1 = 1 UMETA(Displayname = "value1"),
+	T2E2_Value2 = 2 UMETA(Displayname = "value2"),
+	T2E2_Value3 = 3 UMETA(Displayname = "value3"),
+	T2E2_Value4 = 4 UMETA(Displayname = "value4"),
+	Unspecified = 0 UMETA(Hidden)
 };
 
 /**
@@ -54,11 +54,11 @@ enum class ETestbed2Enum2 : uint8
 UENUM(BlueprintType)
 enum class ETestbed2Enum3 : uint8
 {
-	T2E3_VALUE1 = 1 UMETA(Displayname = "value1"),
-	T2E3_VALUE2 = 2 UMETA(Displayname = "value2"),
-	T2E3_VALUE3 = 3 UMETA(Displayname = "value3"),
-	T2E3_VALUE4 = 4 UMETA(Displayname = "value4"),
-	UNSPECIFIED = 0 UMETA(Hidden)
+	T2E3_Value1 = 1 UMETA(Displayname = "value1"),
+	T2E3_Value2 = 2 UMETA(Displayname = "value2"),
+	T2E3_Value3 = 3 UMETA(Displayname = "value3"),
+	T2E3_Value4 = 4 UMETA(Displayname = "value4"),
+	Unspecified = 0 UMETA(Hidden)
 };
 
 /**

--- a/rules.yaml
+++ b/rules.yaml
@@ -1,5 +1,5 @@
 engines:
-  cli: ">= v0.38.3"
+  cli: ">= v0.46.0"
 features:
   - name: api
     scopes:

--- a/templates/module/Source/module/Private/Generated/api/data.cpp.tpl
+++ b/templates/module/Source/module/Private/Generated/api/data.cpp.tpl
@@ -36,12 +36,12 @@ bool U{{ $ModuleName }}Library::to{{$moduleEnumName}}({{$class}}& ConvertedEnum,
 	{
 {{- range .Members }}
 	case {{.Value}}:
-		ConvertedEnum = {{$class}}::{{ abbreviate $moduleEnumName }}_{{CAMEL .Name}};
+		ConvertedEnum = {{$class}}::{{ abbreviate $moduleEnumName }}_{{Camel .Name}};
 		bSuccessful = true;
 		break;
 {{- end }}
 	default:
-		ConvertedEnum = {{$class}}::{{ abbreviate $moduleEnumName }}_{{CAMEL .Default.Name}};
+		ConvertedEnum = {{$class}}::{{ abbreviate $moduleEnumName }}_{{Camel .Default.Name}};
 	}
 	return bSuccessful;
 }

--- a/templates/module/Source/module/Public/Generated/api/data.h.tpl
+++ b/templates/module/Source/module/Public/Generated/api/data.h.tpl
@@ -54,9 +54,9 @@ enum class {{$class}} : uint8
 {{- $hasZeroDefaultVal := false}}
 {{- range $idx, $elem := .Members }}
 	{{- if $idx}},{{end}}
-	{{ abbreviate $moduleEnumName }}_{{ CAMEL .Name }} = {{.Value}} UMETA(Displayname = "{{.Name}}"){{if eq .Value 0}}{{$hasZeroDefaultVal = true}}{{end}}
+	{{ abbreviate $moduleEnumName }}_{{ Camel .Name }} = {{.Value}} UMETA(Displayname = "{{.Name}}"){{if eq .Value 0}}{{$hasZeroDefaultVal = true}}{{end}}
 {{- end }}
-{{- if not $hasZeroDefaultVal}},{{nl}}	UNSPECIFIED = 0 UMETA(Hidden){{end}}
+{{- if not $hasZeroDefaultVal}},{{nl}}	Unspecified = 0 UMETA(Hidden){{end}}
 };
 {{ end }}
 {{- range .Module.Structs }}


### PR DESCRIPTION
## 📑 Description
- change the enum naming style to be pascalcase instead of all uppercase

## ✅ Checks
<!-- Make sure your pr passes the CI checks and do check the following fields as needed - -->
- [x] My pull request adheres to the code style of this project
- [ ] My code requires changes to the documentation
- [ ] I have updated the documentation as required
- [x] All the tests have passed

## ℹ Additional Information
<!-- Any additional information like breaking changes, dependencies added, screenshots, comparisons between new and old behavior, etc. -->