### PR TITLE
fix(build): parse failure count instead of findstr match

### DIFF
--- a/goldenmaster/Plugins/buildTestPlugins.bat
+++ b/goldenmaster/Plugins/buildTestPlugins.bat
@@ -182,8 +182,14 @@ call :buildTestPlugins "%ProjectTarget_path%/TP_Blank.uproject" %script_path% ".
 @REM check test results JSON as source of truth (UAT may return non-zero from
 @REM shutdown ensures unrelated to test outcomes, e.g. UE 5.7 access detector)
 if not exist %script_path%index.json (echo WARNING: no test results found & exit /b 1)
-findstr /C:"\"failed\": 0" %script_path%index.json >nul
-if %ERRORLEVEL% GEQ 1 exit /b %ERRORLEVEL%
+set "failcount="
+for /f "tokens=2 delims=:" %%a in ('findstr /R "failed" "%script_path%index.json"') do set "failcount=%%a"
+set "failcount=!failcount: =!"
+set "failcount=!failcount:,=!"
+if !failcount! GTR 0 (
+	echo ERROR: !failcount! test^(s^) failed
+	exit /b 1
+)
 
 @REM compile-only monolithic (Shipping) build to catch export/link issues
 echo Running monolithic (Shipping) compile check...

--- a/templates/buildTestPlugins.bat.tpl
+++ b/templates/buildTestPlugins.bat.tpl
@@ -82,8 +82,14 @@ call :buildTestPlugins "%ProjectTarget_path%/TP_Blank.uproject" %script_path% ".
 @REM check test results JSON as source of truth (UAT may return non-zero from
 @REM shutdown ensures unrelated to test outcomes, e.g. UE 5.7 access detector)
 if not exist %script_path%index.json (echo WARNING: no test results found & exit /b 1)
-findstr /C:"\"failed\": 0" %script_path%index.json >nul
-if %ERRORLEVEL% GEQ 1 exit /b %ERRORLEVEL%
+set "failcount="
+for /f "tokens=2 delims=:" %%a in ('findstr /R "failed" "%script_path%index.json"') do set "failcount=%%a"
+set "failcount=!failcount: =!"
+set "failcount=!failcount:,=!"
+if !failcount! GTR 0 (
+	echo ERROR: !failcount! test^(s^) failed
+	exit /b 1
+)
 
 @REM compile-only monolithic (Shipping) build to catch export/link issues
 echo Running monolithic (Shipping) compile check...


### PR DESCRIPTION
## 📑 Description
- the buildtest script was silently ignoring failed tests on Windows, this fix makes sure test failures are actually caught

## ✅ Checks
<!-- Make sure your pr passes the CI checks and do check the following fields as needed - -->
- [ ] My pull request adheres to the code style of this project
- [ ] My code requires changes to the documentation
- [ ] I have updated the documentation as required
- [ ] All the tests have passed

## ℹ Additional Information
<!-- Any additional information like breaking changes, dependencies added, screenshots, comparisons between new and old behavior, etc. -->