### PR TITLE
fix: UE 5.8 build compatibility

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,10 +26,10 @@ We aim for full feature parity between usage from within Blueprints or UE C++.
 ### Compatibility
 
 The generated plugin code is regularly tested in these configurations:
-| platform | UE4.25 | UE4.27 | UE5.5 | UE5.6 | UE5.7 |
-|----------| :---: | :---: | :---: |  :---: |  :---: |
-| Windows  |:heavy_check_mark: (until v2.x)|:heavy_check_mark:| :heavy_check_mark:| :heavy_check_mark:| :heavy_check_mark:|
-| Linux    |:heavy_check_mark: (until v2.x)|:heavy_check_mark:| :heavy_check_mark:| :heavy_check_mark:| :heavy_check_mark:|
+| platform | UE4.25 | UE4.27 | UE5.5 | UE5.6 | UE5.7 | UE5.8 |
+|----------| :---: | :---: | :---: |  :---: |  :---: |  :---: |
+| Windows  |:heavy_check_mark: (until v2.x)|:heavy_check_mark:| :heavy_check_mark:| :heavy_check_mark:| :heavy_check_mark:| :heavy_check_mark:|
+| Linux    |:heavy_check_mark: (until v2.x)|:heavy_check_mark:| :heavy_check_mark:| :heavy_check_mark:| :heavy_check_mark:| :heavy_check_mark:|
 ## Code Generation Features
 
 The template offers the following feature switches which can be enabled during code generation:

--- a/goldenmaster/Plugins/Counter/Source/CounterCore/Private/CounterSettings.cpp
+++ b/goldenmaster/Plugins/Counter/Source/CounterCore/Private/CounterSettings.cpp
@@ -12,7 +12,11 @@
 UCounterSettings::UCounterSettings(const FObjectInitializer& ObjectInitializer)
 	: Super(ObjectInitializer)
 {
+#if ENGINE_MAJOR_VERSION >= 5 && ENGINE_MINOR_VERSION >= 8
+	FCoreDelegates::GetOnPostEngineInit().AddUObject(this, &UCounterSettings::ValidateSettingsPostEngineInit);
+#else
 	FCoreDelegates::OnPostEngineInit.AddUObject(this, &UCounterSettings::ValidateSettingsPostEngineInit);
+#endif
 }
 
 void UCounterSettings::ValidateSettingsPostEngineInit()

--- a/goldenmaster/Plugins/CustomTypes/Source/CustomTypesCore/Private/CustomTypesSettings.cpp
+++ b/goldenmaster/Plugins/CustomTypes/Source/CustomTypesCore/Private/CustomTypesSettings.cpp
@@ -12,7 +12,11 @@
 UCustomTypesSettings::UCustomTypesSettings(const FObjectInitializer& ObjectInitializer)
 	: Super(ObjectInitializer)
 {
+#if ENGINE_MAJOR_VERSION >= 5 && ENGINE_MINOR_VERSION >= 8
+	FCoreDelegates::GetOnPostEngineInit().AddUObject(this, &UCustomTypesSettings::ValidateSettingsPostEngineInit);
+#else
 	FCoreDelegates::OnPostEngineInit.AddUObject(this, &UCustomTypesSettings::ValidateSettingsPostEngineInit);
+#endif
 }
 
 void UCustomTypesSettings::ValidateSettingsPostEngineInit()

--- a/goldenmaster/Plugins/ExternTypes/Source/ExternTypesCore/Private/ExternTypesSettings.cpp
+++ b/goldenmaster/Plugins/ExternTypes/Source/ExternTypesCore/Private/ExternTypesSettings.cpp
@@ -12,7 +12,11 @@
 UExternTypesSettings::UExternTypesSettings(const FObjectInitializer& ObjectInitializer)
 	: Super(ObjectInitializer)
 {
+#if ENGINE_MAJOR_VERSION >= 5 && ENGINE_MINOR_VERSION >= 8
+	FCoreDelegates::GetOnPostEngineInit().AddUObject(this, &UExternTypesSettings::ValidateSettingsPostEngineInit);
+#else
 	FCoreDelegates::OnPostEngineInit.AddUObject(this, &UExternTypesSettings::ValidateSettingsPostEngineInit);
+#endif
 }
 
 void UExternTypesSettings::ValidateSettingsPostEngineInit()

--- a/goldenmaster/Plugins/TbEnum/Source/TbEnumCore/Private/TbEnumSettings.cpp
+++ b/goldenmaster/Plugins/TbEnum/Source/TbEnumCore/Private/TbEnumSettings.cpp
@@ -12,7 +12,11 @@
 UTbEnumSettings::UTbEnumSettings(const FObjectInitializer& ObjectInitializer)
 	: Super(ObjectInitializer)
 {
+#if ENGINE_MAJOR_VERSION >= 5 && ENGINE_MINOR_VERSION >= 8
+	FCoreDelegates::GetOnPostEngineInit().AddUObject(this, &UTbEnumSettings::ValidateSettingsPostEngineInit);
+#else
 	FCoreDelegates::OnPostEngineInit.AddUObject(this, &UTbEnumSettings::ValidateSettingsPostEngineInit);
+#endif
 }
 
 void UTbEnumSettings::ValidateSettingsPostEngineInit()

--- a/goldenmaster/Plugins/TbIfaceimport/Source/TbIfaceimportCore/Private/TbIfaceimportSettings.cpp
+++ b/goldenmaster/Plugins/TbIfaceimport/Source/TbIfaceimportCore/Private/TbIfaceimportSettings.cpp
@@ -12,7 +12,11 @@
 UTbIfaceimportSettings::UTbIfaceimportSettings(const FObjectInitializer& ObjectInitializer)
 	: Super(ObjectInitializer)
 {
+#if ENGINE_MAJOR_VERSION >= 5 && ENGINE_MINOR_VERSION >= 8
+	FCoreDelegates::GetOnPostEngineInit().AddUObject(this, &UTbIfaceimportSettings::ValidateSettingsPostEngineInit);
+#else
 	FCoreDelegates::OnPostEngineInit.AddUObject(this, &UTbIfaceimportSettings::ValidateSettingsPostEngineInit);
+#endif
 }
 
 void UTbIfaceimportSettings::ValidateSettingsPostEngineInit()

--- a/goldenmaster/Plugins/TbNames/Source/TbNamesCore/Private/TbNamesSettings.cpp
+++ b/goldenmaster/Plugins/TbNames/Source/TbNamesCore/Private/TbNamesSettings.cpp
@@ -12,7 +12,11 @@
 UTbNamesSettings::UTbNamesSettings(const FObjectInitializer& ObjectInitializer)
 	: Super(ObjectInitializer)
 {
+#if ENGINE_MAJOR_VERSION >= 5 && ENGINE_MINOR_VERSION >= 8
+	FCoreDelegates::GetOnPostEngineInit().AddUObject(this, &UTbNamesSettings::ValidateSettingsPostEngineInit);
+#else
 	FCoreDelegates::OnPostEngineInit.AddUObject(this, &UTbNamesSettings::ValidateSettingsPostEngineInit);
+#endif
 }
 
 void UTbNamesSettings::ValidateSettingsPostEngineInit()

--- a/goldenmaster/Plugins/TbRefIfaces/Source/TbRefIfacesCore/Private/TbRefIfacesSettings.cpp
+++ b/goldenmaster/Plugins/TbRefIfaces/Source/TbRefIfacesCore/Private/TbRefIfacesSettings.cpp
@@ -12,7 +12,11 @@
 UTbRefIfacesSettings::UTbRefIfacesSettings(const FObjectInitializer& ObjectInitializer)
 	: Super(ObjectInitializer)
 {
+#if ENGINE_MAJOR_VERSION >= 5 && ENGINE_MINOR_VERSION >= 8
+	FCoreDelegates::GetOnPostEngineInit().AddUObject(this, &UTbRefIfacesSettings::ValidateSettingsPostEngineInit);
+#else
 	FCoreDelegates::OnPostEngineInit.AddUObject(this, &UTbRefIfacesSettings::ValidateSettingsPostEngineInit);
+#endif
 }
 
 void UTbRefIfacesSettings::ValidateSettingsPostEngineInit()

--- a/goldenmaster/Plugins/TbSame1/Source/TbSame1Core/Private/TbSame1Settings.cpp
+++ b/goldenmaster/Plugins/TbSame1/Source/TbSame1Core/Private/TbSame1Settings.cpp
@@ -12,7 +12,11 @@
 UTbSame1Settings::UTbSame1Settings(const FObjectInitializer& ObjectInitializer)
 	: Super(ObjectInitializer)
 {
+#if ENGINE_MAJOR_VERSION >= 5 && ENGINE_MINOR_VERSION >= 8
+	FCoreDelegates::GetOnPostEngineInit().AddUObject(this, &UTbSame1Settings::ValidateSettingsPostEngineInit);
+#else
 	FCoreDelegates::OnPostEngineInit.AddUObject(this, &UTbSame1Settings::ValidateSettingsPostEngineInit);
+#endif
 }
 
 void UTbSame1Settings::ValidateSettingsPostEngineInit()

--- a/goldenmaster/Plugins/TbSame2/Source/TbSame2Core/Private/TbSame2Settings.cpp
+++ b/goldenmaster/Plugins/TbSame2/Source/TbSame2Core/Private/TbSame2Settings.cpp
@@ -12,7 +12,11 @@
 UTbSame2Settings::UTbSame2Settings(const FObjectInitializer& ObjectInitializer)
 	: Super(ObjectInitializer)
 {
+#if ENGINE_MAJOR_VERSION >= 5 && ENGINE_MINOR_VERSION >= 8
+	FCoreDelegates::GetOnPostEngineInit().AddUObject(this, &UTbSame2Settings::ValidateSettingsPostEngineInit);
+#else
 	FCoreDelegates::OnPostEngineInit.AddUObject(this, &UTbSame2Settings::ValidateSettingsPostEngineInit);
+#endif
 }
 
 void UTbSame2Settings::ValidateSettingsPostEngineInit()

--- a/goldenmaster/Plugins/TbSimple/Source/TbSimpleCore/Private/TbSimpleSettings.cpp
+++ b/goldenmaster/Plugins/TbSimple/Source/TbSimpleCore/Private/TbSimpleSettings.cpp
@@ -12,7 +12,11 @@
 UTbSimpleSettings::UTbSimpleSettings(const FObjectInitializer& ObjectInitializer)
 	: Super(ObjectInitializer)
 {
+#if ENGINE_MAJOR_VERSION >= 5 && ENGINE_MINOR_VERSION >= 8
+	FCoreDelegates::GetOnPostEngineInit().AddUObject(this, &UTbSimpleSettings::ValidateSettingsPostEngineInit);
+#else
 	FCoreDelegates::OnPostEngineInit.AddUObject(this, &UTbSimpleSettings::ValidateSettingsPostEngineInit);
+#endif
 }
 
 void UTbSimpleSettings::ValidateSettingsPostEngineInit()

--- a/goldenmaster/Plugins/TbStructArray/Source/TbStructArrayCore/Private/TbStructArraySettings.cpp
+++ b/goldenmaster/Plugins/TbStructArray/Source/TbStructArrayCore/Private/TbStructArraySettings.cpp
@@ -12,7 +12,11 @@
 UTbStructArraySettings::UTbStructArraySettings(const FObjectInitializer& ObjectInitializer)
 	: Super(ObjectInitializer)
 {
+#if ENGINE_MAJOR_VERSION >= 5 && ENGINE_MINOR_VERSION >= 8
+	FCoreDelegates::GetOnPostEngineInit().AddUObject(this, &UTbStructArraySettings::ValidateSettingsPostEngineInit);
+#else
 	FCoreDelegates::OnPostEngineInit.AddUObject(this, &UTbStructArraySettings::ValidateSettingsPostEngineInit);
+#endif
 }
 
 void UTbStructArraySettings::ValidateSettingsPostEngineInit()

--- a/goldenmaster/Plugins/Testbed1/Source/Testbed1Core/Private/Testbed1Settings.cpp
+++ b/goldenmaster/Plugins/Testbed1/Source/Testbed1Core/Private/Testbed1Settings.cpp
@@ -12,7 +12,11 @@
 UTestbed1Settings::UTestbed1Settings(const FObjectInitializer& ObjectInitializer)
 	: Super(ObjectInitializer)
 {
+#if ENGINE_MAJOR_VERSION >= 5 && ENGINE_MINOR_VERSION >= 8
+	FCoreDelegates::GetOnPostEngineInit().AddUObject(this, &UTestbed1Settings::ValidateSettingsPostEngineInit);
+#else
 	FCoreDelegates::OnPostEngineInit.AddUObject(this, &UTestbed1Settings::ValidateSettingsPostEngineInit);
+#endif
 }
 
 void UTestbed1Settings::ValidateSettingsPostEngineInit()

--- a/goldenmaster/Plugins/Testbed2/Source/Testbed2Core/Private/Testbed2Settings.cpp
+++ b/goldenmaster/Plugins/Testbed2/Source/Testbed2Core/Private/Testbed2Settings.cpp
@@ -12,7 +12,11 @@
 UTestbed2Settings::UTestbed2Settings(const FObjectInitializer& ObjectInitializer)
 	: Super(ObjectInitializer)
 {
+#if ENGINE_MAJOR_VERSION >= 5 && ENGINE_MINOR_VERSION >= 8
+	FCoreDelegates::GetOnPostEngineInit().AddUObject(this, &UTestbed2Settings::ValidateSettingsPostEngineInit);
+#else
 	FCoreDelegates::OnPostEngineInit.AddUObject(this, &UTestbed2Settings::ValidateSettingsPostEngineInit);
+#endif
 }
 
 void UTestbed2Settings::ValidateSettingsPostEngineInit()

--- a/goldenmaster/Plugins/buildTestPlugins.bat
+++ b/goldenmaster/Plugins/buildTestPlugins.bat
@@ -44,6 +44,10 @@ echo Copy blank project from %UEtemplate_path% to %ProjectTarget_path%\
 xcopy /E /Y "%UEtemplate_path%" "%ProjectTarget_path%\" >nul
 if %ERRORLEVEL% GEQ 1 exit /b %ERRORLEVEL%
 
+@REM strip game module from uproject (not needed for plugin testing,
+@REM avoids module-not-found errors on non-installed engine builds)
+>"%ProjectTarget_path%\TP_Blank.uproject" echo {"FileVersion": 3, "EngineAssociation": ""}
+
 @REM create Plugins folder
 mkdir %ProjectTarget_path%\Plugins
 if %ERRORLEVEL% GEQ 1 exit /b %ERRORLEVEL%
@@ -192,7 +196,7 @@ exit /b 0
 @REM build UE plugin
 :buildTestPlugins
 (
-	"%RunUAT_path%" BuildCookRun -unattended -installed -project="%1" -run -RunAutomationTest="%3" -nullrhi -NoP4 -build -verbose -nodebuginfo -log="%2/RunTests.log" -addcmdline="-ReportExportPath=%2 " -Configuration=Test -notools -utf8output -WarningsAsErrors
+	"%RunUAT_path%" BuildCookRun -unattended -installed -project="%1" -run -editortest -RunAutomationTest="%3" -nullrhi -NoP4 -build -verbose -nodebuginfo -log="%2/RunTests.log" -addcmdline="-ReportExportPath=%2 " -notools -utf8output -WarningsAsErrors
 	set buildresult=!ERRORLEVEL!
 )
 exit /b %ERRORLEVEL%

--- a/goldenmaster/Plugins/buildTestPlugins.sh
+++ b/goldenmaster/Plugins/buildTestPlugins.sh
@@ -39,6 +39,11 @@ if [ $? -ne 0 ]; then exit 1; fi;
 echo Copy blank project from $UEtemplate_path to $script_path
 cp -rf "$UEtemplate_path" "$script_path/build" 1>&-
 if [ $? -ne 0 ]; then exit 1; fi;
+
+# strip game module from uproject (not needed for plugin testing,
+# avoids module-not-found errors on non-installed engine builds)
+echo '{"FileVersion": 3, "EngineAssociation": ""}' > "$ProjectTarget_path/TP_Blank.uproject"
+
 #
 # function implementations
 #
@@ -46,7 +51,7 @@ if [ $? -ne 0 ]; then exit 1; fi;
 # build and test plugins
 buildTestPlugins()
 {
-	"$RunUAT_path" BuildCookRun -unattended -installed -project="$1" -run -RunAutomationTest="$3" -nullrhi -NoP4 -build -verbose -nodebuginfo -log="$2/RunTests.log" -addcmdline="-ReportExportPath=$2 " -Configuration=Test -notools -utf8output -WarningsAsErrors
+	"$RunUAT_path" BuildCookRun -unattended -installed -project="$1" -run -editortest -RunAutomationTest="$3" -nullrhi -NoP4 -build -verbose -nodebuginfo -log="$2/RunTests.log" -addcmdline="-ReportExportPath=$2 " -notools -utf8output -WarningsAsErrors
 	buildresult=$?
 }
 

--- a/rules.yaml
+++ b/rules.yaml
@@ -1,5 +1,5 @@
 engines:
-  cli: ">= v0.47.0"
+  cli: ">= v0.50.2"
 features:
   - name: api
     scopes:

--- a/templates/buildTestPlugins.bat.tpl
+++ b/templates/buildTestPlugins.bat.tpl
@@ -50,6 +50,10 @@ echo Copy blank project from %UEtemplate_path% to %ProjectTarget_path%\
 xcopy /E /Y "%UEtemplate_path%" "%ProjectTarget_path%\" >nul
 if %ERRORLEVEL% GEQ 1 exit /b %ERRORLEVEL%
 
+@REM strip game module from uproject (not needed for plugin testing,
+@REM avoids module-not-found errors on non-installed engine builds)
+>"%ProjectTarget_path%\TP_Blank.uproject" echo {"FileVersion": 3, "EngineAssociation": ""}
+
 @REM create Plugins folder
 mkdir %ProjectTarget_path%\Plugins
 if %ERRORLEVEL% GEQ 1 exit /b %ERRORLEVEL%
@@ -92,7 +96,7 @@ exit /b 0
 @REM build UE plugin
 :buildTestPlugins
 (
-	"%RunUAT_path%" BuildCookRun -unattended -installed -project="%1" -run -RunAutomationTest="%3" -nullrhi -NoP4 -build -verbose -nodebuginfo -log="%2/RunTests.log" -addcmdline="-ReportExportPath=%2 " -Configuration=Test -notools -utf8output -WarningsAsErrors
+	"%RunUAT_path%" BuildCookRun -unattended -installed -project="%1" -run -editortest -RunAutomationTest="%3" -nullrhi -NoP4 -build -verbose -nodebuginfo -log="%2/RunTests.log" -addcmdline="-ReportExportPath=%2 " -notools -utf8output -WarningsAsErrors
 	set buildresult=!ERRORLEVEL!
 )
 exit /b %ERRORLEVEL%

--- a/templates/buildTestPlugins.sh.tpl
+++ b/templates/buildTestPlugins.sh.tpl
@@ -47,6 +47,11 @@ if [ $? -ne 0 ]; then exit 1; fi;
 echo Copy blank project from $UEtemplate_path to $script_path
 cp -rf "$UEtemplate_path" "$script_path/build" 1>&-
 if [ $? -ne 0 ]; then exit 1; fi;
+
+# strip game module from uproject (not needed for plugin testing,
+# avoids module-not-found errors on non-installed engine builds)
+echo '{"FileVersion": 3, "EngineAssociation": ""}' > "$ProjectTarget_path/TP_Blank.uproject"
+
 #
 # function implementations
 #
@@ -54,7 +59,7 @@ if [ $? -ne 0 ]; then exit 1; fi;
 # build and test plugins
 buildTestPlugins()
 {
-	"$RunUAT_path" BuildCookRun -unattended -installed -project="$1" -run -RunAutomationTest="$3" -nullrhi -NoP4 -build -verbose -nodebuginfo -log="$2/RunTests.log" -addcmdline="-ReportExportPath=$2 " -Configuration=Test -notools -utf8output -WarningsAsErrors
+	"$RunUAT_path" BuildCookRun -unattended -installed -project="$1" -run -editortest -RunAutomationTest="$3" -nullrhi -NoP4 -build -verbose -nodebuginfo -log="$2/RunTests.log" -addcmdline="-ReportExportPath=$2 " -notools -utf8output -WarningsAsErrors
 	buildresult=$?
 }
 

--- a/templates/module/Source/modulecore/Private/pluginnamesettings.cpp.tpl
+++ b/templates/module/Source/modulecore/Private/pluginnamesettings.cpp.tpl
@@ -19,7 +19,11 @@
 U{{$ModuleName}}Settings::U{{$ModuleName}}Settings(const FObjectInitializer& ObjectInitializer)
 	: Super(ObjectInitializer)
 {
+#if ENGINE_MAJOR_VERSION >= 5 && ENGINE_MINOR_VERSION >= 8
+	FCoreDelegates::GetOnPostEngineInit().AddUObject(this, &U{{$ModuleName}}Settings::ValidateSettingsPostEngineInit);
+#else
 	FCoreDelegates::OnPostEngineInit.AddUObject(this, &U{{$ModuleName}}Settings::ValidateSettingsPostEngineInit);
+#endif
 }
 
 void U{{$ModuleName}}Settings::ValidateSettingsPostEngineInit()


### PR DESCRIPTION
 ## Summary 
- Use `-editortest` for automation tests to avoid game client module discovery issues on non-installed engine builds
- Strip TP_Blank game module from test project (not needed for plugin testing)
- Guard deprecated `FCoreDelegates::OnPostEngineInit` with version check for UE 5.8+ while keeping 4.27-5.7 compat
- Add UE 5.8 to compatibility matrix

## Test plan
- [x] Run `buildTestPlugins.bat` on UE 5.8 — 1893 tests pass
- [x] Run `buildPlugins.bat` on UE 5.8 — zero compiler warnings
- [x] Verify builds still work on UE 5.7 / 4.27