### PR TITLE
chore: update LICENSE copyright and add README License section

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,7 +1,7 @@
 MIT License
 
-Copyright (c) 2020-2021 ApiGear UG (haftungsbeschränkt)
-Copyright (c) 2021-2026 Epic Games Inc. All rights reserved.
+Copyright (c) 2020-2022 ApiGear UG (haftungsbeschränkt)
+Copyright (c) 2022-2026 Epic Games, Inc.
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/README.md
+++ b/README.md
@@ -41,3 +41,7 @@ The [feature overview](https://apigear.io/template-unreal/docs/features) has lin
 * `msgbus`: create the adaption layer for the [UE MsgBus](https://dev.epicgames.com/documentation/en-us/unreal-engine/API/Runtime/Messaging) protocol. This can be used for communication inside the same UE app or between different instances, including across network interfaces.
 * `mqtt`: create the adaption layer for the [MQTT](https://apigear.io/template-unreal/docs/features/mqtt) protocol. This can be used for communication with other technologies like python, pure c++ etc. By default it uses the [Paho C MQTT](https://github.com/eclipse-paho/paho.mqtt.c) library for communication.
 * `jni`: create the jni adaption layer for the android messenger communication provided by [apigear java template](https://github.com/apigear-io/template-java). Please read the [JNI feature documentation](https://apigear.io/template-unreal/docs/features/jni).
+
+## License
+
+Licensed under the [MIT License](./LICENSE). See [LICENSE](./LICENSE) for details.


### PR DESCRIPTION
Updates the LICENSE to the standard, entity-accurate copyright attribution (drops the contradictory "All rights reserved." trailer and corrects the year range) and adds a README License section where missing. MIT is the standard license used across ApiGear projects.