### PR TITLE
fix(olink): use unique logFunc name

### DIFF
--- a/goldenmaster/Plugins/ApiGear/Source/ApiGearOLink/Private/Tests/OLinkHostConnection.spec.cpp
+++ b/goldenmaster/Plugins/ApiGear/Source/ApiGearOLink/Private/Tests/OLinkHostConnection.spec.cpp
@@ -109,7 +109,7 @@ TUniquePtr<FOLinkHostConnectionFixture> Fixture;
 
 END_DEFINE_SPEC(UOLinkHostConnectionSpec);
 
-ApiGear::ObjectLink::WriteLogFunc logFunc = [](ApiGear::ObjectLink::LogLevel level, const std::string& msg)
+ApiGear::ObjectLink::WriteLogFunc olinkSpecLogFunc = [](ApiGear::ObjectLink::LogLevel level, const std::string& msg)
 {
 	UE_LOG(LogTemp, Log, TEXT("%s"), UTF8_TO_TCHAR(msg.c_str()));
 };
@@ -124,7 +124,7 @@ void UOLinkHostConnectionSpec::Define()
 		TestFalse(TEXT("The host connection should yet be valid"), Fixture->HostConnection.IsValid());
 
 		Fixture->Socket = new MockNetworkingWebSocket();
-		Fixture->HostConnection = MakeShared<FOLinkHostConnection>(Fixture->Socket, Fixture->GetRegistry(), logFunc);
+		Fixture->HostConnection = MakeShared<FOLinkHostConnection>(Fixture->Socket, Fixture->GetRegistry(), olinkSpecLogFunc);
 		Fixture->Node = std::make_shared<MockNode>(Fixture->GetRegistry());
 		Fixture->HostConnection->Node.reset();
 		Fixture->HostConnection->Node = Fixture->Node;

--- a/templates/ApiGear/Source/ApiGearOLink/Private/Tests/OLinkHostConnection.spec.cpp
+++ b/templates/ApiGear/Source/ApiGearOLink/Private/Tests/OLinkHostConnection.spec.cpp
@@ -109,7 +109,7 @@ TUniquePtr<FOLinkHostConnectionFixture> Fixture;
 
 END_DEFINE_SPEC(UOLinkHostConnectionSpec);
 
-ApiGear::ObjectLink::WriteLogFunc logFunc = [](ApiGear::ObjectLink::LogLevel level, const std::string& msg)
+ApiGear::ObjectLink::WriteLogFunc olinkSpecLogFunc = [](ApiGear::ObjectLink::LogLevel level, const std::string& msg)
 {
 	UE_LOG(LogTemp, Log, TEXT("%s"), UTF8_TO_TCHAR(msg.c_str()));
 };
@@ -124,7 +124,7 @@ void UOLinkHostConnectionSpec::Define()
 		TestFalse(TEXT("The host connection should yet be valid"), Fixture->HostConnection.IsValid());
 
 		Fixture->Socket = new MockNetworkingWebSocket();
-		Fixture->HostConnection = MakeShared<FOLinkHostConnection>(Fixture->Socket, Fixture->GetRegistry(), logFunc);
+		Fixture->HostConnection = MakeShared<FOLinkHostConnection>(Fixture->Socket, Fixture->GetRegistry(), olinkSpecLogFunc);
 		Fixture->Node = std::make_shared<MockNode>(Fixture->GetRegistry());
 		Fixture->HostConnection->Node.reset();
 		Fixture->HostConnection->Node = Fixture->Node;


### PR DESCRIPTION
## 📑 Description
In unity build mode non-unique function names potentially cause build issues. This uses a unique name for the test file.

<!-- You can also choose to add a list of changes and if they have been completed or not by using the markdown to-do list syntax
- [ ] Not Completed
- [x] Completed
-->

## ✅ Checks
<!-- Make sure your pr passes the CI checks and do check the following fields as needed - -->
- [ ] My pull request adheres to the code style of this project
- [ ] My code requires changes to the documentation
- [ ] I have updated the documentation as required
- [ ] All the tests have passed

## ℹ Additional Information
<!-- Any additional information like breaking changes, dependencies added, screenshots, comparisons between new and old behavior, etc. -->