### PR TITLE
fix(olink): make sure test works with UE5.6

### DIFF
--- a/goldenmaster/Plugins/ApiGear/Source/ApiGearOLink/Private/Tests/OLinkHostConnection.spec.cpp
+++ b/goldenmaster/Plugins/ApiGear/Source/ApiGearOLink/Private/Tests/OLinkHostConnection.spec.cpp
@@ -107,12 +107,12 @@ BEGIN_DEFINE_SPEC(UOLinkHostConnectionSpec, "ApiGear.OLink.HostConnection", ApiG
 
 TUniquePtr<FOLinkHostConnectionFixture> Fixture;
 
+END_DEFINE_SPEC(UOLinkHostConnectionSpec);
+
 ApiGear::ObjectLink::WriteLogFunc logFunc = [](ApiGear::ObjectLink::LogLevel level, const std::string& msg)
 {
 	UE_LOG(LogTemp, Log, TEXT("%s"), UTF8_TO_TCHAR(msg.c_str()));
 };
-
-END_DEFINE_SPEC(UOLinkHostConnectionSpec);
 
 void UOLinkHostConnectionSpec::Define()
 {
@@ -124,7 +124,7 @@ void UOLinkHostConnectionSpec::Define()
 		TestFalse(TEXT("The host connection should yet be valid"), Fixture->HostConnection.IsValid());
 
 		Fixture->Socket = new MockNetworkingWebSocket();
-		Fixture->HostConnection = MakeShared<FOLinkHostConnection>(Fixture->Socket, Fixture->GetRegistry(), UOLinkHostConnectionSpec::logFunc);
+		Fixture->HostConnection = MakeShared<FOLinkHostConnection>(Fixture->Socket, Fixture->GetRegistry(), logFunc);
 		Fixture->Node = std::make_shared<MockNode>(Fixture->GetRegistry());
 		Fixture->HostConnection->Node.reset();
 		Fixture->HostConnection->Node = Fixture->Node;

--- a/templates/ApiGear/Source/ApiGearOLink/Private/Tests/OLinkHostConnection.spec.cpp
+++ b/templates/ApiGear/Source/ApiGearOLink/Private/Tests/OLinkHostConnection.spec.cpp
@@ -107,12 +107,12 @@ BEGIN_DEFINE_SPEC(UOLinkHostConnectionSpec, "ApiGear.OLink.HostConnection", ApiG
 
 TUniquePtr<FOLinkHostConnectionFixture> Fixture;
 
+END_DEFINE_SPEC(UOLinkHostConnectionSpec);
+
 ApiGear::ObjectLink::WriteLogFunc logFunc = [](ApiGear::ObjectLink::LogLevel level, const std::string& msg)
 {
 	UE_LOG(LogTemp, Log, TEXT("%s"), UTF8_TO_TCHAR(msg.c_str()));
 };
-
-END_DEFINE_SPEC(UOLinkHostConnectionSpec);
 
 void UOLinkHostConnectionSpec::Define()
 {
@@ -124,7 +124,7 @@ void UOLinkHostConnectionSpec::Define()
 		TestFalse(TEXT("The host connection should yet be valid"), Fixture->HostConnection.IsValid());
 
 		Fixture->Socket = new MockNetworkingWebSocket();
-		Fixture->HostConnection = MakeShared<FOLinkHostConnection>(Fixture->Socket, Fixture->GetRegistry(), UOLinkHostConnectionSpec::logFunc);
+		Fixture->HostConnection = MakeShared<FOLinkHostConnection>(Fixture->Socket, Fixture->GetRegistry(), logFunc);
 		Fixture->Node = std::make_shared<MockNode>(Fixture->GetRegistry());
 		Fixture->HostConnection->Node.reset();
 		Fixture->HostConnection->Node = Fixture->Node;


### PR DESCRIPTION
## 📑 Description
The UE5.6 build was broken due to a issue with logging in the olink apigear tests.

## ✅ Checks
<!-- Make sure your pr passes the CI checks and do check the following fields as needed - -->
- [ ] My pull request adheres to the code style of this project
- [ ] My code requires changes to the documentation
- [ ] I have updated the documentation as required
- [ ] All the tests have passed

## ℹ Additional Information
<!-- Any additional information like breaking changes, dependencies added, screenshots, comparisons between new and old behavior, etc. -->