### PR TITLE
Add asis

### DIFF
--- a/goldenmaster/Plugins/Counter/Source/CounterJni/Counter_JNI_UPL.xml
+++ b/goldenmaster/Plugins/Counter/Source/CounterJni/Counter_JNI_UPL.xml
@@ -107,6 +107,36 @@ tasks.configureEach { task ->
 
 	<!-- optional additions to the GameActivity class in GameActivity.java -->
 	<gameActivityClassAdditions>
+		<insert>
+			<![CDATA[
+			// Counter: bridge the ApiGear BindingLifecycleRegistry SPI
+			// to ASIS's pre-destroy callback registry. Runs once when GameActivity
+			// class is loaded, before any JNI subsystem binds, installing a
+			// coordinator that forwards register/unregister calls into
+			// UnrealSharedInstanceService. This is the only place the generated
+			// code is coupled to ASIS; the SPI in apigear.android.lifecycle stays
+			// host-agnostic and the bridge is emitted only when this consumer
+			// opts in via the asis feature.
+			static
+			{
+				apigear.android.lifecycle.BindingLifecycleRegistry.setCoordinator(
+					new apigear.android.lifecycle.IBindingLifecycleCoordinator()
+					{
+						@Override
+						public void registerCleanup(Runnable cleanup)
+						{
+							com.epicgames.asis.UnrealSharedInstanceService.addPreDestroyCallback(cleanup);
+						}
+
+						@Override
+						public void unregisterCleanup(Runnable cleanup)
+						{
+							com.epicgames.asis.UnrealSharedInstanceService.removePreDestroyCallback(cleanup);
+						}
+					});
+			}
+			]]>
+		</insert>
 	</gameActivityClassAdditions>
 
 

--- a/goldenmaster/Plugins/Counter/Source/CounterJni/Private/Generated/Jni/CounterCounterJniClient.cpp
+++ b/goldenmaster/Plugins/Counter/Source/CounterJni/Private/Generated/Jni/CounterCounterJniClient.cpp
@@ -8,6 +8,7 @@
 
 #include "Async/Async.h"
 #include "Engine/Engine.h"
+#include "Misc/CoreDelegates.h"
 
 #include "Generated/Detail/CounterMethodHelper.h"
 #include "Generated/Detail/CounterCommonJavaConverter.h"
@@ -209,12 +210,29 @@ void UCounterCounterJniClient::Initialize(FSubsystemCollectionBase& Collection)
 	jobject localRef = Env->NewObject(Cache->clientClassCounter, Cache->clientClassCounterCtor);
 	m_javaJniClientInstance = Env->NewGlobalRef(localRef);
 	FAndroidApplication::GetJavaEnv()->DeleteLocalRef(localRef);
+
+	// Auto-rebind on foreground: ASIS-style hosts may destroy and recreate the
+	// Service that owns the engine without recreating the UE engine itself.
+	// Pre-destroy callbacks unbind the ServiceConnection cleanly, but the engine
+	// resume path doesn't re-trigger _bindToService. Subscribe so that if we
+	// were previously bound (cached m_lastBoundServicePackage) and aren't
+	// currently ready, the binding is restored automatically.
+	m_ForegroundDelegateHandle = FCoreDelegates::ApplicationHasEnteredForegroundDelegate.AddWeakLambda(this, [this]()
+		{
+		if (!b_isReady.load(std::memory_order_acquire) && !m_lastBoundServicePackage.IsEmpty())
+		{
+			UE_LOG(LogCounterCounterClient_JNI, Log,
+				TEXT("Auto-rebinding to %s on foreground"), *m_lastBoundServicePackage);
+			_bindToService(m_lastBoundServicePackage, m_lastConnectionId);
+		}
+	});
 #endif
 }
 
 void UCounterCounterJniClient::Deinitialize()
 {
 	UE_LOG(LogCounterCounterClient_JNI, Verbose, TEXT("deinit"));
+	FCoreDelegates::ApplicationHasEnteredForegroundDelegate.Remove(m_ForegroundDelegateHandle);
 	_unbind();
 	b_isReady.store(false, std::memory_order_release);
 	gUCounterCounterJniClientHandle.store(nullptr, std::memory_order_release);

--- a/goldenmaster/Plugins/Counter/Source/CounterJni/Public/Counter/Generated/Jni/CounterCounterJniClient.h
+++ b/goldenmaster/Plugins/Counter/Source/CounterJni/Public/Counter/Generated/Jni/CounterCounterJniClient.h
@@ -125,6 +125,9 @@ private:
 	std::atomic<bool> b_isReady{false};
 	FString m_lastBoundServicePackage;
 	FString m_lastConnectionId;
+	// Handle for UE foreground delegate subscription. Used to auto-rebind
+	// after the host Service is recreated without an engine tear-down.
+	FDelegateHandle m_ForegroundDelegateHandle;
 #if PLATFORM_ANDROID && USE_ANDROID_JNI
 	jobject m_javaJniClientInstance = nullptr;
 #endif

--- a/goldenmaster/Plugins/CustomTypes/Source/CustomTypesJni/CustomTypes_JNI_UPL.xml
+++ b/goldenmaster/Plugins/CustomTypes/Source/CustomTypesJni/CustomTypes_JNI_UPL.xml
@@ -94,6 +94,36 @@ tasks.configureEach { task ->
 
 	<!-- optional additions to the GameActivity class in GameActivity.java -->
 	<gameActivityClassAdditions>
+		<insert>
+			<![CDATA[
+			// CustomTypes: bridge the ApiGear BindingLifecycleRegistry SPI
+			// to ASIS's pre-destroy callback registry. Runs once when GameActivity
+			// class is loaded, before any JNI subsystem binds, installing a
+			// coordinator that forwards register/unregister calls into
+			// UnrealSharedInstanceService. This is the only place the generated
+			// code is coupled to ASIS; the SPI in apigear.android.lifecycle stays
+			// host-agnostic and the bridge is emitted only when this consumer
+			// opts in via the asis feature.
+			static
+			{
+				apigear.android.lifecycle.BindingLifecycleRegistry.setCoordinator(
+					new apigear.android.lifecycle.IBindingLifecycleCoordinator()
+					{
+						@Override
+						public void registerCleanup(Runnable cleanup)
+						{
+							com.epicgames.asis.UnrealSharedInstanceService.addPreDestroyCallback(cleanup);
+						}
+
+						@Override
+						public void unregisterCleanup(Runnable cleanup)
+						{
+							com.epicgames.asis.UnrealSharedInstanceService.removePreDestroyCallback(cleanup);
+						}
+					});
+			}
+			]]>
+		</insert>
 	</gameActivityClassAdditions>
 
 

--- a/goldenmaster/Plugins/ExternTypes/Source/ExternTypesJni/ExternTypes_JNI_UPL.xml
+++ b/goldenmaster/Plugins/ExternTypes/Source/ExternTypesJni/ExternTypes_JNI_UPL.xml
@@ -94,6 +94,36 @@ tasks.configureEach { task ->
 
 	<!-- optional additions to the GameActivity class in GameActivity.java -->
 	<gameActivityClassAdditions>
+		<insert>
+			<![CDATA[
+			// ExternTypes: bridge the ApiGear BindingLifecycleRegistry SPI
+			// to ASIS's pre-destroy callback registry. Runs once when GameActivity
+			// class is loaded, before any JNI subsystem binds, installing a
+			// coordinator that forwards register/unregister calls into
+			// UnrealSharedInstanceService. This is the only place the generated
+			// code is coupled to ASIS; the SPI in apigear.android.lifecycle stays
+			// host-agnostic and the bridge is emitted only when this consumer
+			// opts in via the asis feature.
+			static
+			{
+				apigear.android.lifecycle.BindingLifecycleRegistry.setCoordinator(
+					new apigear.android.lifecycle.IBindingLifecycleCoordinator()
+					{
+						@Override
+						public void registerCleanup(Runnable cleanup)
+						{
+							com.epicgames.asis.UnrealSharedInstanceService.addPreDestroyCallback(cleanup);
+						}
+
+						@Override
+						public void unregisterCleanup(Runnable cleanup)
+						{
+							com.epicgames.asis.UnrealSharedInstanceService.removePreDestroyCallback(cleanup);
+						}
+					});
+			}
+			]]>
+		</insert>
 	</gameActivityClassAdditions>
 
 

--- a/goldenmaster/Plugins/TbEnum/Source/TbEnumJni/Private/Generated/Jni/TbEnumEnumInterfaceJniClient.cpp
+++ b/goldenmaster/Plugins/TbEnum/Source/TbEnumJni/Private/Generated/Jni/TbEnumEnumInterfaceJniClient.cpp
@@ -9,6 +9,7 @@
 
 #include "Async/Async.h"
 #include "Engine/Engine.h"
+#include "Misc/CoreDelegates.h"
 
 #include "Generated/Detail/TbEnumMethodHelper.h"
 #include "Generated/Detail/TbEnumCommonJavaConverter.h"
@@ -210,12 +211,29 @@ void UTbEnumEnumInterfaceJniClient::Initialize(FSubsystemCollectionBase& Collect
 	jobject localRef = Env->NewObject(Cache->clientClassEnumInterface, Cache->clientClassEnumInterfaceCtor);
 	m_javaJniClientInstance = Env->NewGlobalRef(localRef);
 	FAndroidApplication::GetJavaEnv()->DeleteLocalRef(localRef);
+
+	// Auto-rebind on foreground: ASIS-style hosts may destroy and recreate the
+	// Service that owns the engine without recreating the UE engine itself.
+	// Pre-destroy callbacks unbind the ServiceConnection cleanly, but the engine
+	// resume path doesn't re-trigger _bindToService. Subscribe so that if we
+	// were previously bound (cached m_lastBoundServicePackage) and aren't
+	// currently ready, the binding is restored automatically.
+	m_ForegroundDelegateHandle = FCoreDelegates::ApplicationHasEnteredForegroundDelegate.AddWeakLambda(this, [this]()
+		{
+		if (!b_isReady.load(std::memory_order_acquire) && !m_lastBoundServicePackage.IsEmpty())
+		{
+			UE_LOG(LogTbEnumEnumInterfaceClient_JNI, Log,
+				TEXT("Auto-rebinding to %s on foreground"), *m_lastBoundServicePackage);
+			_bindToService(m_lastBoundServicePackage, m_lastConnectionId);
+		}
+	});
 #endif
 }
 
 void UTbEnumEnumInterfaceJniClient::Deinitialize()
 {
 	UE_LOG(LogTbEnumEnumInterfaceClient_JNI, Verbose, TEXT("deinit"));
+	FCoreDelegates::ApplicationHasEnteredForegroundDelegate.Remove(m_ForegroundDelegateHandle);
 	_unbind();
 	b_isReady.store(false, std::memory_order_release);
 	gUTbEnumEnumInterfaceJniClientHandle.store(nullptr, std::memory_order_release);

--- a/goldenmaster/Plugins/TbEnum/Source/TbEnumJni/Public/TbEnum/Generated/Jni/TbEnumEnumInterfaceJniClient.h
+++ b/goldenmaster/Plugins/TbEnum/Source/TbEnumJni/Public/TbEnum/Generated/Jni/TbEnumEnumInterfaceJniClient.h
@@ -137,6 +137,9 @@ private:
 	std::atomic<bool> b_isReady{false};
 	FString m_lastBoundServicePackage;
 	FString m_lastConnectionId;
+	// Handle for UE foreground delegate subscription. Used to auto-rebind
+	// after the host Service is recreated without an engine tear-down.
+	FDelegateHandle m_ForegroundDelegateHandle;
 #if PLATFORM_ANDROID && USE_ANDROID_JNI
 	jobject m_javaJniClientInstance = nullptr;
 #endif

--- a/goldenmaster/Plugins/TbEnum/Source/TbEnumJni/TbEnum_JNI_UPL.xml
+++ b/goldenmaster/Plugins/TbEnum/Source/TbEnumJni/TbEnum_JNI_UPL.xml
@@ -107,6 +107,36 @@ tasks.configureEach { task ->
 
 	<!-- optional additions to the GameActivity class in GameActivity.java -->
 	<gameActivityClassAdditions>
+		<insert>
+			<![CDATA[
+			// TbEnum: bridge the ApiGear BindingLifecycleRegistry SPI
+			// to ASIS's pre-destroy callback registry. Runs once when GameActivity
+			// class is loaded, before any JNI subsystem binds, installing a
+			// coordinator that forwards register/unregister calls into
+			// UnrealSharedInstanceService. This is the only place the generated
+			// code is coupled to ASIS; the SPI in apigear.android.lifecycle stays
+			// host-agnostic and the bridge is emitted only when this consumer
+			// opts in via the asis feature.
+			static
+			{
+				apigear.android.lifecycle.BindingLifecycleRegistry.setCoordinator(
+					new apigear.android.lifecycle.IBindingLifecycleCoordinator()
+					{
+						@Override
+						public void registerCleanup(Runnable cleanup)
+						{
+							com.epicgames.asis.UnrealSharedInstanceService.addPreDestroyCallback(cleanup);
+						}
+
+						@Override
+						public void unregisterCleanup(Runnable cleanup)
+						{
+							com.epicgames.asis.UnrealSharedInstanceService.removePreDestroyCallback(cleanup);
+						}
+					});
+			}
+			]]>
+		</insert>
 	</gameActivityClassAdditions>
 
 

--- a/goldenmaster/Plugins/TbIfaceimport/Source/TbIfaceimportJni/Private/Generated/Jni/TbIfaceimportEmptyIfJniClient.cpp
+++ b/goldenmaster/Plugins/TbIfaceimport/Source/TbIfaceimportJni/Private/Generated/Jni/TbIfaceimportEmptyIfJniClient.cpp
@@ -8,6 +8,7 @@
 
 #include "Async/Async.h"
 #include "Engine/Engine.h"
+#include "Misc/CoreDelegates.h"
 
 #include "Generated/Detail/TbIfaceimportMethodHelper.h"
 #include "Generated/Detail/TbIfaceimportCommonJavaConverter.h"
@@ -153,12 +154,29 @@ void UTbIfaceimportEmptyIfJniClient::Initialize(FSubsystemCollectionBase& Collec
 	jobject localRef = Env->NewObject(Cache->clientClassEmptyIf, Cache->clientClassEmptyIfCtor);
 	m_javaJniClientInstance = Env->NewGlobalRef(localRef);
 	FAndroidApplication::GetJavaEnv()->DeleteLocalRef(localRef);
+
+	// Auto-rebind on foreground: ASIS-style hosts may destroy and recreate the
+	// Service that owns the engine without recreating the UE engine itself.
+	// Pre-destroy callbacks unbind the ServiceConnection cleanly, but the engine
+	// resume path doesn't re-trigger _bindToService. Subscribe so that if we
+	// were previously bound (cached m_lastBoundServicePackage) and aren't
+	// currently ready, the binding is restored automatically.
+	m_ForegroundDelegateHandle = FCoreDelegates::ApplicationHasEnteredForegroundDelegate.AddWeakLambda(this, [this]()
+		{
+		if (!b_isReady.load(std::memory_order_acquire) && !m_lastBoundServicePackage.IsEmpty())
+		{
+			UE_LOG(LogTbIfaceimportEmptyIfClient_JNI, Log,
+				TEXT("Auto-rebinding to %s on foreground"), *m_lastBoundServicePackage);
+			_bindToService(m_lastBoundServicePackage, m_lastConnectionId);
+		}
+	});
 #endif
 }
 
 void UTbIfaceimportEmptyIfJniClient::Deinitialize()
 {
 	UE_LOG(LogTbIfaceimportEmptyIfClient_JNI, Verbose, TEXT("deinit"));
+	FCoreDelegates::ApplicationHasEnteredForegroundDelegate.Remove(m_ForegroundDelegateHandle);
 	_unbind();
 	b_isReady.store(false, std::memory_order_release);
 	gUTbIfaceimportEmptyIfJniClientHandle.store(nullptr, std::memory_order_release);

--- a/goldenmaster/Plugins/TbIfaceimport/Source/TbIfaceimportJni/Public/TbIfaceimport/Generated/Jni/TbIfaceimportEmptyIfJniClient.h
+++ b/goldenmaster/Plugins/TbIfaceimport/Source/TbIfaceimportJni/Public/TbIfaceimport/Generated/Jni/TbIfaceimportEmptyIfJniClient.h
@@ -83,6 +83,9 @@ private:
 	std::atomic<bool> b_isReady{false};
 	FString m_lastBoundServicePackage;
 	FString m_lastConnectionId;
+	// Handle for UE foreground delegate subscription. Used to auto-rebind
+	// after the host Service is recreated without an engine tear-down.
+	FDelegateHandle m_ForegroundDelegateHandle;
 #if PLATFORM_ANDROID && USE_ANDROID_JNI
 	jobject m_javaJniClientInstance = nullptr;
 #endif

--- a/goldenmaster/Plugins/TbIfaceimport/Source/TbIfaceimportJni/TbIfaceimport_JNI_UPL.xml
+++ b/goldenmaster/Plugins/TbIfaceimport/Source/TbIfaceimportJni/TbIfaceimport_JNI_UPL.xml
@@ -107,6 +107,36 @@ tasks.configureEach { task ->
 
 	<!-- optional additions to the GameActivity class in GameActivity.java -->
 	<gameActivityClassAdditions>
+		<insert>
+			<![CDATA[
+			// TbIfaceimport: bridge the ApiGear BindingLifecycleRegistry SPI
+			// to ASIS's pre-destroy callback registry. Runs once when GameActivity
+			// class is loaded, before any JNI subsystem binds, installing a
+			// coordinator that forwards register/unregister calls into
+			// UnrealSharedInstanceService. This is the only place the generated
+			// code is coupled to ASIS; the SPI in apigear.android.lifecycle stays
+			// host-agnostic and the bridge is emitted only when this consumer
+			// opts in via the asis feature.
+			static
+			{
+				apigear.android.lifecycle.BindingLifecycleRegistry.setCoordinator(
+					new apigear.android.lifecycle.IBindingLifecycleCoordinator()
+					{
+						@Override
+						public void registerCleanup(Runnable cleanup)
+						{
+							com.epicgames.asis.UnrealSharedInstanceService.addPreDestroyCallback(cleanup);
+						}
+
+						@Override
+						public void unregisterCleanup(Runnable cleanup)
+						{
+							com.epicgames.asis.UnrealSharedInstanceService.removePreDestroyCallback(cleanup);
+						}
+					});
+			}
+			]]>
+		</insert>
 	</gameActivityClassAdditions>
 
 

--- a/goldenmaster/Plugins/TbNames/Source/TbNamesJni/Private/Generated/Jni/TbNamesNamEsJniClient.cpp
+++ b/goldenmaster/Plugins/TbNames/Source/TbNamesJni/Private/Generated/Jni/TbNamesNamEsJniClient.cpp
@@ -9,6 +9,7 @@
 
 #include "Async/Async.h"
 #include "Engine/Engine.h"
+#include "Misc/CoreDelegates.h"
 
 #include "Generated/Detail/TbNamesMethodHelper.h"
 #include "Generated/Detail/TbNamesCommonJavaConverter.h"
@@ -196,12 +197,29 @@ void UTbNamesNamEsJniClient::Initialize(FSubsystemCollectionBase& Collection)
 	jobject localRef = Env->NewObject(Cache->clientClassNamEs, Cache->clientClassNamEsCtor);
 	m_javaJniClientInstance = Env->NewGlobalRef(localRef);
 	FAndroidApplication::GetJavaEnv()->DeleteLocalRef(localRef);
+
+	// Auto-rebind on foreground: ASIS-style hosts may destroy and recreate the
+	// Service that owns the engine without recreating the UE engine itself.
+	// Pre-destroy callbacks unbind the ServiceConnection cleanly, but the engine
+	// resume path doesn't re-trigger _bindToService. Subscribe so that if we
+	// were previously bound (cached m_lastBoundServicePackage) and aren't
+	// currently ready, the binding is restored automatically.
+	m_ForegroundDelegateHandle = FCoreDelegates::ApplicationHasEnteredForegroundDelegate.AddWeakLambda(this, [this]()
+		{
+		if (!b_isReady.load(std::memory_order_acquire) && !m_lastBoundServicePackage.IsEmpty())
+		{
+			UE_LOG(LogTbNamesNamEsClient_JNI, Log,
+				TEXT("Auto-rebinding to %s on foreground"), *m_lastBoundServicePackage);
+			_bindToService(m_lastBoundServicePackage, m_lastConnectionId);
+		}
+	});
 #endif
 }
 
 void UTbNamesNamEsJniClient::Deinitialize()
 {
 	UE_LOG(LogTbNamesNamEsClient_JNI, Verbose, TEXT("deinit"));
+	FCoreDelegates::ApplicationHasEnteredForegroundDelegate.Remove(m_ForegroundDelegateHandle);
 	_unbind();
 	b_isReady.store(false, std::memory_order_release);
 	gUTbNamesNamEsJniClientHandle.store(nullptr, std::memory_order_release);

--- a/goldenmaster/Plugins/TbNames/Source/TbNamesJni/Public/TbNames/Generated/Jni/TbNamesNamEsJniClient.h
+++ b/goldenmaster/Plugins/TbNames/Source/TbNamesJni/Public/TbNames/Generated/Jni/TbNamesNamEsJniClient.h
@@ -119,6 +119,9 @@ private:
 	std::atomic<bool> b_isReady{false};
 	FString m_lastBoundServicePackage;
 	FString m_lastConnectionId;
+	// Handle for UE foreground delegate subscription. Used to auto-rebind
+	// after the host Service is recreated without an engine tear-down.
+	FDelegateHandle m_ForegroundDelegateHandle;
 #if PLATFORM_ANDROID && USE_ANDROID_JNI
 	jobject m_javaJniClientInstance = nullptr;
 #endif

--- a/goldenmaster/Plugins/TbNames/Source/TbNamesJni/TbNames_JNI_UPL.xml
+++ b/goldenmaster/Plugins/TbNames/Source/TbNamesJni/TbNames_JNI_UPL.xml
@@ -107,6 +107,36 @@ tasks.configureEach { task ->
 
 	<!-- optional additions to the GameActivity class in GameActivity.java -->
 	<gameActivityClassAdditions>
+		<insert>
+			<![CDATA[
+			// TbNames: bridge the ApiGear BindingLifecycleRegistry SPI
+			// to ASIS's pre-destroy callback registry. Runs once when GameActivity
+			// class is loaded, before any JNI subsystem binds, installing a
+			// coordinator that forwards register/unregister calls into
+			// UnrealSharedInstanceService. This is the only place the generated
+			// code is coupled to ASIS; the SPI in apigear.android.lifecycle stays
+			// host-agnostic and the bridge is emitted only when this consumer
+			// opts in via the asis feature.
+			static
+			{
+				apigear.android.lifecycle.BindingLifecycleRegistry.setCoordinator(
+					new apigear.android.lifecycle.IBindingLifecycleCoordinator()
+					{
+						@Override
+						public void registerCleanup(Runnable cleanup)
+						{
+							com.epicgames.asis.UnrealSharedInstanceService.addPreDestroyCallback(cleanup);
+						}
+
+						@Override
+						public void unregisterCleanup(Runnable cleanup)
+						{
+							com.epicgames.asis.UnrealSharedInstanceService.removePreDestroyCallback(cleanup);
+						}
+					});
+			}
+			]]>
+		</insert>
 	</gameActivityClassAdditions>
 
 

--- a/goldenmaster/Plugins/TbRefIfaces/Source/TbRefIfacesJni/Private/Generated/Jni/TbRefIfacesParentIfJniClient.cpp
+++ b/goldenmaster/Plugins/TbRefIfaces/Source/TbRefIfacesJni/Private/Generated/Jni/TbRefIfacesParentIfJniClient.cpp
@@ -8,6 +8,7 @@
 
 #include "Async/Async.h"
 #include "Engine/Engine.h"
+#include "Misc/CoreDelegates.h"
 
 #include "Generated/Detail/TbRefIfacesMethodHelper.h"
 #include "Generated/Detail/TbRefIfacesCommonJavaConverter.h"
@@ -209,12 +210,29 @@ void UTbRefIfacesParentIfJniClient::Initialize(FSubsystemCollectionBase& Collect
 	jobject localRef = Env->NewObject(Cache->clientClassParentIf, Cache->clientClassParentIfCtor);
 	m_javaJniClientInstance = Env->NewGlobalRef(localRef);
 	FAndroidApplication::GetJavaEnv()->DeleteLocalRef(localRef);
+
+	// Auto-rebind on foreground: ASIS-style hosts may destroy and recreate the
+	// Service that owns the engine without recreating the UE engine itself.
+	// Pre-destroy callbacks unbind the ServiceConnection cleanly, but the engine
+	// resume path doesn't re-trigger _bindToService. Subscribe so that if we
+	// were previously bound (cached m_lastBoundServicePackage) and aren't
+	// currently ready, the binding is restored automatically.
+	m_ForegroundDelegateHandle = FCoreDelegates::ApplicationHasEnteredForegroundDelegate.AddWeakLambda(this, [this]()
+		{
+		if (!b_isReady.load(std::memory_order_acquire) && !m_lastBoundServicePackage.IsEmpty())
+		{
+			UE_LOG(LogTbRefIfacesParentIfClient_JNI, Log,
+				TEXT("Auto-rebinding to %s on foreground"), *m_lastBoundServicePackage);
+			_bindToService(m_lastBoundServicePackage, m_lastConnectionId);
+		}
+	});
 #endif
 }
 
 void UTbRefIfacesParentIfJniClient::Deinitialize()
 {
 	UE_LOG(LogTbRefIfacesParentIfClient_JNI, Verbose, TEXT("deinit"));
+	FCoreDelegates::ApplicationHasEnteredForegroundDelegate.Remove(m_ForegroundDelegateHandle);
 	_unbind();
 	b_isReady.store(false, std::memory_order_release);
 	gUTbRefIfacesParentIfJniClientHandle.store(nullptr, std::memory_order_release);

--- a/goldenmaster/Plugins/TbRefIfaces/Source/TbRefIfacesJni/Private/Generated/Jni/TbRefIfacesSimpleLocalIfJniClient.cpp
+++ b/goldenmaster/Plugins/TbRefIfaces/Source/TbRefIfacesJni/Private/Generated/Jni/TbRefIfacesSimpleLocalIfJniClient.cpp
@@ -8,6 +8,7 @@
 
 #include "Async/Async.h"
 #include "Engine/Engine.h"
+#include "Misc/CoreDelegates.h"
 
 #include "Generated/Detail/TbRefIfacesMethodHelper.h"
 #include "Generated/Detail/TbRefIfacesCommonJavaConverter.h"
@@ -167,12 +168,29 @@ void UTbRefIfacesSimpleLocalIfJniClient::Initialize(FSubsystemCollectionBase& Co
 	jobject localRef = Env->NewObject(Cache->clientClassSimpleLocalIf, Cache->clientClassSimpleLocalIfCtor);
 	m_javaJniClientInstance = Env->NewGlobalRef(localRef);
 	FAndroidApplication::GetJavaEnv()->DeleteLocalRef(localRef);
+
+	// Auto-rebind on foreground: ASIS-style hosts may destroy and recreate the
+	// Service that owns the engine without recreating the UE engine itself.
+	// Pre-destroy callbacks unbind the ServiceConnection cleanly, but the engine
+	// resume path doesn't re-trigger _bindToService. Subscribe so that if we
+	// were previously bound (cached m_lastBoundServicePackage) and aren't
+	// currently ready, the binding is restored automatically.
+	m_ForegroundDelegateHandle = FCoreDelegates::ApplicationHasEnteredForegroundDelegate.AddWeakLambda(this, [this]()
+		{
+		if (!b_isReady.load(std::memory_order_acquire) && !m_lastBoundServicePackage.IsEmpty())
+		{
+			UE_LOG(LogTbRefIfacesSimpleLocalIfClient_JNI, Log,
+				TEXT("Auto-rebinding to %s on foreground"), *m_lastBoundServicePackage);
+			_bindToService(m_lastBoundServicePackage, m_lastConnectionId);
+		}
+	});
 #endif
 }
 
 void UTbRefIfacesSimpleLocalIfJniClient::Deinitialize()
 {
 	UE_LOG(LogTbRefIfacesSimpleLocalIfClient_JNI, Verbose, TEXT("deinit"));
+	FCoreDelegates::ApplicationHasEnteredForegroundDelegate.Remove(m_ForegroundDelegateHandle);
 	_unbind();
 	b_isReady.store(false, std::memory_order_release);
 	gUTbRefIfacesSimpleLocalIfJniClientHandle.store(nullptr, std::memory_order_release);

--- a/goldenmaster/Plugins/TbRefIfaces/Source/TbRefIfacesJni/Public/TbRefIfaces/Generated/Jni/TbRefIfacesParentIfJniClient.h
+++ b/goldenmaster/Plugins/TbRefIfaces/Source/TbRefIfacesJni/Public/TbRefIfaces/Generated/Jni/TbRefIfacesParentIfJniClient.h
@@ -137,6 +137,9 @@ private:
 	std::atomic<bool> b_isReady{false};
 	FString m_lastBoundServicePackage;
 	FString m_lastConnectionId;
+	// Handle for UE foreground delegate subscription. Used to auto-rebind
+	// after the host Service is recreated without an engine tear-down.
+	FDelegateHandle m_ForegroundDelegateHandle;
 #if PLATFORM_ANDROID && USE_ANDROID_JNI
 	jobject m_javaJniClientInstance = nullptr;
 #endif

--- a/goldenmaster/Plugins/TbRefIfaces/Source/TbRefIfacesJni/Public/TbRefIfaces/Generated/Jni/TbRefIfacesSimpleLocalIfJniClient.h
+++ b/goldenmaster/Plugins/TbRefIfaces/Source/TbRefIfacesJni/Public/TbRefIfaces/Generated/Jni/TbRefIfacesSimpleLocalIfJniClient.h
@@ -95,6 +95,9 @@ private:
 	std::atomic<bool> b_isReady{false};
 	FString m_lastBoundServicePackage;
 	FString m_lastConnectionId;
+	// Handle for UE foreground delegate subscription. Used to auto-rebind
+	// after the host Service is recreated without an engine tear-down.
+	FDelegateHandle m_ForegroundDelegateHandle;
 #if PLATFORM_ANDROID && USE_ANDROID_JNI
 	jobject m_javaJniClientInstance = nullptr;
 #endif

--- a/goldenmaster/Plugins/TbRefIfaces/Source/TbRefIfacesJni/TbRefIfaces_JNI_UPL.xml
+++ b/goldenmaster/Plugins/TbRefIfaces/Source/TbRefIfacesJni/TbRefIfaces_JNI_UPL.xml
@@ -120,6 +120,36 @@ tasks.configureEach { task ->
 
 	<!-- optional additions to the GameActivity class in GameActivity.java -->
 	<gameActivityClassAdditions>
+		<insert>
+			<![CDATA[
+			// TbRefIfaces: bridge the ApiGear BindingLifecycleRegistry SPI
+			// to ASIS's pre-destroy callback registry. Runs once when GameActivity
+			// class is loaded, before any JNI subsystem binds, installing a
+			// coordinator that forwards register/unregister calls into
+			// UnrealSharedInstanceService. This is the only place the generated
+			// code is coupled to ASIS; the SPI in apigear.android.lifecycle stays
+			// host-agnostic and the bridge is emitted only when this consumer
+			// opts in via the asis feature.
+			static
+			{
+				apigear.android.lifecycle.BindingLifecycleRegistry.setCoordinator(
+					new apigear.android.lifecycle.IBindingLifecycleCoordinator()
+					{
+						@Override
+						public void registerCleanup(Runnable cleanup)
+						{
+							com.epicgames.asis.UnrealSharedInstanceService.addPreDestroyCallback(cleanup);
+						}
+
+						@Override
+						public void unregisterCleanup(Runnable cleanup)
+						{
+							com.epicgames.asis.UnrealSharedInstanceService.removePreDestroyCallback(cleanup);
+						}
+					});
+			}
+			]]>
+		</insert>
 	</gameActivityClassAdditions>
 
 

--- a/goldenmaster/Plugins/TbSame1/Source/TbSame1Jni/Private/Generated/Jni/TbSame1SameEnum1InterfaceJniClient.cpp
+++ b/goldenmaster/Plugins/TbSame1/Source/TbSame1Jni/Private/Generated/Jni/TbSame1SameEnum1InterfaceJniClient.cpp
@@ -9,6 +9,7 @@
 
 #include "Async/Async.h"
 #include "Engine/Engine.h"
+#include "Misc/CoreDelegates.h"
 
 #include "Generated/Detail/TbSame1MethodHelper.h"
 #include "Generated/Detail/TbSame1CommonJavaConverter.h"
@@ -168,12 +169,29 @@ void UTbSame1SameEnum1InterfaceJniClient::Initialize(FSubsystemCollectionBase& C
 	jobject localRef = Env->NewObject(Cache->clientClassSameEnum1Interface, Cache->clientClassSameEnum1InterfaceCtor);
 	m_javaJniClientInstance = Env->NewGlobalRef(localRef);
 	FAndroidApplication::GetJavaEnv()->DeleteLocalRef(localRef);
+
+	// Auto-rebind on foreground: ASIS-style hosts may destroy and recreate the
+	// Service that owns the engine without recreating the UE engine itself.
+	// Pre-destroy callbacks unbind the ServiceConnection cleanly, but the engine
+	// resume path doesn't re-trigger _bindToService. Subscribe so that if we
+	// were previously bound (cached m_lastBoundServicePackage) and aren't
+	// currently ready, the binding is restored automatically.
+	m_ForegroundDelegateHandle = FCoreDelegates::ApplicationHasEnteredForegroundDelegate.AddWeakLambda(this, [this]()
+		{
+		if (!b_isReady.load(std::memory_order_acquire) && !m_lastBoundServicePackage.IsEmpty())
+		{
+			UE_LOG(LogTbSame1SameEnum1InterfaceClient_JNI, Log,
+				TEXT("Auto-rebinding to %s on foreground"), *m_lastBoundServicePackage);
+			_bindToService(m_lastBoundServicePackage, m_lastConnectionId);
+		}
+	});
 #endif
 }
 
 void UTbSame1SameEnum1InterfaceJniClient::Deinitialize()
 {
 	UE_LOG(LogTbSame1SameEnum1InterfaceClient_JNI, Verbose, TEXT("deinit"));
+	FCoreDelegates::ApplicationHasEnteredForegroundDelegate.Remove(m_ForegroundDelegateHandle);
 	_unbind();
 	b_isReady.store(false, std::memory_order_release);
 	gUTbSame1SameEnum1InterfaceJniClientHandle.store(nullptr, std::memory_order_release);

--- a/goldenmaster/Plugins/TbSame1/Source/TbSame1Jni/Private/Generated/Jni/TbSame1SameEnum2InterfaceJniClient.cpp
+++ b/goldenmaster/Plugins/TbSame1/Source/TbSame1Jni/Private/Generated/Jni/TbSame1SameEnum2InterfaceJniClient.cpp
@@ -9,6 +9,7 @@
 
 #include "Async/Async.h"
 #include "Engine/Engine.h"
+#include "Misc/CoreDelegates.h"
 
 #include "Generated/Detail/TbSame1MethodHelper.h"
 #include "Generated/Detail/TbSame1CommonJavaConverter.h"
@@ -182,12 +183,29 @@ void UTbSame1SameEnum2InterfaceJniClient::Initialize(FSubsystemCollectionBase& C
 	jobject localRef = Env->NewObject(Cache->clientClassSameEnum2Interface, Cache->clientClassSameEnum2InterfaceCtor);
 	m_javaJniClientInstance = Env->NewGlobalRef(localRef);
 	FAndroidApplication::GetJavaEnv()->DeleteLocalRef(localRef);
+
+	// Auto-rebind on foreground: ASIS-style hosts may destroy and recreate the
+	// Service that owns the engine without recreating the UE engine itself.
+	// Pre-destroy callbacks unbind the ServiceConnection cleanly, but the engine
+	// resume path doesn't re-trigger _bindToService. Subscribe so that if we
+	// were previously bound (cached m_lastBoundServicePackage) and aren't
+	// currently ready, the binding is restored automatically.
+	m_ForegroundDelegateHandle = FCoreDelegates::ApplicationHasEnteredForegroundDelegate.AddWeakLambda(this, [this]()
+		{
+		if (!b_isReady.load(std::memory_order_acquire) && !m_lastBoundServicePackage.IsEmpty())
+		{
+			UE_LOG(LogTbSame1SameEnum2InterfaceClient_JNI, Log,
+				TEXT("Auto-rebinding to %s on foreground"), *m_lastBoundServicePackage);
+			_bindToService(m_lastBoundServicePackage, m_lastConnectionId);
+		}
+	});
 #endif
 }
 
 void UTbSame1SameEnum2InterfaceJniClient::Deinitialize()
 {
 	UE_LOG(LogTbSame1SameEnum2InterfaceClient_JNI, Verbose, TEXT("deinit"));
+	FCoreDelegates::ApplicationHasEnteredForegroundDelegate.Remove(m_ForegroundDelegateHandle);
 	_unbind();
 	b_isReady.store(false, std::memory_order_release);
 	gUTbSame1SameEnum2InterfaceJniClientHandle.store(nullptr, std::memory_order_release);

--- a/goldenmaster/Plugins/TbSame1/Source/TbSame1Jni/Private/Generated/Jni/TbSame1SameStruct1InterfaceJniClient.cpp
+++ b/goldenmaster/Plugins/TbSame1/Source/TbSame1Jni/Private/Generated/Jni/TbSame1SameStruct1InterfaceJniClient.cpp
@@ -9,6 +9,7 @@
 
 #include "Async/Async.h"
 #include "Engine/Engine.h"
+#include "Misc/CoreDelegates.h"
 
 #include "Generated/Detail/TbSame1MethodHelper.h"
 #include "Generated/Detail/TbSame1CommonJavaConverter.h"
@@ -168,12 +169,29 @@ void UTbSame1SameStruct1InterfaceJniClient::Initialize(FSubsystemCollectionBase&
 	jobject localRef = Env->NewObject(Cache->clientClassSameStruct1Interface, Cache->clientClassSameStruct1InterfaceCtor);
 	m_javaJniClientInstance = Env->NewGlobalRef(localRef);
 	FAndroidApplication::GetJavaEnv()->DeleteLocalRef(localRef);
+
+	// Auto-rebind on foreground: ASIS-style hosts may destroy and recreate the
+	// Service that owns the engine without recreating the UE engine itself.
+	// Pre-destroy callbacks unbind the ServiceConnection cleanly, but the engine
+	// resume path doesn't re-trigger _bindToService. Subscribe so that if we
+	// were previously bound (cached m_lastBoundServicePackage) and aren't
+	// currently ready, the binding is restored automatically.
+	m_ForegroundDelegateHandle = FCoreDelegates::ApplicationHasEnteredForegroundDelegate.AddWeakLambda(this, [this]()
+		{
+		if (!b_isReady.load(std::memory_order_acquire) && !m_lastBoundServicePackage.IsEmpty())
+		{
+			UE_LOG(LogTbSame1SameStruct1InterfaceClient_JNI, Log,
+				TEXT("Auto-rebinding to %s on foreground"), *m_lastBoundServicePackage);
+			_bindToService(m_lastBoundServicePackage, m_lastConnectionId);
+		}
+	});
 #endif
 }
 
 void UTbSame1SameStruct1InterfaceJniClient::Deinitialize()
 {
 	UE_LOG(LogTbSame1SameStruct1InterfaceClient_JNI, Verbose, TEXT("deinit"));
+	FCoreDelegates::ApplicationHasEnteredForegroundDelegate.Remove(m_ForegroundDelegateHandle);
 	_unbind();
 	b_isReady.store(false, std::memory_order_release);
 	gUTbSame1SameStruct1InterfaceJniClientHandle.store(nullptr, std::memory_order_release);

--- a/goldenmaster/Plugins/TbSame1/Source/TbSame1Jni/Private/Generated/Jni/TbSame1SameStruct2InterfaceJniClient.cpp
+++ b/goldenmaster/Plugins/TbSame1/Source/TbSame1Jni/Private/Generated/Jni/TbSame1SameStruct2InterfaceJniClient.cpp
@@ -9,6 +9,7 @@
 
 #include "Async/Async.h"
 #include "Engine/Engine.h"
+#include "Misc/CoreDelegates.h"
 
 #include "Generated/Detail/TbSame1MethodHelper.h"
 #include "Generated/Detail/TbSame1CommonJavaConverter.h"
@@ -182,12 +183,29 @@ void UTbSame1SameStruct2InterfaceJniClient::Initialize(FSubsystemCollectionBase&
 	jobject localRef = Env->NewObject(Cache->clientClassSameStruct2Interface, Cache->clientClassSameStruct2InterfaceCtor);
 	m_javaJniClientInstance = Env->NewGlobalRef(localRef);
 	FAndroidApplication::GetJavaEnv()->DeleteLocalRef(localRef);
+
+	// Auto-rebind on foreground: ASIS-style hosts may destroy and recreate the
+	// Service that owns the engine without recreating the UE engine itself.
+	// Pre-destroy callbacks unbind the ServiceConnection cleanly, but the engine
+	// resume path doesn't re-trigger _bindToService. Subscribe so that if we
+	// were previously bound (cached m_lastBoundServicePackage) and aren't
+	// currently ready, the binding is restored automatically.
+	m_ForegroundDelegateHandle = FCoreDelegates::ApplicationHasEnteredForegroundDelegate.AddWeakLambda(this, [this]()
+		{
+		if (!b_isReady.load(std::memory_order_acquire) && !m_lastBoundServicePackage.IsEmpty())
+		{
+			UE_LOG(LogTbSame1SameStruct2InterfaceClient_JNI, Log,
+				TEXT("Auto-rebinding to %s on foreground"), *m_lastBoundServicePackage);
+			_bindToService(m_lastBoundServicePackage, m_lastConnectionId);
+		}
+	});
 #endif
 }
 
 void UTbSame1SameStruct2InterfaceJniClient::Deinitialize()
 {
 	UE_LOG(LogTbSame1SameStruct2InterfaceClient_JNI, Verbose, TEXT("deinit"));
+	FCoreDelegates::ApplicationHasEnteredForegroundDelegate.Remove(m_ForegroundDelegateHandle);
 	_unbind();
 	b_isReady.store(false, std::memory_order_release);
 	gUTbSame1SameStruct2InterfaceJniClientHandle.store(nullptr, std::memory_order_release);

--- a/goldenmaster/Plugins/TbSame1/Source/TbSame1Jni/Public/TbSame1/Generated/Jni/TbSame1SameEnum1InterfaceJniClient.h
+++ b/goldenmaster/Plugins/TbSame1/Source/TbSame1Jni/Public/TbSame1/Generated/Jni/TbSame1SameEnum1InterfaceJniClient.h
@@ -95,6 +95,9 @@ private:
 	std::atomic<bool> b_isReady{false};
 	FString m_lastBoundServicePackage;
 	FString m_lastConnectionId;
+	// Handle for UE foreground delegate subscription. Used to auto-rebind
+	// after the host Service is recreated without an engine tear-down.
+	FDelegateHandle m_ForegroundDelegateHandle;
 #if PLATFORM_ANDROID && USE_ANDROID_JNI
 	jobject m_javaJniClientInstance = nullptr;
 #endif

--- a/goldenmaster/Plugins/TbSame1/Source/TbSame1Jni/Public/TbSame1/Generated/Jni/TbSame1SameEnum2InterfaceJniClient.h
+++ b/goldenmaster/Plugins/TbSame1/Source/TbSame1Jni/Public/TbSame1/Generated/Jni/TbSame1SameEnum2InterfaceJniClient.h
@@ -109,6 +109,9 @@ private:
 	std::atomic<bool> b_isReady{false};
 	FString m_lastBoundServicePackage;
 	FString m_lastConnectionId;
+	// Handle for UE foreground delegate subscription. Used to auto-rebind
+	// after the host Service is recreated without an engine tear-down.
+	FDelegateHandle m_ForegroundDelegateHandle;
 #if PLATFORM_ANDROID && USE_ANDROID_JNI
 	jobject m_javaJniClientInstance = nullptr;
 #endif

--- a/goldenmaster/Plugins/TbSame1/Source/TbSame1Jni/Public/TbSame1/Generated/Jni/TbSame1SameStruct1InterfaceJniClient.h
+++ b/goldenmaster/Plugins/TbSame1/Source/TbSame1Jni/Public/TbSame1/Generated/Jni/TbSame1SameStruct1InterfaceJniClient.h
@@ -95,6 +95,9 @@ private:
 	std::atomic<bool> b_isReady{false};
 	FString m_lastBoundServicePackage;
 	FString m_lastConnectionId;
+	// Handle for UE foreground delegate subscription. Used to auto-rebind
+	// after the host Service is recreated without an engine tear-down.
+	FDelegateHandle m_ForegroundDelegateHandle;
 #if PLATFORM_ANDROID && USE_ANDROID_JNI
 	jobject m_javaJniClientInstance = nullptr;
 #endif

--- a/goldenmaster/Plugins/TbSame1/Source/TbSame1Jni/Public/TbSame1/Generated/Jni/TbSame1SameStruct2InterfaceJniClient.h
+++ b/goldenmaster/Plugins/TbSame1/Source/TbSame1Jni/Public/TbSame1/Generated/Jni/TbSame1SameStruct2InterfaceJniClient.h
@@ -109,6 +109,9 @@ private:
 	std::atomic<bool> b_isReady{false};
 	FString m_lastBoundServicePackage;
 	FString m_lastConnectionId;
+	// Handle for UE foreground delegate subscription. Used to auto-rebind
+	// after the host Service is recreated without an engine tear-down.
+	FDelegateHandle m_ForegroundDelegateHandle;
 #if PLATFORM_ANDROID && USE_ANDROID_JNI
 	jobject m_javaJniClientInstance = nullptr;
 #endif

--- a/goldenmaster/Plugins/TbSame1/Source/TbSame1Jni/TbSame1_JNI_UPL.xml
+++ b/goldenmaster/Plugins/TbSame1/Source/TbSame1Jni/TbSame1_JNI_UPL.xml
@@ -146,6 +146,36 @@ tasks.configureEach { task ->
 
 	<!-- optional additions to the GameActivity class in GameActivity.java -->
 	<gameActivityClassAdditions>
+		<insert>
+			<![CDATA[
+			// TbSame1: bridge the ApiGear BindingLifecycleRegistry SPI
+			// to ASIS's pre-destroy callback registry. Runs once when GameActivity
+			// class is loaded, before any JNI subsystem binds, installing a
+			// coordinator that forwards register/unregister calls into
+			// UnrealSharedInstanceService. This is the only place the generated
+			// code is coupled to ASIS; the SPI in apigear.android.lifecycle stays
+			// host-agnostic and the bridge is emitted only when this consumer
+			// opts in via the asis feature.
+			static
+			{
+				apigear.android.lifecycle.BindingLifecycleRegistry.setCoordinator(
+					new apigear.android.lifecycle.IBindingLifecycleCoordinator()
+					{
+						@Override
+						public void registerCleanup(Runnable cleanup)
+						{
+							com.epicgames.asis.UnrealSharedInstanceService.addPreDestroyCallback(cleanup);
+						}
+
+						@Override
+						public void unregisterCleanup(Runnable cleanup)
+						{
+							com.epicgames.asis.UnrealSharedInstanceService.removePreDestroyCallback(cleanup);
+						}
+					});
+			}
+			]]>
+		</insert>
 	</gameActivityClassAdditions>
 
 

--- a/goldenmaster/Plugins/TbSame2/Source/TbSame2Jni/Private/Generated/Jni/TbSame2SameEnum1InterfaceJniClient.cpp
+++ b/goldenmaster/Plugins/TbSame2/Source/TbSame2Jni/Private/Generated/Jni/TbSame2SameEnum1InterfaceJniClient.cpp
@@ -9,6 +9,7 @@
 
 #include "Async/Async.h"
 #include "Engine/Engine.h"
+#include "Misc/CoreDelegates.h"
 
 #include "Generated/Detail/TbSame2MethodHelper.h"
 #include "Generated/Detail/TbSame2CommonJavaConverter.h"
@@ -168,12 +169,29 @@ void UTbSame2SameEnum1InterfaceJniClient::Initialize(FSubsystemCollectionBase& C
 	jobject localRef = Env->NewObject(Cache->clientClassSameEnum1Interface, Cache->clientClassSameEnum1InterfaceCtor);
 	m_javaJniClientInstance = Env->NewGlobalRef(localRef);
 	FAndroidApplication::GetJavaEnv()->DeleteLocalRef(localRef);
+
+	// Auto-rebind on foreground: ASIS-style hosts may destroy and recreate the
+	// Service that owns the engine without recreating the UE engine itself.
+	// Pre-destroy callbacks unbind the ServiceConnection cleanly, but the engine
+	// resume path doesn't re-trigger _bindToService. Subscribe so that if we
+	// were previously bound (cached m_lastBoundServicePackage) and aren't
+	// currently ready, the binding is restored automatically.
+	m_ForegroundDelegateHandle = FCoreDelegates::ApplicationHasEnteredForegroundDelegate.AddWeakLambda(this, [this]()
+		{
+		if (!b_isReady.load(std::memory_order_acquire) && !m_lastBoundServicePackage.IsEmpty())
+		{
+			UE_LOG(LogTbSame2SameEnum1InterfaceClient_JNI, Log,
+				TEXT("Auto-rebinding to %s on foreground"), *m_lastBoundServicePackage);
+			_bindToService(m_lastBoundServicePackage, m_lastConnectionId);
+		}
+	});
 #endif
 }
 
 void UTbSame2SameEnum1InterfaceJniClient::Deinitialize()
 {
 	UE_LOG(LogTbSame2SameEnum1InterfaceClient_JNI, Verbose, TEXT("deinit"));
+	FCoreDelegates::ApplicationHasEnteredForegroundDelegate.Remove(m_ForegroundDelegateHandle);
 	_unbind();
 	b_isReady.store(false, std::memory_order_release);
 	gUTbSame2SameEnum1InterfaceJniClientHandle.store(nullptr, std::memory_order_release);

--- a/goldenmaster/Plugins/TbSame2/Source/TbSame2Jni/Private/Generated/Jni/TbSame2SameEnum2InterfaceJniClient.cpp
+++ b/goldenmaster/Plugins/TbSame2/Source/TbSame2Jni/Private/Generated/Jni/TbSame2SameEnum2InterfaceJniClient.cpp
@@ -9,6 +9,7 @@
 
 #include "Async/Async.h"
 #include "Engine/Engine.h"
+#include "Misc/CoreDelegates.h"
 
 #include "Generated/Detail/TbSame2MethodHelper.h"
 #include "Generated/Detail/TbSame2CommonJavaConverter.h"
@@ -182,12 +183,29 @@ void UTbSame2SameEnum2InterfaceJniClient::Initialize(FSubsystemCollectionBase& C
 	jobject localRef = Env->NewObject(Cache->clientClassSameEnum2Interface, Cache->clientClassSameEnum2InterfaceCtor);
 	m_javaJniClientInstance = Env->NewGlobalRef(localRef);
 	FAndroidApplication::GetJavaEnv()->DeleteLocalRef(localRef);
+
+	// Auto-rebind on foreground: ASIS-style hosts may destroy and recreate the
+	// Service that owns the engine without recreating the UE engine itself.
+	// Pre-destroy callbacks unbind the ServiceConnection cleanly, but the engine
+	// resume path doesn't re-trigger _bindToService. Subscribe so that if we
+	// were previously bound (cached m_lastBoundServicePackage) and aren't
+	// currently ready, the binding is restored automatically.
+	m_ForegroundDelegateHandle = FCoreDelegates::ApplicationHasEnteredForegroundDelegate.AddWeakLambda(this, [this]()
+		{
+		if (!b_isReady.load(std::memory_order_acquire) && !m_lastBoundServicePackage.IsEmpty())
+		{
+			UE_LOG(LogTbSame2SameEnum2InterfaceClient_JNI, Log,
+				TEXT("Auto-rebinding to %s on foreground"), *m_lastBoundServicePackage);
+			_bindToService(m_lastBoundServicePackage, m_lastConnectionId);
+		}
+	});
 #endif
 }
 
 void UTbSame2SameEnum2InterfaceJniClient::Deinitialize()
 {
 	UE_LOG(LogTbSame2SameEnum2InterfaceClient_JNI, Verbose, TEXT("deinit"));
+	FCoreDelegates::ApplicationHasEnteredForegroundDelegate.Remove(m_ForegroundDelegateHandle);
 	_unbind();
 	b_isReady.store(false, std::memory_order_release);
 	gUTbSame2SameEnum2InterfaceJniClientHandle.store(nullptr, std::memory_order_release);

--- a/goldenmaster/Plugins/TbSame2/Source/TbSame2Jni/Private/Generated/Jni/TbSame2SameStruct1InterfaceJniClient.cpp
+++ b/goldenmaster/Plugins/TbSame2/Source/TbSame2Jni/Private/Generated/Jni/TbSame2SameStruct1InterfaceJniClient.cpp
@@ -9,6 +9,7 @@
 
 #include "Async/Async.h"
 #include "Engine/Engine.h"
+#include "Misc/CoreDelegates.h"
 
 #include "Generated/Detail/TbSame2MethodHelper.h"
 #include "Generated/Detail/TbSame2CommonJavaConverter.h"
@@ -168,12 +169,29 @@ void UTbSame2SameStruct1InterfaceJniClient::Initialize(FSubsystemCollectionBase&
 	jobject localRef = Env->NewObject(Cache->clientClassSameStruct1Interface, Cache->clientClassSameStruct1InterfaceCtor);
 	m_javaJniClientInstance = Env->NewGlobalRef(localRef);
 	FAndroidApplication::GetJavaEnv()->DeleteLocalRef(localRef);
+
+	// Auto-rebind on foreground: ASIS-style hosts may destroy and recreate the
+	// Service that owns the engine without recreating the UE engine itself.
+	// Pre-destroy callbacks unbind the ServiceConnection cleanly, but the engine
+	// resume path doesn't re-trigger _bindToService. Subscribe so that if we
+	// were previously bound (cached m_lastBoundServicePackage) and aren't
+	// currently ready, the binding is restored automatically.
+	m_ForegroundDelegateHandle = FCoreDelegates::ApplicationHasEnteredForegroundDelegate.AddWeakLambda(this, [this]()
+		{
+		if (!b_isReady.load(std::memory_order_acquire) && !m_lastBoundServicePackage.IsEmpty())
+		{
+			UE_LOG(LogTbSame2SameStruct1InterfaceClient_JNI, Log,
+				TEXT("Auto-rebinding to %s on foreground"), *m_lastBoundServicePackage);
+			_bindToService(m_lastBoundServicePackage, m_lastConnectionId);
+		}
+	});
 #endif
 }
 
 void UTbSame2SameStruct1InterfaceJniClient::Deinitialize()
 {
 	UE_LOG(LogTbSame2SameStruct1InterfaceClient_JNI, Verbose, TEXT("deinit"));
+	FCoreDelegates::ApplicationHasEnteredForegroundDelegate.Remove(m_ForegroundDelegateHandle);
 	_unbind();
 	b_isReady.store(false, std::memory_order_release);
 	gUTbSame2SameStruct1InterfaceJniClientHandle.store(nullptr, std::memory_order_release);

--- a/goldenmaster/Plugins/TbSame2/Source/TbSame2Jni/Private/Generated/Jni/TbSame2SameStruct2InterfaceJniClient.cpp
+++ b/goldenmaster/Plugins/TbSame2/Source/TbSame2Jni/Private/Generated/Jni/TbSame2SameStruct2InterfaceJniClient.cpp
@@ -9,6 +9,7 @@
 
 #include "Async/Async.h"
 #include "Engine/Engine.h"
+#include "Misc/CoreDelegates.h"
 
 #include "Generated/Detail/TbSame2MethodHelper.h"
 #include "Generated/Detail/TbSame2CommonJavaConverter.h"
@@ -182,12 +183,29 @@ void UTbSame2SameStruct2InterfaceJniClient::Initialize(FSubsystemCollectionBase&
 	jobject localRef = Env->NewObject(Cache->clientClassSameStruct2Interface, Cache->clientClassSameStruct2InterfaceCtor);
 	m_javaJniClientInstance = Env->NewGlobalRef(localRef);
 	FAndroidApplication::GetJavaEnv()->DeleteLocalRef(localRef);
+
+	// Auto-rebind on foreground: ASIS-style hosts may destroy and recreate the
+	// Service that owns the engine without recreating the UE engine itself.
+	// Pre-destroy callbacks unbind the ServiceConnection cleanly, but the engine
+	// resume path doesn't re-trigger _bindToService. Subscribe so that if we
+	// were previously bound (cached m_lastBoundServicePackage) and aren't
+	// currently ready, the binding is restored automatically.
+	m_ForegroundDelegateHandle = FCoreDelegates::ApplicationHasEnteredForegroundDelegate.AddWeakLambda(this, [this]()
+		{
+		if (!b_isReady.load(std::memory_order_acquire) && !m_lastBoundServicePackage.IsEmpty())
+		{
+			UE_LOG(LogTbSame2SameStruct2InterfaceClient_JNI, Log,
+				TEXT("Auto-rebinding to %s on foreground"), *m_lastBoundServicePackage);
+			_bindToService(m_lastBoundServicePackage, m_lastConnectionId);
+		}
+	});
 #endif
 }
 
 void UTbSame2SameStruct2InterfaceJniClient::Deinitialize()
 {
 	UE_LOG(LogTbSame2SameStruct2InterfaceClient_JNI, Verbose, TEXT("deinit"));
+	FCoreDelegates::ApplicationHasEnteredForegroundDelegate.Remove(m_ForegroundDelegateHandle);
 	_unbind();
 	b_isReady.store(false, std::memory_order_release);
 	gUTbSame2SameStruct2InterfaceJniClientHandle.store(nullptr, std::memory_order_release);

--- a/goldenmaster/Plugins/TbSame2/Source/TbSame2Jni/Public/TbSame2/Generated/Jni/TbSame2SameEnum1InterfaceJniClient.h
+++ b/goldenmaster/Plugins/TbSame2/Source/TbSame2Jni/Public/TbSame2/Generated/Jni/TbSame2SameEnum1InterfaceJniClient.h
@@ -95,6 +95,9 @@ private:
 	std::atomic<bool> b_isReady{false};
 	FString m_lastBoundServicePackage;
 	FString m_lastConnectionId;
+	// Handle for UE foreground delegate subscription. Used to auto-rebind
+	// after the host Service is recreated without an engine tear-down.
+	FDelegateHandle m_ForegroundDelegateHandle;
 #if PLATFORM_ANDROID && USE_ANDROID_JNI
 	jobject m_javaJniClientInstance = nullptr;
 #endif

--- a/goldenmaster/Plugins/TbSame2/Source/TbSame2Jni/Public/TbSame2/Generated/Jni/TbSame2SameEnum2InterfaceJniClient.h
+++ b/goldenmaster/Plugins/TbSame2/Source/TbSame2Jni/Public/TbSame2/Generated/Jni/TbSame2SameEnum2InterfaceJniClient.h
@@ -109,6 +109,9 @@ private:
 	std::atomic<bool> b_isReady{false};
 	FString m_lastBoundServicePackage;
 	FString m_lastConnectionId;
+	// Handle for UE foreground delegate subscription. Used to auto-rebind
+	// after the host Service is recreated without an engine tear-down.
+	FDelegateHandle m_ForegroundDelegateHandle;
 #if PLATFORM_ANDROID && USE_ANDROID_JNI
 	jobject m_javaJniClientInstance = nullptr;
 #endif

--- a/goldenmaster/Plugins/TbSame2/Source/TbSame2Jni/Public/TbSame2/Generated/Jni/TbSame2SameStruct1InterfaceJniClient.h
+++ b/goldenmaster/Plugins/TbSame2/Source/TbSame2Jni/Public/TbSame2/Generated/Jni/TbSame2SameStruct1InterfaceJniClient.h
@@ -95,6 +95,9 @@ private:
 	std::atomic<bool> b_isReady{false};
 	FString m_lastBoundServicePackage;
 	FString m_lastConnectionId;
+	// Handle for UE foreground delegate subscription. Used to auto-rebind
+	// after the host Service is recreated without an engine tear-down.
+	FDelegateHandle m_ForegroundDelegateHandle;
 #if PLATFORM_ANDROID && USE_ANDROID_JNI
 	jobject m_javaJniClientInstance = nullptr;
 #endif

--- a/goldenmaster/Plugins/TbSame2/Source/TbSame2Jni/Public/TbSame2/Generated/Jni/TbSame2SameStruct2InterfaceJniClient.h
+++ b/goldenmaster/Plugins/TbSame2/Source/TbSame2Jni/Public/TbSame2/Generated/Jni/TbSame2SameStruct2InterfaceJniClient.h
@@ -109,6 +109,9 @@ private:
 	std::atomic<bool> b_isReady{false};
 	FString m_lastBoundServicePackage;
 	FString m_lastConnectionId;
+	// Handle for UE foreground delegate subscription. Used to auto-rebind
+	// after the host Service is recreated without an engine tear-down.
+	FDelegateHandle m_ForegroundDelegateHandle;
 #if PLATFORM_ANDROID && USE_ANDROID_JNI
 	jobject m_javaJniClientInstance = nullptr;
 #endif

--- a/goldenmaster/Plugins/TbSame2/Source/TbSame2Jni/TbSame2_JNI_UPL.xml
+++ b/goldenmaster/Plugins/TbSame2/Source/TbSame2Jni/TbSame2_JNI_UPL.xml
@@ -146,6 +146,36 @@ tasks.configureEach { task ->
 
 	<!-- optional additions to the GameActivity class in GameActivity.java -->
 	<gameActivityClassAdditions>
+		<insert>
+			<![CDATA[
+			// TbSame2: bridge the ApiGear BindingLifecycleRegistry SPI
+			// to ASIS's pre-destroy callback registry. Runs once when GameActivity
+			// class is loaded, before any JNI subsystem binds, installing a
+			// coordinator that forwards register/unregister calls into
+			// UnrealSharedInstanceService. This is the only place the generated
+			// code is coupled to ASIS; the SPI in apigear.android.lifecycle stays
+			// host-agnostic and the bridge is emitted only when this consumer
+			// opts in via the asis feature.
+			static
+			{
+				apigear.android.lifecycle.BindingLifecycleRegistry.setCoordinator(
+					new apigear.android.lifecycle.IBindingLifecycleCoordinator()
+					{
+						@Override
+						public void registerCleanup(Runnable cleanup)
+						{
+							com.epicgames.asis.UnrealSharedInstanceService.addPreDestroyCallback(cleanup);
+						}
+
+						@Override
+						public void unregisterCleanup(Runnable cleanup)
+						{
+							com.epicgames.asis.UnrealSharedInstanceService.removePreDestroyCallback(cleanup);
+						}
+					});
+			}
+			]]>
+		</insert>
 	</gameActivityClassAdditions>
 
 

--- a/goldenmaster/Plugins/TbSimple/Source/TbSimpleJni/Private/Generated/Jni/TbSimpleEmptyInterfaceJniClient.cpp
+++ b/goldenmaster/Plugins/TbSimple/Source/TbSimpleJni/Private/Generated/Jni/TbSimpleEmptyInterfaceJniClient.cpp
@@ -8,6 +8,7 @@
 
 #include "Async/Async.h"
 #include "Engine/Engine.h"
+#include "Misc/CoreDelegates.h"
 
 #include "Generated/Detail/TbSimpleMethodHelper.h"
 #include "Generated/Detail/TbSimpleCommonJavaConverter.h"
@@ -153,12 +154,29 @@ void UTbSimpleEmptyInterfaceJniClient::Initialize(FSubsystemCollectionBase& Coll
 	jobject localRef = Env->NewObject(Cache->clientClassEmptyInterface, Cache->clientClassEmptyInterfaceCtor);
 	m_javaJniClientInstance = Env->NewGlobalRef(localRef);
 	FAndroidApplication::GetJavaEnv()->DeleteLocalRef(localRef);
+
+	// Auto-rebind on foreground: ASIS-style hosts may destroy and recreate the
+	// Service that owns the engine without recreating the UE engine itself.
+	// Pre-destroy callbacks unbind the ServiceConnection cleanly, but the engine
+	// resume path doesn't re-trigger _bindToService. Subscribe so that if we
+	// were previously bound (cached m_lastBoundServicePackage) and aren't
+	// currently ready, the binding is restored automatically.
+	m_ForegroundDelegateHandle = FCoreDelegates::ApplicationHasEnteredForegroundDelegate.AddWeakLambda(this, [this]()
+		{
+		if (!b_isReady.load(std::memory_order_acquire) && !m_lastBoundServicePackage.IsEmpty())
+		{
+			UE_LOG(LogTbSimpleEmptyInterfaceClient_JNI, Log,
+				TEXT("Auto-rebinding to %s on foreground"), *m_lastBoundServicePackage);
+			_bindToService(m_lastBoundServicePackage, m_lastConnectionId);
+		}
+	});
 #endif
 }
 
 void UTbSimpleEmptyInterfaceJniClient::Deinitialize()
 {
 	UE_LOG(LogTbSimpleEmptyInterfaceClient_JNI, Verbose, TEXT("deinit"));
+	FCoreDelegates::ApplicationHasEnteredForegroundDelegate.Remove(m_ForegroundDelegateHandle);
 	_unbind();
 	b_isReady.store(false, std::memory_order_release);
 	gUTbSimpleEmptyInterfaceJniClientHandle.store(nullptr, std::memory_order_release);

--- a/goldenmaster/Plugins/TbSimple/Source/TbSimpleJni/Private/Generated/Jni/TbSimpleNoOperationsInterfaceJniClient.cpp
+++ b/goldenmaster/Plugins/TbSimple/Source/TbSimpleJni/Private/Generated/Jni/TbSimpleNoOperationsInterfaceJniClient.cpp
@@ -8,6 +8,7 @@
 
 #include "Async/Async.h"
 #include "Engine/Engine.h"
+#include "Misc/CoreDelegates.h"
 
 #include "Generated/Detail/TbSimpleMethodHelper.h"
 #include "Generated/Detail/TbSimpleCommonJavaConverter.h"
@@ -167,12 +168,29 @@ void UTbSimpleNoOperationsInterfaceJniClient::Initialize(FSubsystemCollectionBas
 	jobject localRef = Env->NewObject(Cache->clientClassNoOperationsInterface, Cache->clientClassNoOperationsInterfaceCtor);
 	m_javaJniClientInstance = Env->NewGlobalRef(localRef);
 	FAndroidApplication::GetJavaEnv()->DeleteLocalRef(localRef);
+
+	// Auto-rebind on foreground: ASIS-style hosts may destroy and recreate the
+	// Service that owns the engine without recreating the UE engine itself.
+	// Pre-destroy callbacks unbind the ServiceConnection cleanly, but the engine
+	// resume path doesn't re-trigger _bindToService. Subscribe so that if we
+	// were previously bound (cached m_lastBoundServicePackage) and aren't
+	// currently ready, the binding is restored automatically.
+	m_ForegroundDelegateHandle = FCoreDelegates::ApplicationHasEnteredForegroundDelegate.AddWeakLambda(this, [this]()
+		{
+		if (!b_isReady.load(std::memory_order_acquire) && !m_lastBoundServicePackage.IsEmpty())
+		{
+			UE_LOG(LogTbSimpleNoOperationsInterfaceClient_JNI, Log,
+				TEXT("Auto-rebinding to %s on foreground"), *m_lastBoundServicePackage);
+			_bindToService(m_lastBoundServicePackage, m_lastConnectionId);
+		}
+	});
 #endif
 }
 
 void UTbSimpleNoOperationsInterfaceJniClient::Deinitialize()
 {
 	UE_LOG(LogTbSimpleNoOperationsInterfaceClient_JNI, Verbose, TEXT("deinit"));
+	FCoreDelegates::ApplicationHasEnteredForegroundDelegate.Remove(m_ForegroundDelegateHandle);
 	_unbind();
 	b_isReady.store(false, std::memory_order_release);
 	gUTbSimpleNoOperationsInterfaceJniClientHandle.store(nullptr, std::memory_order_release);

--- a/goldenmaster/Plugins/TbSimple/Source/TbSimpleJni/Private/Generated/Jni/TbSimpleNoPropertiesInterfaceJniClient.cpp
+++ b/goldenmaster/Plugins/TbSimple/Source/TbSimpleJni/Private/Generated/Jni/TbSimpleNoPropertiesInterfaceJniClient.cpp
@@ -8,6 +8,7 @@
 
 #include "Async/Async.h"
 #include "Engine/Engine.h"
+#include "Misc/CoreDelegates.h"
 
 #include "Generated/Detail/TbSimpleMethodHelper.h"
 #include "Generated/Detail/TbSimpleCommonJavaConverter.h"
@@ -167,12 +168,29 @@ void UTbSimpleNoPropertiesInterfaceJniClient::Initialize(FSubsystemCollectionBas
 	jobject localRef = Env->NewObject(Cache->clientClassNoPropertiesInterface, Cache->clientClassNoPropertiesInterfaceCtor);
 	m_javaJniClientInstance = Env->NewGlobalRef(localRef);
 	FAndroidApplication::GetJavaEnv()->DeleteLocalRef(localRef);
+
+	// Auto-rebind on foreground: ASIS-style hosts may destroy and recreate the
+	// Service that owns the engine without recreating the UE engine itself.
+	// Pre-destroy callbacks unbind the ServiceConnection cleanly, but the engine
+	// resume path doesn't re-trigger _bindToService. Subscribe so that if we
+	// were previously bound (cached m_lastBoundServicePackage) and aren't
+	// currently ready, the binding is restored automatically.
+	m_ForegroundDelegateHandle = FCoreDelegates::ApplicationHasEnteredForegroundDelegate.AddWeakLambda(this, [this]()
+		{
+		if (!b_isReady.load(std::memory_order_acquire) && !m_lastBoundServicePackage.IsEmpty())
+		{
+			UE_LOG(LogTbSimpleNoPropertiesInterfaceClient_JNI, Log,
+				TEXT("Auto-rebinding to %s on foreground"), *m_lastBoundServicePackage);
+			_bindToService(m_lastBoundServicePackage, m_lastConnectionId);
+		}
+	});
 #endif
 }
 
 void UTbSimpleNoPropertiesInterfaceJniClient::Deinitialize()
 {
 	UE_LOG(LogTbSimpleNoPropertiesInterfaceClient_JNI, Verbose, TEXT("deinit"));
+	FCoreDelegates::ApplicationHasEnteredForegroundDelegate.Remove(m_ForegroundDelegateHandle);
 	_unbind();
 	b_isReady.store(false, std::memory_order_release);
 	gUTbSimpleNoPropertiesInterfaceJniClientHandle.store(nullptr, std::memory_order_release);

--- a/goldenmaster/Plugins/TbSimple/Source/TbSimpleJni/Private/Generated/Jni/TbSimpleNoSignalsInterfaceJniClient.cpp
+++ b/goldenmaster/Plugins/TbSimple/Source/TbSimpleJni/Private/Generated/Jni/TbSimpleNoSignalsInterfaceJniClient.cpp
@@ -8,6 +8,7 @@
 
 #include "Async/Async.h"
 #include "Engine/Engine.h"
+#include "Misc/CoreDelegates.h"
 
 #include "Generated/Detail/TbSimpleMethodHelper.h"
 #include "Generated/Detail/TbSimpleCommonJavaConverter.h"
@@ -181,12 +182,29 @@ void UTbSimpleNoSignalsInterfaceJniClient::Initialize(FSubsystemCollectionBase& 
 	jobject localRef = Env->NewObject(Cache->clientClassNoSignalsInterface, Cache->clientClassNoSignalsInterfaceCtor);
 	m_javaJniClientInstance = Env->NewGlobalRef(localRef);
 	FAndroidApplication::GetJavaEnv()->DeleteLocalRef(localRef);
+
+	// Auto-rebind on foreground: ASIS-style hosts may destroy and recreate the
+	// Service that owns the engine without recreating the UE engine itself.
+	// Pre-destroy callbacks unbind the ServiceConnection cleanly, but the engine
+	// resume path doesn't re-trigger _bindToService. Subscribe so that if we
+	// were previously bound (cached m_lastBoundServicePackage) and aren't
+	// currently ready, the binding is restored automatically.
+	m_ForegroundDelegateHandle = FCoreDelegates::ApplicationHasEnteredForegroundDelegate.AddWeakLambda(this, [this]()
+		{
+		if (!b_isReady.load(std::memory_order_acquire) && !m_lastBoundServicePackage.IsEmpty())
+		{
+			UE_LOG(LogTbSimpleNoSignalsInterfaceClient_JNI, Log,
+				TEXT("Auto-rebinding to %s on foreground"), *m_lastBoundServicePackage);
+			_bindToService(m_lastBoundServicePackage, m_lastConnectionId);
+		}
+	});
 #endif
 }
 
 void UTbSimpleNoSignalsInterfaceJniClient::Deinitialize()
 {
 	UE_LOG(LogTbSimpleNoSignalsInterfaceClient_JNI, Verbose, TEXT("deinit"));
+	FCoreDelegates::ApplicationHasEnteredForegroundDelegate.Remove(m_ForegroundDelegateHandle);
 	_unbind();
 	b_isReady.store(false, std::memory_order_release);
 	gUTbSimpleNoSignalsInterfaceJniClientHandle.store(nullptr, std::memory_order_release);

--- a/goldenmaster/Plugins/TbSimple/Source/TbSimpleJni/Private/Generated/Jni/TbSimpleSimpleArrayInterfaceJniClient.cpp
+++ b/goldenmaster/Plugins/TbSimple/Source/TbSimpleJni/Private/Generated/Jni/TbSimpleSimpleArrayInterfaceJniClient.cpp
@@ -8,6 +8,7 @@
 
 #include "Async/Async.h"
 #include "Engine/Engine.h"
+#include "Misc/CoreDelegates.h"
 
 #include "Generated/Detail/TbSimpleMethodHelper.h"
 #include "Generated/Detail/TbSimpleCommonJavaConverter.h"
@@ -265,12 +266,29 @@ void UTbSimpleSimpleArrayInterfaceJniClient::Initialize(FSubsystemCollectionBase
 	jobject localRef = Env->NewObject(Cache->clientClassSimpleArrayInterface, Cache->clientClassSimpleArrayInterfaceCtor);
 	m_javaJniClientInstance = Env->NewGlobalRef(localRef);
 	FAndroidApplication::GetJavaEnv()->DeleteLocalRef(localRef);
+
+	// Auto-rebind on foreground: ASIS-style hosts may destroy and recreate the
+	// Service that owns the engine without recreating the UE engine itself.
+	// Pre-destroy callbacks unbind the ServiceConnection cleanly, but the engine
+	// resume path doesn't re-trigger _bindToService. Subscribe so that if we
+	// were previously bound (cached m_lastBoundServicePackage) and aren't
+	// currently ready, the binding is restored automatically.
+	m_ForegroundDelegateHandle = FCoreDelegates::ApplicationHasEnteredForegroundDelegate.AddWeakLambda(this, [this]()
+		{
+		if (!b_isReady.load(std::memory_order_acquire) && !m_lastBoundServicePackage.IsEmpty())
+		{
+			UE_LOG(LogTbSimpleSimpleArrayInterfaceClient_JNI, Log,
+				TEXT("Auto-rebinding to %s on foreground"), *m_lastBoundServicePackage);
+			_bindToService(m_lastBoundServicePackage, m_lastConnectionId);
+		}
+	});
 #endif
 }
 
 void UTbSimpleSimpleArrayInterfaceJniClient::Deinitialize()
 {
 	UE_LOG(LogTbSimpleSimpleArrayInterfaceClient_JNI, Verbose, TEXT("deinit"));
+	FCoreDelegates::ApplicationHasEnteredForegroundDelegate.Remove(m_ForegroundDelegateHandle);
 	_unbind();
 	b_isReady.store(false, std::memory_order_release);
 	gUTbSimpleSimpleArrayInterfaceJniClientHandle.store(nullptr, std::memory_order_release);

--- a/goldenmaster/Plugins/TbSimple/Source/TbSimpleJni/Private/Generated/Jni/TbSimpleSimpleInterfaceJniClient.cpp
+++ b/goldenmaster/Plugins/TbSimple/Source/TbSimpleJni/Private/Generated/Jni/TbSimpleSimpleInterfaceJniClient.cpp
@@ -8,6 +8,7 @@
 
 #include "Async/Async.h"
 #include "Engine/Engine.h"
+#include "Misc/CoreDelegates.h"
 
 #include "Generated/Detail/TbSimpleMethodHelper.h"
 #include "Generated/Detail/TbSimpleCommonJavaConverter.h"
@@ -279,12 +280,29 @@ void UTbSimpleSimpleInterfaceJniClient::Initialize(FSubsystemCollectionBase& Col
 	jobject localRef = Env->NewObject(Cache->clientClassSimpleInterface, Cache->clientClassSimpleInterfaceCtor);
 	m_javaJniClientInstance = Env->NewGlobalRef(localRef);
 	FAndroidApplication::GetJavaEnv()->DeleteLocalRef(localRef);
+
+	// Auto-rebind on foreground: ASIS-style hosts may destroy and recreate the
+	// Service that owns the engine without recreating the UE engine itself.
+	// Pre-destroy callbacks unbind the ServiceConnection cleanly, but the engine
+	// resume path doesn't re-trigger _bindToService. Subscribe so that if we
+	// were previously bound (cached m_lastBoundServicePackage) and aren't
+	// currently ready, the binding is restored automatically.
+	m_ForegroundDelegateHandle = FCoreDelegates::ApplicationHasEnteredForegroundDelegate.AddWeakLambda(this, [this]()
+		{
+		if (!b_isReady.load(std::memory_order_acquire) && !m_lastBoundServicePackage.IsEmpty())
+		{
+			UE_LOG(LogTbSimpleSimpleInterfaceClient_JNI, Log,
+				TEXT("Auto-rebinding to %s on foreground"), *m_lastBoundServicePackage);
+			_bindToService(m_lastBoundServicePackage, m_lastConnectionId);
+		}
+	});
 #endif
 }
 
 void UTbSimpleSimpleInterfaceJniClient::Deinitialize()
 {
 	UE_LOG(LogTbSimpleSimpleInterfaceClient_JNI, Verbose, TEXT("deinit"));
+	FCoreDelegates::ApplicationHasEnteredForegroundDelegate.Remove(m_ForegroundDelegateHandle);
 	_unbind();
 	b_isReady.store(false, std::memory_order_release);
 	gUTbSimpleSimpleInterfaceJniClientHandle.store(nullptr, std::memory_order_release);

--- a/goldenmaster/Plugins/TbSimple/Source/TbSimpleJni/Private/Generated/Jni/TbSimpleVoidInterfaceJniClient.cpp
+++ b/goldenmaster/Plugins/TbSimple/Source/TbSimpleJni/Private/Generated/Jni/TbSimpleVoidInterfaceJniClient.cpp
@@ -8,6 +8,7 @@
 
 #include "Async/Async.h"
 #include "Engine/Engine.h"
+#include "Misc/CoreDelegates.h"
 
 #include "Generated/Detail/TbSimpleMethodHelper.h"
 #include "Generated/Detail/TbSimpleCommonJavaConverter.h"
@@ -160,12 +161,29 @@ void UTbSimpleVoidInterfaceJniClient::Initialize(FSubsystemCollectionBase& Colle
 	jobject localRef = Env->NewObject(Cache->clientClassVoidInterface, Cache->clientClassVoidInterfaceCtor);
 	m_javaJniClientInstance = Env->NewGlobalRef(localRef);
 	FAndroidApplication::GetJavaEnv()->DeleteLocalRef(localRef);
+
+	// Auto-rebind on foreground: ASIS-style hosts may destroy and recreate the
+	// Service that owns the engine without recreating the UE engine itself.
+	// Pre-destroy callbacks unbind the ServiceConnection cleanly, but the engine
+	// resume path doesn't re-trigger _bindToService. Subscribe so that if we
+	// were previously bound (cached m_lastBoundServicePackage) and aren't
+	// currently ready, the binding is restored automatically.
+	m_ForegroundDelegateHandle = FCoreDelegates::ApplicationHasEnteredForegroundDelegate.AddWeakLambda(this, [this]()
+		{
+		if (!b_isReady.load(std::memory_order_acquire) && !m_lastBoundServicePackage.IsEmpty())
+		{
+			UE_LOG(LogTbSimpleVoidInterfaceClient_JNI, Log,
+				TEXT("Auto-rebinding to %s on foreground"), *m_lastBoundServicePackage);
+			_bindToService(m_lastBoundServicePackage, m_lastConnectionId);
+		}
+	});
 #endif
 }
 
 void UTbSimpleVoidInterfaceJniClient::Deinitialize()
 {
 	UE_LOG(LogTbSimpleVoidInterfaceClient_JNI, Verbose, TEXT("deinit"));
+	FCoreDelegates::ApplicationHasEnteredForegroundDelegate.Remove(m_ForegroundDelegateHandle);
 	_unbind();
 	b_isReady.store(false, std::memory_order_release);
 	gUTbSimpleVoidInterfaceJniClientHandle.store(nullptr, std::memory_order_release);

--- a/goldenmaster/Plugins/TbSimple/Source/TbSimpleJni/Public/TbSimple/Generated/Jni/TbSimpleEmptyInterfaceJniClient.h
+++ b/goldenmaster/Plugins/TbSimple/Source/TbSimpleJni/Public/TbSimple/Generated/Jni/TbSimpleEmptyInterfaceJniClient.h
@@ -83,6 +83,9 @@ private:
 	std::atomic<bool> b_isReady{false};
 	FString m_lastBoundServicePackage;
 	FString m_lastConnectionId;
+	// Handle for UE foreground delegate subscription. Used to auto-rebind
+	// after the host Service is recreated without an engine tear-down.
+	FDelegateHandle m_ForegroundDelegateHandle;
 #if PLATFORM_ANDROID && USE_ANDROID_JNI
 	jobject m_javaJniClientInstance = nullptr;
 #endif

--- a/goldenmaster/Plugins/TbSimple/Source/TbSimpleJni/Public/TbSimple/Generated/Jni/TbSimpleNoOperationsInterfaceJniClient.h
+++ b/goldenmaster/Plugins/TbSimple/Source/TbSimpleJni/Public/TbSimple/Generated/Jni/TbSimpleNoOperationsInterfaceJniClient.h
@@ -102,6 +102,9 @@ private:
 	std::atomic<bool> b_isReady{false};
 	FString m_lastBoundServicePackage;
 	FString m_lastConnectionId;
+	// Handle for UE foreground delegate subscription. Used to auto-rebind
+	// after the host Service is recreated without an engine tear-down.
+	FDelegateHandle m_ForegroundDelegateHandle;
 #if PLATFORM_ANDROID && USE_ANDROID_JNI
 	jobject m_javaJniClientInstance = nullptr;
 #endif

--- a/goldenmaster/Plugins/TbSimple/Source/TbSimpleJni/Public/TbSimple/Generated/Jni/TbSimpleNoPropertiesInterfaceJniClient.h
+++ b/goldenmaster/Plugins/TbSimple/Source/TbSimpleJni/Public/TbSimple/Generated/Jni/TbSimpleNoPropertiesInterfaceJniClient.h
@@ -96,6 +96,9 @@ private:
 	std::atomic<bool> b_isReady{false};
 	FString m_lastBoundServicePackage;
 	FString m_lastConnectionId;
+	// Handle for UE foreground delegate subscription. Used to auto-rebind
+	// after the host Service is recreated without an engine tear-down.
+	FDelegateHandle m_ForegroundDelegateHandle;
 #if PLATFORM_ANDROID && USE_ANDROID_JNI
 	jobject m_javaJniClientInstance = nullptr;
 #endif

--- a/goldenmaster/Plugins/TbSimple/Source/TbSimpleJni/Public/TbSimple/Generated/Jni/TbSimpleNoSignalsInterfaceJniClient.h
+++ b/goldenmaster/Plugins/TbSimple/Source/TbSimpleJni/Public/TbSimple/Generated/Jni/TbSimpleNoSignalsInterfaceJniClient.h
@@ -100,6 +100,9 @@ private:
 	std::atomic<bool> b_isReady{false};
 	FString m_lastBoundServicePackage;
 	FString m_lastConnectionId;
+	// Handle for UE foreground delegate subscription. Used to auto-rebind
+	// after the host Service is recreated without an engine tear-down.
+	FDelegateHandle m_ForegroundDelegateHandle;
 #if PLATFORM_ANDROID && USE_ANDROID_JNI
 	jobject m_javaJniClientInstance = nullptr;
 #endif

--- a/goldenmaster/Plugins/TbSimple/Source/TbSimpleJni/Public/TbSimple/Generated/Jni/TbSimpleSimpleArrayInterfaceJniClient.h
+++ b/goldenmaster/Plugins/TbSimple/Source/TbSimpleJni/Public/TbSimple/Generated/Jni/TbSimpleSimpleArrayInterfaceJniClient.h
@@ -198,6 +198,9 @@ private:
 	std::atomic<bool> b_isReady{false};
 	FString m_lastBoundServicePackage;
 	FString m_lastConnectionId;
+	// Handle for UE foreground delegate subscription. Used to auto-rebind
+	// after the host Service is recreated without an engine tear-down.
+	FDelegateHandle m_ForegroundDelegateHandle;
 #if PLATFORM_ANDROID && USE_ANDROID_JNI
 	jobject m_javaJniClientInstance = nullptr;
 #endif

--- a/goldenmaster/Plugins/TbSimple/Source/TbSimpleJni/Public/TbSimple/Generated/Jni/TbSimpleSimpleInterfaceJniClient.h
+++ b/goldenmaster/Plugins/TbSimple/Source/TbSimpleJni/Public/TbSimple/Generated/Jni/TbSimpleSimpleInterfaceJniClient.h
@@ -200,6 +200,9 @@ private:
 	std::atomic<bool> b_isReady{false};
 	FString m_lastBoundServicePackage;
 	FString m_lastConnectionId;
+	// Handle for UE foreground delegate subscription. Used to auto-rebind
+	// after the host Service is recreated without an engine tear-down.
+	FDelegateHandle m_ForegroundDelegateHandle;
 #if PLATFORM_ANDROID && USE_ANDROID_JNI
 	jobject m_javaJniClientInstance = nullptr;
 #endif

--- a/goldenmaster/Plugins/TbSimple/Source/TbSimpleJni/Public/TbSimple/Generated/Jni/TbSimpleVoidInterfaceJniClient.h
+++ b/goldenmaster/Plugins/TbSimple/Source/TbSimpleJni/Public/TbSimple/Generated/Jni/TbSimpleVoidInterfaceJniClient.h
@@ -88,6 +88,9 @@ private:
 	std::atomic<bool> b_isReady{false};
 	FString m_lastBoundServicePackage;
 	FString m_lastConnectionId;
+	// Handle for UE foreground delegate subscription. Used to auto-rebind
+	// after the host Service is recreated without an engine tear-down.
+	FDelegateHandle m_ForegroundDelegateHandle;
 #if PLATFORM_ANDROID && USE_ANDROID_JNI
 	jobject m_javaJniClientInstance = nullptr;
 #endif

--- a/goldenmaster/Plugins/TbSimple/Source/TbSimpleJni/TbSimple_JNI_UPL.xml
+++ b/goldenmaster/Plugins/TbSimple/Source/TbSimpleJni/TbSimple_JNI_UPL.xml
@@ -185,6 +185,36 @@ tasks.configureEach { task ->
 
 	<!-- optional additions to the GameActivity class in GameActivity.java -->
 	<gameActivityClassAdditions>
+		<insert>
+			<![CDATA[
+			// TbSimple: bridge the ApiGear BindingLifecycleRegistry SPI
+			// to ASIS's pre-destroy callback registry. Runs once when GameActivity
+			// class is loaded, before any JNI subsystem binds, installing a
+			// coordinator that forwards register/unregister calls into
+			// UnrealSharedInstanceService. This is the only place the generated
+			// code is coupled to ASIS; the SPI in apigear.android.lifecycle stays
+			// host-agnostic and the bridge is emitted only when this consumer
+			// opts in via the asis feature.
+			static
+			{
+				apigear.android.lifecycle.BindingLifecycleRegistry.setCoordinator(
+					new apigear.android.lifecycle.IBindingLifecycleCoordinator()
+					{
+						@Override
+						public void registerCleanup(Runnable cleanup)
+						{
+							com.epicgames.asis.UnrealSharedInstanceService.addPreDestroyCallback(cleanup);
+						}
+
+						@Override
+						public void unregisterCleanup(Runnable cleanup)
+						{
+							com.epicgames.asis.UnrealSharedInstanceService.removePreDestroyCallback(cleanup);
+						}
+					});
+			}
+			]]>
+		</insert>
 	</gameActivityClassAdditions>
 
 

--- a/goldenmaster/Plugins/TbStructArray/Source/TbStructArrayJni/Private/Generated/Jni/TbStructArrayStructArrayFieldInterfaceJniClient.cpp
+++ b/goldenmaster/Plugins/TbStructArray/Source/TbStructArrayJni/Private/Generated/Jni/TbStructArrayStructArrayFieldInterfaceJniClient.cpp
@@ -9,6 +9,7 @@
 
 #include "Async/Async.h"
 #include "Engine/Engine.h"
+#include "Misc/CoreDelegates.h"
 
 #include "Generated/Detail/TbStructArrayMethodHelper.h"
 #include "Generated/Detail/TbStructArrayCommonJavaConverter.h"
@@ -196,12 +197,29 @@ void UTbStructArrayStructArrayFieldInterfaceJniClient::Initialize(FSubsystemColl
 	jobject localRef = Env->NewObject(Cache->clientClassStructArrayFieldInterface, Cache->clientClassStructArrayFieldInterfaceCtor);
 	m_javaJniClientInstance = Env->NewGlobalRef(localRef);
 	FAndroidApplication::GetJavaEnv()->DeleteLocalRef(localRef);
+
+	// Auto-rebind on foreground: ASIS-style hosts may destroy and recreate the
+	// Service that owns the engine without recreating the UE engine itself.
+	// Pre-destroy callbacks unbind the ServiceConnection cleanly, but the engine
+	// resume path doesn't re-trigger _bindToService. Subscribe so that if we
+	// were previously bound (cached m_lastBoundServicePackage) and aren't
+	// currently ready, the binding is restored automatically.
+	m_ForegroundDelegateHandle = FCoreDelegates::ApplicationHasEnteredForegroundDelegate.AddWeakLambda(this, [this]()
+		{
+		if (!b_isReady.load(std::memory_order_acquire) && !m_lastBoundServicePackage.IsEmpty())
+		{
+			UE_LOG(LogTbStructArrayStructArrayFieldInterfaceClient_JNI, Log,
+				TEXT("Auto-rebinding to %s on foreground"), *m_lastBoundServicePackage);
+			_bindToService(m_lastBoundServicePackage, m_lastConnectionId);
+		}
+	});
 #endif
 }
 
 void UTbStructArrayStructArrayFieldInterfaceJniClient::Deinitialize()
 {
 	UE_LOG(LogTbStructArrayStructArrayFieldInterfaceClient_JNI, Verbose, TEXT("deinit"));
+	FCoreDelegates::ApplicationHasEnteredForegroundDelegate.Remove(m_ForegroundDelegateHandle);
 	_unbind();
 	b_isReady.store(false, std::memory_order_release);
 	gUTbStructArrayStructArrayFieldInterfaceJniClientHandle.store(nullptr, std::memory_order_release);

--- a/goldenmaster/Plugins/TbStructArray/Source/TbStructArrayJni/Public/TbStructArray/Generated/Jni/TbStructArrayStructArrayFieldInterfaceJniClient.h
+++ b/goldenmaster/Plugins/TbStructArray/Source/TbStructArrayJni/Public/TbStructArray/Generated/Jni/TbStructArrayStructArrayFieldInterfaceJniClient.h
@@ -121,6 +121,9 @@ private:
 	std::atomic<bool> b_isReady{false};
 	FString m_lastBoundServicePackage;
 	FString m_lastConnectionId;
+	// Handle for UE foreground delegate subscription. Used to auto-rebind
+	// after the host Service is recreated without an engine tear-down.
+	FDelegateHandle m_ForegroundDelegateHandle;
 #if PLATFORM_ANDROID && USE_ANDROID_JNI
 	jobject m_javaJniClientInstance = nullptr;
 #endif

--- a/goldenmaster/Plugins/TbStructArray/Source/TbStructArrayJni/TbStructArray_JNI_UPL.xml
+++ b/goldenmaster/Plugins/TbStructArray/Source/TbStructArrayJni/TbStructArray_JNI_UPL.xml
@@ -107,6 +107,36 @@ tasks.configureEach { task ->
 
 	<!-- optional additions to the GameActivity class in GameActivity.java -->
 	<gameActivityClassAdditions>
+		<insert>
+			<![CDATA[
+			// TbStructArray: bridge the ApiGear BindingLifecycleRegistry SPI
+			// to ASIS's pre-destroy callback registry. Runs once when GameActivity
+			// class is loaded, before any JNI subsystem binds, installing a
+			// coordinator that forwards register/unregister calls into
+			// UnrealSharedInstanceService. This is the only place the generated
+			// code is coupled to ASIS; the SPI in apigear.android.lifecycle stays
+			// host-agnostic and the bridge is emitted only when this consumer
+			// opts in via the asis feature.
+			static
+			{
+				apigear.android.lifecycle.BindingLifecycleRegistry.setCoordinator(
+					new apigear.android.lifecycle.IBindingLifecycleCoordinator()
+					{
+						@Override
+						public void registerCleanup(Runnable cleanup)
+						{
+							com.epicgames.asis.UnrealSharedInstanceService.addPreDestroyCallback(cleanup);
+						}
+
+						@Override
+						public void unregisterCleanup(Runnable cleanup)
+						{
+							com.epicgames.asis.UnrealSharedInstanceService.removePreDestroyCallback(cleanup);
+						}
+					});
+			}
+			]]>
+		</insert>
 	</gameActivityClassAdditions>
 
 

--- a/goldenmaster/Plugins/Testbed1/Source/Testbed1Jni/Private/Generated/Jni/Testbed1StructArray2InterfaceJniClient.cpp
+++ b/goldenmaster/Plugins/Testbed1/Source/Testbed1Jni/Private/Generated/Jni/Testbed1StructArray2InterfaceJniClient.cpp
@@ -9,6 +9,7 @@
 
 #include "Async/Async.h"
 #include "Engine/Engine.h"
+#include "Misc/CoreDelegates.h"
 
 #include "Generated/Detail/Testbed1MethodHelper.h"
 #include "Generated/Detail/Testbed1CommonJavaConverter.h"
@@ -224,12 +225,29 @@ void UTestbed1StructArray2InterfaceJniClient::Initialize(FSubsystemCollectionBas
 	jobject localRef = Env->NewObject(Cache->clientClassStructArray2Interface, Cache->clientClassStructArray2InterfaceCtor);
 	m_javaJniClientInstance = Env->NewGlobalRef(localRef);
 	FAndroidApplication::GetJavaEnv()->DeleteLocalRef(localRef);
+
+	// Auto-rebind on foreground: ASIS-style hosts may destroy and recreate the
+	// Service that owns the engine without recreating the UE engine itself.
+	// Pre-destroy callbacks unbind the ServiceConnection cleanly, but the engine
+	// resume path doesn't re-trigger _bindToService. Subscribe so that if we
+	// were previously bound (cached m_lastBoundServicePackage) and aren't
+	// currently ready, the binding is restored automatically.
+	m_ForegroundDelegateHandle = FCoreDelegates::ApplicationHasEnteredForegroundDelegate.AddWeakLambda(this, [this]()
+		{
+		if (!b_isReady.load(std::memory_order_acquire) && !m_lastBoundServicePackage.IsEmpty())
+		{
+			UE_LOG(LogTestbed1StructArray2InterfaceClient_JNI, Log,
+				TEXT("Auto-rebinding to %s on foreground"), *m_lastBoundServicePackage);
+			_bindToService(m_lastBoundServicePackage, m_lastConnectionId);
+		}
+	});
 #endif
 }
 
 void UTestbed1StructArray2InterfaceJniClient::Deinitialize()
 {
 	UE_LOG(LogTestbed1StructArray2InterfaceClient_JNI, Verbose, TEXT("deinit"));
+	FCoreDelegates::ApplicationHasEnteredForegroundDelegate.Remove(m_ForegroundDelegateHandle);
 	_unbind();
 	b_isReady.store(false, std::memory_order_release);
 	gUTestbed1StructArray2InterfaceJniClientHandle.store(nullptr, std::memory_order_release);

--- a/goldenmaster/Plugins/Testbed1/Source/Testbed1Jni/Private/Generated/Jni/Testbed1StructArrayInterfaceJniClient.cpp
+++ b/goldenmaster/Plugins/Testbed1/Source/Testbed1Jni/Private/Generated/Jni/Testbed1StructArrayInterfaceJniClient.cpp
@@ -9,6 +9,7 @@
 
 #include "Async/Async.h"
 #include "Engine/Engine.h"
+#include "Misc/CoreDelegates.h"
 
 #include "Generated/Detail/Testbed1MethodHelper.h"
 #include "Generated/Detail/Testbed1CommonJavaConverter.h"
@@ -224,12 +225,29 @@ void UTestbed1StructArrayInterfaceJniClient::Initialize(FSubsystemCollectionBase
 	jobject localRef = Env->NewObject(Cache->clientClassStructArrayInterface, Cache->clientClassStructArrayInterfaceCtor);
 	m_javaJniClientInstance = Env->NewGlobalRef(localRef);
 	FAndroidApplication::GetJavaEnv()->DeleteLocalRef(localRef);
+
+	// Auto-rebind on foreground: ASIS-style hosts may destroy and recreate the
+	// Service that owns the engine without recreating the UE engine itself.
+	// Pre-destroy callbacks unbind the ServiceConnection cleanly, but the engine
+	// resume path doesn't re-trigger _bindToService. Subscribe so that if we
+	// were previously bound (cached m_lastBoundServicePackage) and aren't
+	// currently ready, the binding is restored automatically.
+	m_ForegroundDelegateHandle = FCoreDelegates::ApplicationHasEnteredForegroundDelegate.AddWeakLambda(this, [this]()
+		{
+		if (!b_isReady.load(std::memory_order_acquire) && !m_lastBoundServicePackage.IsEmpty())
+		{
+			UE_LOG(LogTestbed1StructArrayInterfaceClient_JNI, Log,
+				TEXT("Auto-rebinding to %s on foreground"), *m_lastBoundServicePackage);
+			_bindToService(m_lastBoundServicePackage, m_lastConnectionId);
+		}
+	});
 #endif
 }
 
 void UTestbed1StructArrayInterfaceJniClient::Deinitialize()
 {
 	UE_LOG(LogTestbed1StructArrayInterfaceClient_JNI, Verbose, TEXT("deinit"));
+	FCoreDelegates::ApplicationHasEnteredForegroundDelegate.Remove(m_ForegroundDelegateHandle);
 	_unbind();
 	b_isReady.store(false, std::memory_order_release);
 	gUTestbed1StructArrayInterfaceJniClientHandle.store(nullptr, std::memory_order_release);

--- a/goldenmaster/Plugins/Testbed1/Source/Testbed1Jni/Private/Generated/Jni/Testbed1StructInterfaceJniClient.cpp
+++ b/goldenmaster/Plugins/Testbed1/Source/Testbed1Jni/Private/Generated/Jni/Testbed1StructInterfaceJniClient.cpp
@@ -9,6 +9,7 @@
 
 #include "Async/Async.h"
 #include "Engine/Engine.h"
+#include "Misc/CoreDelegates.h"
 
 #include "Generated/Detail/Testbed1MethodHelper.h"
 #include "Generated/Detail/Testbed1CommonJavaConverter.h"
@@ -210,12 +211,29 @@ void UTestbed1StructInterfaceJniClient::Initialize(FSubsystemCollectionBase& Col
 	jobject localRef = Env->NewObject(Cache->clientClassStructInterface, Cache->clientClassStructInterfaceCtor);
 	m_javaJniClientInstance = Env->NewGlobalRef(localRef);
 	FAndroidApplication::GetJavaEnv()->DeleteLocalRef(localRef);
+
+	// Auto-rebind on foreground: ASIS-style hosts may destroy and recreate the
+	// Service that owns the engine without recreating the UE engine itself.
+	// Pre-destroy callbacks unbind the ServiceConnection cleanly, but the engine
+	// resume path doesn't re-trigger _bindToService. Subscribe so that if we
+	// were previously bound (cached m_lastBoundServicePackage) and aren't
+	// currently ready, the binding is restored automatically.
+	m_ForegroundDelegateHandle = FCoreDelegates::ApplicationHasEnteredForegroundDelegate.AddWeakLambda(this, [this]()
+		{
+		if (!b_isReady.load(std::memory_order_acquire) && !m_lastBoundServicePackage.IsEmpty())
+		{
+			UE_LOG(LogTestbed1StructInterfaceClient_JNI, Log,
+				TEXT("Auto-rebinding to %s on foreground"), *m_lastBoundServicePackage);
+			_bindToService(m_lastBoundServicePackage, m_lastConnectionId);
+		}
+	});
 #endif
 }
 
 void UTestbed1StructInterfaceJniClient::Deinitialize()
 {
 	UE_LOG(LogTestbed1StructInterfaceClient_JNI, Verbose, TEXT("deinit"));
+	FCoreDelegates::ApplicationHasEnteredForegroundDelegate.Remove(m_ForegroundDelegateHandle);
 	_unbind();
 	b_isReady.store(false, std::memory_order_release);
 	gUTestbed1StructInterfaceJniClientHandle.store(nullptr, std::memory_order_release);

--- a/goldenmaster/Plugins/Testbed1/Source/Testbed1Jni/Public/Testbed1/Generated/Jni/Testbed1StructArray2InterfaceJniClient.h
+++ b/goldenmaster/Plugins/Testbed1/Source/Testbed1Jni/Public/Testbed1/Generated/Jni/Testbed1StructArray2InterfaceJniClient.h
@@ -147,6 +147,9 @@ private:
 	std::atomic<bool> b_isReady{false};
 	FString m_lastBoundServicePackage;
 	FString m_lastConnectionId;
+	// Handle for UE foreground delegate subscription. Used to auto-rebind
+	// after the host Service is recreated without an engine tear-down.
+	FDelegateHandle m_ForegroundDelegateHandle;
 #if PLATFORM_ANDROID && USE_ANDROID_JNI
 	jobject m_javaJniClientInstance = nullptr;
 #endif

--- a/goldenmaster/Plugins/Testbed1/Source/Testbed1Jni/Public/Testbed1/Generated/Jni/Testbed1StructArrayInterfaceJniClient.h
+++ b/goldenmaster/Plugins/Testbed1/Source/Testbed1Jni/Public/Testbed1/Generated/Jni/Testbed1StructArrayInterfaceJniClient.h
@@ -151,6 +151,9 @@ private:
 	std::atomic<bool> b_isReady{false};
 	FString m_lastBoundServicePackage;
 	FString m_lastConnectionId;
+	// Handle for UE foreground delegate subscription. Used to auto-rebind
+	// after the host Service is recreated without an engine tear-down.
+	FDelegateHandle m_ForegroundDelegateHandle;
 #if PLATFORM_ANDROID && USE_ANDROID_JNI
 	jobject m_javaJniClientInstance = nullptr;
 #endif

--- a/goldenmaster/Plugins/Testbed1/Source/Testbed1Jni/Public/Testbed1/Generated/Jni/Testbed1StructInterfaceJniClient.h
+++ b/goldenmaster/Plugins/Testbed1/Source/Testbed1Jni/Public/Testbed1/Generated/Jni/Testbed1StructInterfaceJniClient.h
@@ -137,6 +137,9 @@ private:
 	std::atomic<bool> b_isReady{false};
 	FString m_lastBoundServicePackage;
 	FString m_lastConnectionId;
+	// Handle for UE foreground delegate subscription. Used to auto-rebind
+	// after the host Service is recreated without an engine tear-down.
+	FDelegateHandle m_ForegroundDelegateHandle;
 #if PLATFORM_ANDROID && USE_ANDROID_JNI
 	jobject m_javaJniClientInstance = nullptr;
 #endif

--- a/goldenmaster/Plugins/Testbed1/Source/Testbed1Jni/Testbed1_JNI_UPL.xml
+++ b/goldenmaster/Plugins/Testbed1/Source/Testbed1Jni/Testbed1_JNI_UPL.xml
@@ -133,6 +133,36 @@ tasks.configureEach { task ->
 
 	<!-- optional additions to the GameActivity class in GameActivity.java -->
 	<gameActivityClassAdditions>
+		<insert>
+			<![CDATA[
+			// Testbed1: bridge the ApiGear BindingLifecycleRegistry SPI
+			// to ASIS's pre-destroy callback registry. Runs once when GameActivity
+			// class is loaded, before any JNI subsystem binds, installing a
+			// coordinator that forwards register/unregister calls into
+			// UnrealSharedInstanceService. This is the only place the generated
+			// code is coupled to ASIS; the SPI in apigear.android.lifecycle stays
+			// host-agnostic and the bridge is emitted only when this consumer
+			// opts in via the asis feature.
+			static
+			{
+				apigear.android.lifecycle.BindingLifecycleRegistry.setCoordinator(
+					new apigear.android.lifecycle.IBindingLifecycleCoordinator()
+					{
+						@Override
+						public void registerCleanup(Runnable cleanup)
+						{
+							com.epicgames.asis.UnrealSharedInstanceService.addPreDestroyCallback(cleanup);
+						}
+
+						@Override
+						public void unregisterCleanup(Runnable cleanup)
+						{
+							com.epicgames.asis.UnrealSharedInstanceService.removePreDestroyCallback(cleanup);
+						}
+					});
+			}
+			]]>
+		</insert>
 	</gameActivityClassAdditions>
 
 

--- a/goldenmaster/Plugins/Testbed2/Source/Testbed2Jni/Private/Generated/Jni/Testbed2ManyParamInterfaceJniClient.cpp
+++ b/goldenmaster/Plugins/Testbed2/Source/Testbed2Jni/Private/Generated/Jni/Testbed2ManyParamInterfaceJniClient.cpp
@@ -9,6 +9,7 @@
 
 #include "Async/Async.h"
 #include "Engine/Engine.h"
+#include "Misc/CoreDelegates.h"
 
 #include "Generated/Detail/Testbed2MethodHelper.h"
 #include "Generated/Detail/Testbed2CommonJavaConverter.h"
@@ -210,12 +211,29 @@ void UTestbed2ManyParamInterfaceJniClient::Initialize(FSubsystemCollectionBase& 
 	jobject localRef = Env->NewObject(Cache->clientClassManyParamInterface, Cache->clientClassManyParamInterfaceCtor);
 	m_javaJniClientInstance = Env->NewGlobalRef(localRef);
 	FAndroidApplication::GetJavaEnv()->DeleteLocalRef(localRef);
+
+	// Auto-rebind on foreground: ASIS-style hosts may destroy and recreate the
+	// Service that owns the engine without recreating the UE engine itself.
+	// Pre-destroy callbacks unbind the ServiceConnection cleanly, but the engine
+	// resume path doesn't re-trigger _bindToService. Subscribe so that if we
+	// were previously bound (cached m_lastBoundServicePackage) and aren't
+	// currently ready, the binding is restored automatically.
+	m_ForegroundDelegateHandle = FCoreDelegates::ApplicationHasEnteredForegroundDelegate.AddWeakLambda(this, [this]()
+		{
+		if (!b_isReady.load(std::memory_order_acquire) && !m_lastBoundServicePackage.IsEmpty())
+		{
+			UE_LOG(LogTestbed2ManyParamInterfaceClient_JNI, Log,
+				TEXT("Auto-rebinding to %s on foreground"), *m_lastBoundServicePackage);
+			_bindToService(m_lastBoundServicePackage, m_lastConnectionId);
+		}
+	});
 #endif
 }
 
 void UTestbed2ManyParamInterfaceJniClient::Deinitialize()
 {
 	UE_LOG(LogTestbed2ManyParamInterfaceClient_JNI, Verbose, TEXT("deinit"));
+	FCoreDelegates::ApplicationHasEnteredForegroundDelegate.Remove(m_ForegroundDelegateHandle);
 	_unbind();
 	b_isReady.store(false, std::memory_order_release);
 	gUTestbed2ManyParamInterfaceJniClientHandle.store(nullptr, std::memory_order_release);

--- a/goldenmaster/Plugins/Testbed2/Source/Testbed2Jni/Private/Generated/Jni/Testbed2NestedStruct1InterfaceJniClient.cpp
+++ b/goldenmaster/Plugins/Testbed2/Source/Testbed2Jni/Private/Generated/Jni/Testbed2NestedStruct1InterfaceJniClient.cpp
@@ -9,6 +9,7 @@
 
 #include "Async/Async.h"
 #include "Engine/Engine.h"
+#include "Misc/CoreDelegates.h"
 
 #include "Generated/Detail/Testbed2MethodHelper.h"
 #include "Generated/Detail/Testbed2CommonJavaConverter.h"
@@ -182,12 +183,29 @@ void UTestbed2NestedStruct1InterfaceJniClient::Initialize(FSubsystemCollectionBa
 	jobject localRef = Env->NewObject(Cache->clientClassNestedStruct1Interface, Cache->clientClassNestedStruct1InterfaceCtor);
 	m_javaJniClientInstance = Env->NewGlobalRef(localRef);
 	FAndroidApplication::GetJavaEnv()->DeleteLocalRef(localRef);
+
+	// Auto-rebind on foreground: ASIS-style hosts may destroy and recreate the
+	// Service that owns the engine without recreating the UE engine itself.
+	// Pre-destroy callbacks unbind the ServiceConnection cleanly, but the engine
+	// resume path doesn't re-trigger _bindToService. Subscribe so that if we
+	// were previously bound (cached m_lastBoundServicePackage) and aren't
+	// currently ready, the binding is restored automatically.
+	m_ForegroundDelegateHandle = FCoreDelegates::ApplicationHasEnteredForegroundDelegate.AddWeakLambda(this, [this]()
+		{
+		if (!b_isReady.load(std::memory_order_acquire) && !m_lastBoundServicePackage.IsEmpty())
+		{
+			UE_LOG(LogTestbed2NestedStruct1InterfaceClient_JNI, Log,
+				TEXT("Auto-rebinding to %s on foreground"), *m_lastBoundServicePackage);
+			_bindToService(m_lastBoundServicePackage, m_lastConnectionId);
+		}
+	});
 #endif
 }
 
 void UTestbed2NestedStruct1InterfaceJniClient::Deinitialize()
 {
 	UE_LOG(LogTestbed2NestedStruct1InterfaceClient_JNI, Verbose, TEXT("deinit"));
+	FCoreDelegates::ApplicationHasEnteredForegroundDelegate.Remove(m_ForegroundDelegateHandle);
 	_unbind();
 	b_isReady.store(false, std::memory_order_release);
 	gUTestbed2NestedStruct1InterfaceJniClientHandle.store(nullptr, std::memory_order_release);

--- a/goldenmaster/Plugins/Testbed2/Source/Testbed2Jni/Private/Generated/Jni/Testbed2NestedStruct2InterfaceJniClient.cpp
+++ b/goldenmaster/Plugins/Testbed2/Source/Testbed2Jni/Private/Generated/Jni/Testbed2NestedStruct2InterfaceJniClient.cpp
@@ -9,6 +9,7 @@
 
 #include "Async/Async.h"
 #include "Engine/Engine.h"
+#include "Misc/CoreDelegates.h"
 
 #include "Generated/Detail/Testbed2MethodHelper.h"
 #include "Generated/Detail/Testbed2CommonJavaConverter.h"
@@ -182,12 +183,29 @@ void UTestbed2NestedStruct2InterfaceJniClient::Initialize(FSubsystemCollectionBa
 	jobject localRef = Env->NewObject(Cache->clientClassNestedStruct2Interface, Cache->clientClassNestedStruct2InterfaceCtor);
 	m_javaJniClientInstance = Env->NewGlobalRef(localRef);
 	FAndroidApplication::GetJavaEnv()->DeleteLocalRef(localRef);
+
+	// Auto-rebind on foreground: ASIS-style hosts may destroy and recreate the
+	// Service that owns the engine without recreating the UE engine itself.
+	// Pre-destroy callbacks unbind the ServiceConnection cleanly, but the engine
+	// resume path doesn't re-trigger _bindToService. Subscribe so that if we
+	// were previously bound (cached m_lastBoundServicePackage) and aren't
+	// currently ready, the binding is restored automatically.
+	m_ForegroundDelegateHandle = FCoreDelegates::ApplicationHasEnteredForegroundDelegate.AddWeakLambda(this, [this]()
+		{
+		if (!b_isReady.load(std::memory_order_acquire) && !m_lastBoundServicePackage.IsEmpty())
+		{
+			UE_LOG(LogTestbed2NestedStruct2InterfaceClient_JNI, Log,
+				TEXT("Auto-rebinding to %s on foreground"), *m_lastBoundServicePackage);
+			_bindToService(m_lastBoundServicePackage, m_lastConnectionId);
+		}
+	});
 #endif
 }
 
 void UTestbed2NestedStruct2InterfaceJniClient::Deinitialize()
 {
 	UE_LOG(LogTestbed2NestedStruct2InterfaceClient_JNI, Verbose, TEXT("deinit"));
+	FCoreDelegates::ApplicationHasEnteredForegroundDelegate.Remove(m_ForegroundDelegateHandle);
 	_unbind();
 	b_isReady.store(false, std::memory_order_release);
 	gUTestbed2NestedStruct2InterfaceJniClientHandle.store(nullptr, std::memory_order_release);

--- a/goldenmaster/Plugins/Testbed2/Source/Testbed2Jni/Private/Generated/Jni/Testbed2NestedStruct3InterfaceJniClient.cpp
+++ b/goldenmaster/Plugins/Testbed2/Source/Testbed2Jni/Private/Generated/Jni/Testbed2NestedStruct3InterfaceJniClient.cpp
@@ -9,6 +9,7 @@
 
 #include "Async/Async.h"
 #include "Engine/Engine.h"
+#include "Misc/CoreDelegates.h"
 
 #include "Generated/Detail/Testbed2MethodHelper.h"
 #include "Generated/Detail/Testbed2CommonJavaConverter.h"
@@ -196,12 +197,29 @@ void UTestbed2NestedStruct3InterfaceJniClient::Initialize(FSubsystemCollectionBa
 	jobject localRef = Env->NewObject(Cache->clientClassNestedStruct3Interface, Cache->clientClassNestedStruct3InterfaceCtor);
 	m_javaJniClientInstance = Env->NewGlobalRef(localRef);
 	FAndroidApplication::GetJavaEnv()->DeleteLocalRef(localRef);
+
+	// Auto-rebind on foreground: ASIS-style hosts may destroy and recreate the
+	// Service that owns the engine without recreating the UE engine itself.
+	// Pre-destroy callbacks unbind the ServiceConnection cleanly, but the engine
+	// resume path doesn't re-trigger _bindToService. Subscribe so that if we
+	// were previously bound (cached m_lastBoundServicePackage) and aren't
+	// currently ready, the binding is restored automatically.
+	m_ForegroundDelegateHandle = FCoreDelegates::ApplicationHasEnteredForegroundDelegate.AddWeakLambda(this, [this]()
+		{
+		if (!b_isReady.load(std::memory_order_acquire) && !m_lastBoundServicePackage.IsEmpty())
+		{
+			UE_LOG(LogTestbed2NestedStruct3InterfaceClient_JNI, Log,
+				TEXT("Auto-rebinding to %s on foreground"), *m_lastBoundServicePackage);
+			_bindToService(m_lastBoundServicePackage, m_lastConnectionId);
+		}
+	});
 #endif
 }
 
 void UTestbed2NestedStruct3InterfaceJniClient::Deinitialize()
 {
 	UE_LOG(LogTestbed2NestedStruct3InterfaceClient_JNI, Verbose, TEXT("deinit"));
+	FCoreDelegates::ApplicationHasEnteredForegroundDelegate.Remove(m_ForegroundDelegateHandle);
 	_unbind();
 	b_isReady.store(false, std::memory_order_release);
 	gUTestbed2NestedStruct3InterfaceJniClientHandle.store(nullptr, std::memory_order_release);

--- a/goldenmaster/Plugins/Testbed2/Source/Testbed2Jni/Public/Testbed2/Generated/Jni/Testbed2ManyParamInterfaceJniClient.h
+++ b/goldenmaster/Plugins/Testbed2/Source/Testbed2Jni/Public/Testbed2/Generated/Jni/Testbed2ManyParamInterfaceJniClient.h
@@ -137,6 +137,9 @@ private:
 	std::atomic<bool> b_isReady{false};
 	FString m_lastBoundServicePackage;
 	FString m_lastConnectionId;
+	// Handle for UE foreground delegate subscription. Used to auto-rebind
+	// after the host Service is recreated without an engine tear-down.
+	FDelegateHandle m_ForegroundDelegateHandle;
 #if PLATFORM_ANDROID && USE_ANDROID_JNI
 	jobject m_javaJniClientInstance = nullptr;
 #endif

--- a/goldenmaster/Plugins/Testbed2/Source/Testbed2Jni/Public/Testbed2/Generated/Jni/Testbed2NestedStruct1InterfaceJniClient.h
+++ b/goldenmaster/Plugins/Testbed2/Source/Testbed2Jni/Public/Testbed2/Generated/Jni/Testbed2NestedStruct1InterfaceJniClient.h
@@ -102,6 +102,9 @@ private:
 	std::atomic<bool> b_isReady{false};
 	FString m_lastBoundServicePackage;
 	FString m_lastConnectionId;
+	// Handle for UE foreground delegate subscription. Used to auto-rebind
+	// after the host Service is recreated without an engine tear-down.
+	FDelegateHandle m_ForegroundDelegateHandle;
 #if PLATFORM_ANDROID && USE_ANDROID_JNI
 	jobject m_javaJniClientInstance = nullptr;
 #endif

--- a/goldenmaster/Plugins/Testbed2/Source/Testbed2Jni/Public/Testbed2/Generated/Jni/Testbed2NestedStruct2InterfaceJniClient.h
+++ b/goldenmaster/Plugins/Testbed2/Source/Testbed2Jni/Public/Testbed2/Generated/Jni/Testbed2NestedStruct2InterfaceJniClient.h
@@ -109,6 +109,9 @@ private:
 	std::atomic<bool> b_isReady{false};
 	FString m_lastBoundServicePackage;
 	FString m_lastConnectionId;
+	// Handle for UE foreground delegate subscription. Used to auto-rebind
+	// after the host Service is recreated without an engine tear-down.
+	FDelegateHandle m_ForegroundDelegateHandle;
 #if PLATFORM_ANDROID && USE_ANDROID_JNI
 	jobject m_javaJniClientInstance = nullptr;
 #endif

--- a/goldenmaster/Plugins/Testbed2/Source/Testbed2Jni/Public/Testbed2/Generated/Jni/Testbed2NestedStruct3InterfaceJniClient.h
+++ b/goldenmaster/Plugins/Testbed2/Source/Testbed2Jni/Public/Testbed2/Generated/Jni/Testbed2NestedStruct3InterfaceJniClient.h
@@ -123,6 +123,9 @@ private:
 	std::atomic<bool> b_isReady{false};
 	FString m_lastBoundServicePackage;
 	FString m_lastConnectionId;
+	// Handle for UE foreground delegate subscription. Used to auto-rebind
+	// after the host Service is recreated without an engine tear-down.
+	FDelegateHandle m_ForegroundDelegateHandle;
 #if PLATFORM_ANDROID && USE_ANDROID_JNI
 	jobject m_javaJniClientInstance = nullptr;
 #endif

--- a/goldenmaster/Plugins/Testbed2/Source/Testbed2Jni/Testbed2_JNI_UPL.xml
+++ b/goldenmaster/Plugins/Testbed2/Source/Testbed2Jni/Testbed2_JNI_UPL.xml
@@ -146,6 +146,36 @@ tasks.configureEach { task ->
 
 	<!-- optional additions to the GameActivity class in GameActivity.java -->
 	<gameActivityClassAdditions>
+		<insert>
+			<![CDATA[
+			// Testbed2: bridge the ApiGear BindingLifecycleRegistry SPI
+			// to ASIS's pre-destroy callback registry. Runs once when GameActivity
+			// class is loaded, before any JNI subsystem binds, installing a
+			// coordinator that forwards register/unregister calls into
+			// UnrealSharedInstanceService. This is the only place the generated
+			// code is coupled to ASIS; the SPI in apigear.android.lifecycle stays
+			// host-agnostic and the bridge is emitted only when this consumer
+			// opts in via the asis feature.
+			static
+			{
+				apigear.android.lifecycle.BindingLifecycleRegistry.setCoordinator(
+					new apigear.android.lifecycle.IBindingLifecycleCoordinator()
+					{
+						@Override
+						public void registerCleanup(Runnable cleanup)
+						{
+							com.epicgames.asis.UnrealSharedInstanceService.addPreDestroyCallback(cleanup);
+						}
+
+						@Override
+						public void unregisterCleanup(Runnable cleanup)
+						{
+							com.epicgames.asis.UnrealSharedInstanceService.removePreDestroyCallback(cleanup);
+						}
+					});
+			}
+			]]>
+		</insert>
 	</gameActivityClassAdditions>
 
 

--- a/rules.yaml
+++ b/rules.yaml
@@ -680,3 +680,13 @@ features:
           - source: "module/Source/modulejni/Private/Tests/jnifixture.cpp.tpl"
             target: "Private/Tests/{{Camel .Module.Name}}{{Camel .Interface.Name}}JniFixture.cpp"
             preserve: true
+  # Opt-in integration for hosts based on the Epic Games
+  # AndroidSingleInstanceService (ASIS) plugin. Enabling this feature emits
+  # a UPL gameActivityClassAdditions block that wires the apigear binding
+  # lifecycle SPI to ASIS's pre-destroy callback registry, so JNI clients
+  # unbind before the host Service's onDestroy returns and Android does not
+  # report ServiceConnectionLeaked. The feature owns no documents -- it is
+  # a pure marker flag, checked by the jni feature's UPL template.
+  - name: asis
+    requires:
+      - jni

--- a/templates/module/Source/modulejni/Private/Generated/jni/jniclient.cpp.tpl
+++ b/templates/module/Source/modulejni/Private/Generated/jni/jniclient.cpp.tpl
@@ -90,6 +90,7 @@
 {{ end }}
 #include "Async/Async.h"
 #include "Engine/Engine.h"
+#include "Misc/CoreDelegates.h"
 
 #include "Generated/Detail/{{$ModuleName}}MethodHelper.h"
 #include "Generated/Detail/{{$ModuleName}}CommonJavaConverter.h"
@@ -270,12 +271,29 @@ void {{$Class}}::Initialize(FSubsystemCollectionBase& Collection)
 	jobject localRef = Env->NewObject(Cache->{{$clientClass}}, Cache->{{$clientClass}}Ctor);
 	m_javaJniClientInstance = Env->NewGlobalRef(localRef);
 	FAndroidApplication::GetJavaEnv()->DeleteLocalRef(localRef);
+
+	// Auto-rebind on foreground: ASIS-style hosts may destroy and recreate the
+	// Service that owns the engine without recreating the UE engine itself.
+	// Pre-destroy callbacks unbind the ServiceConnection cleanly, but the engine
+	// resume path doesn't re-trigger _bindToService. Subscribe so that if we
+	// were previously bound (cached m_lastBoundServicePackage) and aren't
+	// currently ready, the binding is restored automatically.
+	m_ForegroundDelegateHandle = FCoreDelegates::ApplicationHasEnteredForegroundDelegate.AddWeakLambda(this, [this]()
+		{
+		if (!b_isReady.load(std::memory_order_acquire) && !m_lastBoundServicePackage.IsEmpty())
+		{
+			UE_LOG(Log{{$Iface}}Client_JNI, Log,
+				TEXT("Auto-rebinding to %s on foreground"), *m_lastBoundServicePackage);
+			_bindToService(m_lastBoundServicePackage, m_lastConnectionId);
+		}
+	});
 #endif
 }
 
 void {{$Class}}::Deinitialize()
 {
 	UE_LOG(Log{{$Iface}}Client_JNI, Verbose, TEXT("deinit"));
+	FCoreDelegates::ApplicationHasEnteredForegroundDelegate.Remove(m_ForegroundDelegateHandle);
 	_unbind();
 	b_isReady.store(false, std::memory_order_release);
 	g{{$Class}}Handle.store(nullptr, std::memory_order_release);

--- a/templates/module/Source/modulejni/Public/Generated/jni/jniclient.h.tpl
+++ b/templates/module/Source/modulejni/Public/Generated/jni/jniclient.h.tpl
@@ -125,6 +125,9 @@ private:
 	std::atomic<bool> b_isReady{false};
 	FString m_lastBoundServicePackage;
 	FString m_lastConnectionId;
+	// Handle for UE foreground delegate subscription. Used to auto-rebind
+	// after the host Service is recreated without an engine tear-down.
+	FDelegateHandle m_ForegroundDelegateHandle;
 #if PLATFORM_ANDROID && USE_ANDROID_JNI
 	jobject m_javaJniClientInstance = nullptr;
 #endif

--- a/templates/module/Source/modulejni/jni_UPL.xml.tpl
+++ b/templates/module/Source/modulejni/jni_UPL.xml.tpl
@@ -125,6 +125,38 @@ tasks.configureEach { task ->
 
 	<!-- optional additions to the GameActivity class in GameActivity.java -->
 	<gameActivityClassAdditions>
+{{- if .Features.asis }}
+		<insert>
+			<![CDATA[
+			// {{Camel .Module.Name}}: bridge the ApiGear BindingLifecycleRegistry SPI
+			// to ASIS's pre-destroy callback registry. Runs once when GameActivity
+			// class is loaded, before any JNI subsystem binds, installing a
+			// coordinator that forwards register/unregister calls into
+			// UnrealSharedInstanceService. This is the only place the generated
+			// code is coupled to ASIS; the SPI in apigear.android.lifecycle stays
+			// host-agnostic and the bridge is emitted only when this consumer
+			// opts in via the asis feature.
+			static
+			{
+				apigear.android.lifecycle.BindingLifecycleRegistry.setCoordinator(
+					new apigear.android.lifecycle.IBindingLifecycleCoordinator()
+					{
+						@Override
+						public void registerCleanup(Runnable cleanup)
+						{
+							com.epicgames.asis.UnrealSharedInstanceService.addPreDestroyCallback(cleanup);
+						}
+
+						@Override
+						public void unregisterCleanup(Runnable cleanup)
+						{
+							com.epicgames.asis.UnrealSharedInstanceService.removePreDestroyCallback(cleanup);
+						}
+					});
+			}
+			]]>
+		</insert>
+{{- end }}
 	</gameActivityClassAdditions>
 
 


### PR DESCRIPTION
## 📑 Description
<!-- Add a brief description of the pr -->
Two complementary changes that let apigear-generated JNI clients survive a host Service destroy/recreate cycle in which the UE engine is not torn down — the lifecycle exhibited by Epic's AndroidSingleInstanceService (ASIS) host. Without these, the binding established by _bindToService is unbound when the host Service is destroyed and is never reinstated on host recreate.
<!-- You can also choose to add a list of changes and if they have been completed or not by using the markdown to-do list syntax
- [ ] Not Completed
- [x] Completed
-->

## ✅ Checks
<!-- Make sure your pr passes the CI checks and do check the following fields as needed - -->
- [x] My pull request adheres to the code style of this project
- [x] My code requires changes to the documentation
- [ ] I have updated the documentation as required
- [ ] All the tests have passed

## ℹ Additional Information
<!-- Any additional information like breaking changes, dependencies added, screenshots, comparisons between new and old behavior, etc. -->